### PR TITLE
replace marker light by new marker light tagging

### DIFF
--- a/josm-presets/de-signals-eso.xml
+++ b/josm-presets/de-signals-eso.xml
@@ -49,8 +49,14 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						value="DE-ESO:ks" />
 					<key key="railway:signal:distant:form"
 						value="light" />
-					<key key="railway:signal:distant:states"
-						value="DE-ESO:ks1;DE-ESO:ks2" />
+					<combo key="railway:signal:distant:states" default="DE-ESO:ks1;DE-ESO:ks2"
+						text="Signal states"
+						de.text="Signalzustände"
+						delete_if_empty="true"
+						delimiter="|"
+						values="DE-ESO:ks1;DE-ESO:ks2|DE-ESO:ks1;DE-ESO:ks2;DE-ESO:kennlicht|DE-ESO:ks1;DE-ESO:ks2;off|DE-ESO:ks2"
+						de.display_values="Ks 1 und Ks 2|Ks 1, Ks 2 und Kennlicht|Ks 1, Ks 2 und Dunkelschaltung|ausschließlich Ks 2 (gelbes Licht, exotisches Signal)"
+						display_values="Ks 1 and Ks 2|Ks 1, Ks 2 and marker light|Ks 1, Ks 2 and dark|only Ks 2 (yellow light, rarely)" />
 					<check key="railway:signal:distant:shortened"
 						text="Shortened distance"
 						de.text="Verkürzter Bremsweg"
@@ -59,11 +65,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<check key="railway:signal:distant:repeated"
 						text="Repeated Signal"
 						de.text="Vorsignalwiederholer"
-						default="off"
-						delete_if_empty="true" />
-					<check key="railway:signal:distant:marker_light"
-						text="Marker light"
-						de.text="Kennlicht"
 						default="off"
 						delete_if_empty="true" />
 					<space />
@@ -113,8 +114,14 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						display_values="Mastbauform,Zwergsignal"
 						default=""
 						delete_if_empty="true" />
-					<key key="railway:signal:combined:states"
-						value="DE-ESO:hp0;DE-ESO:ks1;DE-ESO:ks2" />
+					<combo key="railway:signal:combined:states" default="DE-ESO:hp0;DE-ESO:ks1;DE-ESO:ks2"
+						text="Signal states"
+						de.text="Signalzustände"
+						delete_if_empty="true"
+						delimiter="|"
+						values="DE-ESO:hp0;DE-ESO:ks1;DE-ESO:ks2|DE-ESO:hp0;DE-ESO:ks1;DE-ESO:ks2;DE-ESO:kennlicht|DE-ESO:hp0;DE-ESO:ks1;DE-ESO:ks2;off"
+						de.display_values="Hp 0, Ks 1 und Ks 2|Hp 0, Ks 1, Ks 2 und Kennlicht|Hp 0, Ks 1, Ks 2 und Dunkelschaltung"
+						display_values="Hp 0, Ks 1 and Ks 2|Hp 0, Ks 1, Ks 2 and marker light|Hp 0, Ks 1, Ks 2 and dark" />
 					<check key="railway:signal:combined:shortened"
 						text="Shortened distance"
 						de.text="Verkürzter Bremsweg"
@@ -134,11 +141,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						values="DE-ESO:dr:zs1;DE-ESO:db:zs7;DE-ESO:db:zs12"
 						display_values="Ersatzsignal;Vorsichtsignal;M-Tafel"
 						default=""
-						delete_if_empty="true" />
-						<check key="railway:signal:combined:marker_light"
-						text="Marker light"
-						de.text="Kennlicht"
-						default="off"
 						delete_if_empty="true" />
 					<space />
 					<preset_link preset_name="Richtungsanzeiger (Zs 2)" />
@@ -193,8 +195,14 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						display_values="Mastbauform,Zwergsignal"
 						default=""
 						delete_if_empty="true" />
