### PR TITLE
Add match attribute to josm signals preset

### DIFF
--- a/josm-presets/de-signals-eso.xml
+++ b/josm-presets/de-signals-eso.xml
@@ -1114,7 +1114,8 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="db:ne2,dr:so3,dr:so3b"
 					display_values="Ne 2 ex-DB,So 3 ex-DR, So 3b ex-DR (mit schwarzem Punkt)"
 					default=""
-					delete_if_empty="true" />
+					delete_if_empty="true"
+					match="keyvalue!" />
 				<key key="railway:signal:distant:form"
 					value="sign" />
 				<check key="railway:signal:distant:shortened"
@@ -1188,7 +1189,8 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						values="bü,so16"
 						display_values="Bü (ex-DB),So 16 (ex-DR)"
 						default=""
-						delete_if_empty="true" />
+						delete_if_empty="true"
+						match="keyvalue!" />
 					<combo key="railway:signal:crossing:states"
 						text="Signal states"
 						de.text="Signalzustände"
@@ -1241,7 +1243,8 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						values="bü2,so15"
 						display_values="Bü 2 'Rautentafel' ex-DB,So 15 ex-DR"
 						default=""
-						delete_if_empty="true" />
+						delete_if_empty="true"
+						match="keyvalue!" />
 					<key key="railway:signal:crossing_distant:form"
 						value="sign" />
 					<check key="railway:signal:crossing:repeated"
@@ -1287,7 +1290,8 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						values="bü3,so14"
 						display_values="Bü 3 ex-DB,So 14 ex-DR"
 						default=""
-						delete_if_empty="true" />
+						delete_if_empty="true"
+						match="keyvalue!" />
 					<key key="railway:signal:crossing_distant:form"
 						value="sign" />
 					<check key="railway:signal:crossing:repeated"
@@ -1693,7 +1697,8 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						values="ra11,ra11b"
 						display_values="Ra 11 (gelb),Ra 11b (weiß)"
 						default=""
-						delete_if_empty="true" />
+						delete_if_empty="true"
+						match="keyvalue!" />
 					<combo key="railway:signal:shunting:form"
 						text="Signal form"
 						de.text="Anzeigeart"
@@ -2027,7 +2032,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						default=""
 						delete_if_empty="true" />
 					<space />
-					<combo key="railway:signal:wrong_road" text="Type" de.text="Typ" default="" delete_if_empty="true">
+					<combo key="railway:signal:wrong_road" text="Type" de.text="Typ" default="" delete_if_empty="true" match="keyvalue!">
 		                <list_entry value="db:zs6" display_value="Zs 6 DB" short_description="Gegengleisanzeiger Zs 6 (ex-DB)" />
 		                <list_entry value="dr:zs7" display_value="Zs 7 DR" short_description="Gegengleisanzeiger Zs 7 (ex-DR)" />
 		            </combo>
@@ -2065,7 +2070,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						default=""
 						delete_if_empty="true" />
 					<space />
-					<combo key="railway:signal:wrong_road" text="Type" de.text="Typ" default="" delete_if_empty="true">
+					<combo key="railway:signal:wrong_road" text="Type" de.text="Typ" default="" delete_if_empty="true" match="keyvalue!">
 						<list_entry value="db:zs8" display_value="Zs 8 DB" short_description="Falschfahrt-Auftragssignal Zs 8 (ex-DB)" />
 						<list_entry value="dr:zs8" display_value="Zs 8 DR" short_description="Linksfahrtersatzsignal Zs 8 (ex-DR)" />
 		            </combo>
@@ -2110,7 +2115,8 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						values="zs13,dr:zs6,dr:zs106"
 						display_values="Zs 13,Zs 6 (Lichtsignal ex-DR),Zs 106 (Tafel ex-DR)"
 						default=""
-						delete_if_empty="true" />
+						delete_if_empty="true"
+						match="keyvalue!" />
 					<combo key="railway:signal:short_route:form"
 						text="Signal form"
 						de.text="Anzeigeart"
@@ -2154,7 +2160,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						default=""
 						delete_if_empty="true" />
 					<space />
-					<combo key="railway:signal:speed_limit" text="Type of signal" de.text="Signaltyp" default="" delete_if_empty="true">
+					<combo key="railway:signal:speed_limit" text="Type of signal" de.text="Signaltyp" default="" delete_if_empty="true" match="keyvalue!">
 						<list_entry value="dr:lf1/2" display_value="Lf 1/2" short_description="Langsamfahrbeginnscheibe Lf 1/2 (ex-DR)" />
 						<list_entry value="lf2" display_value="Lf 2" short_description="Anfangsscheibe Lf 2" />
 						<list_entry value="lf3" display_value="Lf 3" short_description="Endscheibe Lf 3" />
@@ -2209,7 +2215,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						default=""
 						delete_if_empty="true" />
 					<space />
-					<combo key="railway:signal:speed_limit_distant" text="Type of signal" de.text="Signaltyp" default="" delete_if_empty="true">
+					<combo key="railway:signal:speed_limit_distant" text="Type of signal" de.text="Signaltyp" default="" delete_if_empty="true" match="keyvalue!">
 						<list_entry value="lf1" display_value="Lf 1" short_description="Langsamfahrscheibe Lf 1" />
 						<list_entry value="db:lf4" display_value="Lf 4 DB" short_description="Geschwindigkeitstafel Lf 4 (ex-DB)" />
 						<list_entry value="dr:lf4" display_value="Lf 4" short_description="Geschwindigkeitstafel Lf 4 (ex-DR)" />
@@ -2347,7 +2353,8 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="left,right"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung"
 					default=""
-					delete_if_empty="true" />
+					delete_if_empty="true"
+					match="keyvalue!" />
 				<combo key="railway:signal:expected_position:height"
 					text="Signal height"
 					de.text="Signalbauform"


### PR DESCRIPTION
This adds the match attribute to some of the signals to improve the appearance in the Tags/Membership dialog. Now only the signals are shown, that are actually tagged.

![match](https://cloud.githubusercontent.com/assets/5783139/5235675/48c9c698-780d-11e4-9d61-093b61c03305.png)
