### PR TITLE
JOSM Preset: add railway:signal:direction to lzb_start

### DIFF
--- a/josm-presets/de.xml
+++ b/josm-presets/de.xml
@@ -4871,6 +4871,13 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung"
 					default=""
 					delete_if_empty="true" />
+				<combo key="railway:signal:direction"
+					text="Direction"
+					de.text="Anzeigerichtung"
+					values="forward,backward"
+					display_values="In Wegrichtung,Entgegen Wegrichtung"
+					default=""
+					delete_if_empty="true" />
 				<check key="railway:signal:catenary_mast"
 					text="On catenary mast"
 					de.text="Am Oberleitungsmast"


### PR DESCRIPTION
There are lzb start signals which are only valid in one direction. Therefore this should be added to the josm preset.
I didn't test it, but this should work without problems.

---

Es gibt LZB Bereichskennzeichen, die nur für eine Richtung gelten. Deshalb sollte der railway:signal:direction key auch im JOSM Preset vorhanden sein.
Ich hab es nicht getestet, sollte aber funktionieren.