-					<key key="railway:signal:main:states"
-						value="DE-ESO:hp0;DE-ESO:ks1" />
+					<combo key="railway:signal:main:states" default=""
+						text="Signal states"
+						de.text="Signalzustände"
+						delete_if_empty="true"
+						delimiter="|"
+						values="DE-ESO:hp0;DE-ESO:ks1|DE-ESO:hp0;DE-ESO:ks1;DE-ESO:kennlicht|DE-ESO:hp0;DE-ESO:ks1;off"
+						de.display_values="Hp 0 und Ks 1|Hp 0, Ks 1 und Kennlicht|Hp 0, Ks 1 und Dunkelschaltung"
+						display_values="Hp 0 and Ks 1|Hp 0, Ks 1 and marker light|Hp 0, Ks 1 and dark" />
 					<combo key="railway:signal:main:function"
 						text="Signal function"
 						de.text="Signalaufgabe"
@@ -209,11 +217,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						values="DE-ESO:dr:zs1;DE-ESO:db:zs7;DE-ESO:db:zs12"
 						display_values="Ersatzsignal;Vorsichtsignal;M-Tafel"
 						default=""
-						delete_if_empty="true" />
-					<check key="railway:signal:main:marker_light"
-						text="Marker light"
-						de.text="Kennlicht"
-						default="off"
 						delete_if_empty="true" />
 					<space />
 					<preset_link preset_name="Richtungsanzeiger (Zs 2)" />
@@ -271,8 +274,9 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Signal states, Hamburg names (multi-selection)"
 					de.text="Signalzustände, Hamburger Kürzel (Mehrfachauswahl)"
 					delimiter=";"
-					values="DE-ESO:hp0;DE-ESO:sv1;DE-ESO:sv2;DE-ESO:sv3;DE-ESO:sv4;DE-ESO:sv5;DE-ESO:sv6;DE-ESO:sv0"
-					display_values="Hp 0;Sv 1;Sv 2;Sv 3;Sv 4;Sv 5;Sv 6;Sv 0"
+					values="DE-ESO:hp0;DE-ESO:sv1;DE-ESO:sv2;DE-ESO:sv3;DE-ESO:sv4;DE-ESO:sv5;DE-ESO:sv6;DE-ESO:sv0;DE-ESO:kennlicht"
+					display_values="Hp 0;Sv 1;Sv 2;Sv 3;Sv 4;Sv 5;Sv 6;Sv 0;marker light"
+					de.display_values="Hp 0;Sv 1;Sv 2;Sv 3;Sv 4;Sv 5;Sv 6;Sv 0;Kennlicht"
 					default=""
 					delete_if_empty="true" />
 				<combo key="railway:signal:combined:function"
@@ -289,11 +293,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="DE-ESO:dr:zs1;DE-ESO:db:zs7;DE-ESO:db:zs12"
 					display_values="Ersatzsignal;Vorsichtsignal;M-Tafel"
 					default=""
-					delete_if_empty="true" />
-				<check key="railway:signal:combined:marker_light"
-					text="Marker light"
-					de.text="Kennlicht"
-					default="off"
 					delete_if_empty="true" />
 				<check key="railway:signal:distant:shortened"
 					text="Shortened distance"
@@ -358,8 +357,9 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						text="Signal states (multi-selection)"
 						de.text="Signalzustände (Mehrfachauswahl)"
 						delimiter=";"
-						values="DE-ESO:hp0;DE-ESO:hl1;DE-ESO:hl2;DE-ESO:hl3a;DE-ESO:hl3b;DE-ESO:hl4;DE-ESO:hl5;DE-ESO:hl6a;DE-ESO:hl6b;DE-ESO:hl7;DE-ESO:hl8;DE-ESO:hl9a;DE-ESO:hl9b;DE-ESO:hl10;DE-ESO:hl11;DE-ESO:hl12a;DE-ESO:hl12b"
-						display_values="Hp 0;Hl 1;Hl 2;Hl 3a;Hl 3b;Hl 4;Hl 5;Hl 6a;Hl 6b;Hl 7;Hl 8;Hl 9a;Hl 9b;Hl 10;Hl 11;Hl 12a;Hl 12b"
+						values="DE-ESO:hp0;DE-ESO:hl1;DE-ESO:hl2;DE-ESO:hl3a;DE-ESO:hl3b;DE-ESO:hl4;DE-ESO:hl5;DE-ESO:hl6a;DE-ESO:hl6b;DE-ESO:hl7;DE-ESO:hl8;DE-ESO:hl9a;DE-ESO:hl9b;DE-ESO:hl10;DE-ESO:hl11;DE-ESO:hl12a;DE-ESO:hl12b;DE-ESO:kennlicht"
+						display_values="Hp 0;Hl 1;Hl 2;Hl 3a;Hl 3b;Hl 4;Hl 5;Hl 6a;Hl 6b;Hl 7;Hl 8;Hl 9a;Hl 9b;Hl 10;Hl 11;Hl 12a;Hl 12b;marker light"
+						de.display_values="Hp 0;Hl 1;Hl 2;Hl 3a;Hl 3b;Hl 4;Hl 5;Hl 6a;Hl 6b;Hl 7;Hl 8;Hl 9a;Hl 9b;Hl 10;Hl 11;Hl 12a;Hl 12b;Kennlicht"
 						default=""
 						delete_if_empty="true" />
 					<combo key="railway:signal:combined:function"
