### PR TITLE
Replace `between` by `intermediate` because it is out-of-date tagging

### DIFF
--- a/josm-presets/at-signals-v2.xml
+++ b/josm-presets/at-signals-v2.xml
@@ -66,7 +66,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<combo key="railway:signal:main:function"
 				text="Signal function"
 				de.text="Signalaufgabe"
-				values="entry,exit,block,between"
+				values="entry,exit,block,intermediate"
 				display_values="Einfahrsignal,Ausfahrsignal,Blocksignal,Zwischensignal"
 				default=""
 				delete_if_empty="true" />
@@ -137,7 +137,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<combo key="railway:signal:main:function"
 				text="Signal function"
 				de.text="Signalaufgabe"
-				values="entry,exit,block,between"
+				values="entry,exit,block,intermediate"
 				display_values="Einfahrsignal,Ausfahrsignal,Blocksignal,Zwischensignal"
 				default=""
 				delete_if_empty="true" />

--- a/josm-presets/de-signals-eso.xml
+++ b/josm-presets/de-signals-eso.xml
@@ -123,7 +123,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<combo key="railway:signal:combined:function"
 						text="Signal function"
 						de.text="Signalaufgabe"
-						values="entry,exit,block,between"
+						values="entry,exit,block,intermediate"
 						display_values="Einfahrsignal,Ausfahrsignal,Blocksignal,Zwischensignal"
 						default=""
 						delete_if_empty="true" />
@@ -198,7 +198,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<combo key="railway:signal:main:function"
 						text="Signal function"
 						de.text="Signalaufgabe"
-						values="entry,exit,block,between"
+						values="entry,exit,block,intermediate"
 						display_values="Einfahrsignal,Ausfahrsignal,Blocksignal,Zwischensignal"
 						default=""
 						delete_if_empty="true" />
@@ -278,7 +278,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<combo key="railway:signal:combined:function"
 					text="Signal function"
 					de.text="Signalaufgabe"
-					values="entry,exit,block,between"
+					values="entry,exit,block,intermediate"
 					display_values="Einfahrsignal,Ausfahrsignal,Blocksignal,Zwischensignal"
 					default=""
 					delete_if_empty="true" />
@@ -365,7 +365,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<combo key="railway:signal:combined:function"
 						text="Signal function"
 						de.text="Signalaufgabe"
-						values="entry,exit,block,between"
+						values="entry,exit,block,intermediate"
 						display_values="Einfahrsignal,Ausfahrsignal,Blocksignal,Zwischensignal"
 						default=""
 						delete_if_empty="true" />
@@ -444,7 +444,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<combo key="railway:signal:main:function"
 						text="Signal function"
 						de.text="Signalaufgabe"
-						values="entry,exit,block,between"
+						values="entry,exit,block,intermediate"
 						display_values="Einfahrsignal,Ausfahrsignal,Blocksignal,Zwischensignal"
 						default=""
 						delete_if_empty="true" />
@@ -569,7 +569,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<combo key="railway:signal:combined:function"
 						text="Signal function"
 						de.text="Signalaufgabe"
-						values="entry,exit,block,between"
+						values="entry,exit,block,intermediate"
 						display_values="Einfahrsignal,Ausfahrsignal,Blocksignal,Zwischensignal"
 						default=""
 						delete_if_empty="true" />
@@ -644,7 +644,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<combo key="railway:signal:main:function"
 						text="Signal function"
 						de.text="Signalaufgabe"
-						values="entry,exit,block,between"
+						values="entry,exit,block,intermediate"
 						display_values="Einfahrsignal,Ausfahrsignal,Blocksignal,Zwischensignal"
 						default=""
 						delete_if_empty="true" />
@@ -781,7 +781,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<combo key="railway:signal:main:function"
 						text="Signal function"
 						de.text="Signalaufgabe"
-						values="entry,exit,block,between"
+						values="entry,exit,block,intermediate"
 						display_values="Einfahrsignal,Ausfahrsignal,Blocksignal,Zwischensignal"
 						default=""
 						delete_if_empty="true" />
@@ -853,7 +853,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<combo key="railway:signal:main:function"
 						text="Signal function"
 						de.text="Signalaufgabe"
-						values="entry,exit,block,between"
+						values="entry,exit,block,intermediate"
 						display_values="Einfahrsignal,Ausfahrsignal,Blocksignal,Zwischensignal"
 						default=""
 						delete_if_empty="true" />


### PR DESCRIPTION
Although `railway:signal:*:function=between` was deprecated in October (or July) 2014, we still use it in all our tagging schemes. This pull request fixes this issue and replaces `between` by `intermediate`.

This fixes #184 