@@ -376,11 +376,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						values="DE-ESO:dr:zs1;DE-ESO:db:zs12"
 						display_values="Ersatzsignal;M-Tafel"
 						default=""
-						delete_if_empty="true" />
-					<check key="railway:signal:combined:marker_light"
-						text="Marker light"
-						de.text="Kennlicht"
-						default="off"
 						delete_if_empty="true" />
 					<space />
 					<preset_link preset_name="Richtungsanzeiger (Zs 2)" />
@@ -437,8 +432,9 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						text="Signal states (multi-selection)"
 						de.text="Signalzustände (Mehrfachauswahl)"
 						delimiter=";"
-						values="DE-ESO:hp0;DE-ESO:hl1;DE-ESO:hl2;DE-ESO:hl3a;DE-ESO:hl3b;DE-ESO:hl4;DE-ESO:hl5;DE-ESO:hl6a;DE-ESO:hl6b"
-						display_values="Hp 0;Hl 1;Hl 2;Hl 3a;Hl 3b;Hl 4;Hl 5;Hl 6a;Hl 6b"
+						values="DE-ESO:hp0;DE-ESO:hl1;DE-ESO:hl2;DE-ESO:hl3a;DE-ESO:hl3b;DE-ESO:hl4;DE-ESO:hl5;DE-ESO:hl6a;DE-ESO:hl6b;DE-ESO:kennlicht"
+						display_values="Hp 0;Hl 1;Hl 2;Hl 3a;Hl 3b;Hl 4;Hl 5;Hl 6a;Hl 6b;marker light"
+						de.display_values="Hp 0;Hl 1;Hl 2;Hl 3a;Hl 3b;Hl 4;Hl 5;Hl 6a;Hl 6b;Kennlicht"
 						default=""
 						delete_if_empty="true" />
 					<combo key="railway:signal:main:function"
@@ -455,11 +451,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						values="DE-ESO:dr:zs1;DE-ESO:db:zs12"
 						display_values="Ersatzsignal;M-Tafel"
 						default=""
-						delete_if_empty="true" />
-					<check key="railway:signal:main:marker_light"
-						text="Marker light"
-						de.text="Kennlicht"
-						default="off"
 						delete_if_empty="true" />
 					<space />
 					<preset_link preset_name="Richtungsanzeiger (Zs 2)" />
@@ -505,16 +496,17 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						value="DE-ESO:hl" />
 					<key key="railway:signal:distant:form"
 						value="light" />
-					<key key="railway:signal:distant:states"
-						value="DE-ESO:hl1;DE-ESO:hl4;DE-ESO:hl7;DE-ESO:hl10" />
+					<combo key="railway:signal:distant:states" default="DE-ESO:hl1;DE-ESO:hl4;DE-ESO:hl7;DE-ESO:hl10"
+						text="Signal states"
+						de.text="Signalzustände"
+						delete_if_empty="true"
+						delimiter="|"
+						values="DE-ESO:hl1;DE-ESO:hl4;DE-ESO:hl7;DE-ESO:hl10|DE-ESO:hl1;DE-ESO:hl4;DE-ESO:hl7;DE-ESO:hl10;DE-ESO:kennlicht"
+						de.display_values="kein Kennlicht|Kennlicht möglich"
+						display_values="no marker light|marker light possible" />
 					<check key="railway:signal:distant:repeated"
 						text="Repeated Signal"
 						de.text="Vorsignalwiederholer"
-						default="off"
-						delete_if_empty="true" />
-					<check key="railway:signal:distant:marker_light"
-						text="Marker light"
-						de.text="Kennlicht"
 						default="off"
 						delete_if_empty="true" />
 					<space />
@@ -564,8 +556,14 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						display_values="Mastbauform,Zwergsignal"
 						default=""
 						delete_if_empty="true" />
-					<key key="railway:signal:combined:states"
-						value="DE-ESO:hp0;DE-ESO:sk1;DE-ESO:sk2" />
+					<combo key="railway:signal:combined:states" default="DE-ESO:hp0;DE-ESO:sk1;DE-ESO:sk2"
+						text="Signal states"
+						de.text="Signalzustände"
+						delete_if_empty="true"
+						delimiter="|"
+						values="DE-ESO:hp0;DE-ESO:sk1;DE-ESO:sk2|DE-ESO:hp0;DE-ESO:sk1;DE-ESO:sk2;DE-ESO:kennlicht"
+						de.display_values="kein Kennlicht|Kennlicht möglich"
+						display_values="no marker light|marker light possible" />
 					<combo key="railway:signal:combined:function"
 						text="Signal function"
 						de.text="Signalaufgabe"
@@ -580,11 +578,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						values="DE-ESO:dr:zs1;DE-ESO:db:zs7"
 						display_values="Ersatzsignal;Vorsichtsignal"
 						default=""
-						delete_if_empty="true" />
-					<check key="railway:signal:combined:marker_light"
-						text="Marker light"
-						de.text="Kennlicht"
-						default="off"
 						delete_if_empty="true" />
 					<space />
 					<preset_link preset_name="Geschwindigkeitsanzeiger (Zs 3)" />
@@ -639,8 +632,14 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						display_values="Mastbauform,Zwergsignal"
 						default=""
 						delete_if_empty="true" />
-					<key key="railway:signal:main:states"
-						value="DE-ESO:hp0;DE-ESO:sk1" />
+					<combo key="railway:signal:main:states" default="DE-ESO:hp0;DE-ESO:sk1"
+						text="Signal states"
+						de.text="Signalzustände"
+						delete_if_empty="true"
+						delimiter="|"
+						values="DE-ESO:hp0;DE-ESO:sk1|DE-ESO:hp0;DE-ESO:sk1;DE-ESO:kennlicht"
+						de.display_values="kein Kennlicht|Kennlicht möglich"
+						display_values="no marker light|marker light possible" />
 					<combo key="railway:signal:main:function"
 						text="Signal function"
 						de.text="Signalaufgabe"
@@ -655,11 +654,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						values="DE-ESO:dr:zs1;DE-ESO:db:zs7"
 						display_values="Ersatzsignal;Vorsichtsignal"
 						default=""
-						delete_if_empty="true" />
-					<check key="railway:signal:main:marker_light"
-						text="Marker light"
-						de.text="Kennlicht"
-						default="off"
 						delete_if_empty="true" />
 					<space />
 					<preset_link preset_name="Richtungsanzeiger (Zs 2)" />
@@ -705,8 +699,14 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						value="DE-ESO:sk" />
 					<key key="railway:signal:distant:form"
 						value="light" />
-					<key key="railway:signal:distant:states"
-						value="DE-ESO:sk1;DE-ESO:sk2" />
+					<combo key="railway:signal:distant:states" default="DE-ESO:sk1;DE-ESO:sk2"
+						text="Signal states"
+						de.text="Signalzustände"
+						delete_if_empty="true"
+						delimiter="|"
+						values="DE-ESO:sk1;DE-ESO:sk2|DE-ESO:sk1;DE-ESO:sk2;DE-ESO:kennlicht"
+						de.display_values="kein Kennlicht|Kennlicht möglich"
+						display_values="no marker light|marker light possible" />
 					<check key="railway:signal:distant:shortened"
 						text="Shortened distance"
 						de.text="Verkürzter Bremsweg"
@@ -715,11 +715,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<check key="railway:signal:distant:repeated"
 						text="Repeated Signal"
 						de.text="Vorsignalwiederholer"
-						default="off"
-						delete_if_empty="true" />
-					<check key="railway:signal:distant:marker_light"
-						text="Marker light"
-						de.text="Kennlicht"
 						default="off"
 						delete_if_empty="true" />
 					<space />
@@ -775,7 +770,8 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						de.text="Signalzustände (Mehrfachauswahl)"
 						delimiter=";"
 						values="DE-ESO:hp0;DE-ESO:hp1;DE-ESO:hp2"
-						display_values="Halt;Fahrt;Langsamfahrt"
+						display_values="Stop;Proceed;Proceed at reduced speed"
+						de.display_values="Halt;Fahrt;Langsamfahrt"
 						default=""
 						delete_if_empty="true" />
 					<combo key="railway:signal:main:function"
@@ -846,8 +842,9 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						text="Signal states (multi-selection)"
 						de.text="Signalzustände (Mehrfachauswahl)"
 						delimiter=";"
-						values="DE-ESO:hp0;DE-ESO:hp1;DE-ESO:hp2"
-						display_values="Halt;Fahrt;Langsamfahrt"
+						values="DE-ESO:hp0;DE-ESO:hp1;DE-ESO:hp2;DE-ESO:kennlicht"
+						display_values="Stop;Proceed;Proceed at reduced speed;marker light"
+						de.display_values="Halt;Fahrt;Langsamfahrt;Kennlicht"
 						default=""
 						delete_if_empty="true" />
 					<combo key="railway:signal:main:function"
@@ -864,11 +861,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						values="DE-ESO:db:zs1;DE-ESO:dr:zs1;DE-ESO:db:zs7;DE-ESO:db:zs12"
 						display_values="Ersatzsignal (ex-DB);Ersatzsignal (ex-DR);Vorsichtsignal;M-Tafel"
 						default=""
-						delete_if_empty="true" />
-					<check key="railway:signal:main:marker_light"
-						text="Marker light"
-						de.text="Kennlicht"
-						default="off"
 						delete_if_empty="true" />
 					<space />
 					<preset_link preset_name="Richtungsanzeiger (Zs 2)" />
@@ -942,11 +934,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						de.text="Vorsignalwiederholer"
 						default="off"
 						delete_if_empty="true" />
-					<check key="railway:signal:distant:marker_light"
-						text="Marker light"
-						de.text="Kennlicht"
-						default="off"
-						delete_if_empty="true" />
 					<space />
 					<preset_link preset_name="Richtungsvoranzeiger (Zs 2v)" />
 					<preset_link preset_name="Geschwindigkeitsvoranzeiger (Zs 3v)" />
@@ -997,8 +984,9 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						text="Signal states (multi-selection)"
 						de.text="Signalzustände (Mehrfachauswahl)"
 						delimiter=";"
-						values="DE-ESO:vr0;DE-ESO:vr1;DE-ESO:vr2"
-						display_values="Halt erwarten;Fahrt erwarten;Langsamfahrt erwarten"
+						values="DE-ESO:vr0;DE-ESO:vr1;DE-ESO:vr2;DE-ESO:kennlicht"
+						display_values="Expect Stop;Expect Proceed;Expect Proceed at reduced speed;marker light"
+						de.display_values="Halt erwarten;Fahrt erwarten;Langsamfahrt erwarten;Kennlicht"
 						default=""
 						delete_if_empty="true" />
 					<check key="railway:signal:distant:shortened"
@@ -1009,11 +997,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<check key="railway:signal:distant:repeated"
 						text="Repeated Signal"
 						de.text="Vorsignalwiederholer"
-						default="off"
-						delete_if_empty="true" />
-					<check key="railway:signal:distant:marker_light"
-						text="Marker light"
-						de.text="Kennlicht"
 						default="off"
 						delete_if_empty="true" />
 					<space />
@@ -1527,11 +1510,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						values="DE-ESO:sh0;DE-ESO:sh1,DE-ESO:hp0;DE-ESO:sh1,DE-ESO:hp0;DE-ESO:kennlicht"
 						display_values="Formsignal (Sh 0/Sh 1),Lichtsignal (Hp 0/Sh 1),Zugdeckungssignal (Hp 0/Kennlicht)"
 						default=""
-						delete_if_empty="true" />
-					<check key="railway:signal:minor:marker_light"
-						text="Marker light"
-						de.text="Kennlicht"
-						default="off"
 						delete_if_empty="true" />
 					<space />
 					<label text="Signal Gsp 2 siehe 'Gleissperre'" />


### PR DESCRIPTION
This fixes #179 

I replaced the old marker light tagging by the new one and translated some strings at Hp semaphore signals.

I removed marker lights at Vr semaphore signals because they are impossible (they would violate Eisenbahn-Signalordnung).