### PR TITLE
Render bridges and tunnels only if their railway lines are also rendered

### DIFF
--- a/styles/standard.mapcss
+++ b/styles/standard.mapcss
@@ -93,7 +93,17 @@ way|z9-[railway=razed]
 /*************************************************************/
 /* tunnel label (not render if the track has a track number) */
 /*************************************************************/
-way[tunnel=yes][!"railway:track_ref"]::tunnels
+way|z9-[railway=rail][tunnel=yes][!"railway:track_ref"]::tunnels,
+way|z9-[railway=disused][tunnel=yes][!"railway:track_ref"]::tunnels,
+way|z9-[railway=abandoned][tunnel=yes][!"railway:track_ref"]::tunnels,
+way|z9-[railway=razed][tunnel=yes][!"railway:track_ref"]::tunnels,
+way|z9-[railway=proposed][tunnel=yes][!"railway:track_ref"]::tunnels,
+way|z9-[railway=construction][tunnel=yes][!"railway:track_ref"]::tunnels,
+way|z9-[railway=preserved][tunnel=yes][!"railway:track_ref"]::tunnels,
+way|z9-[railway=narrow_gauge][tunnel=yes][!"railway:track_ref"]::tunnels,
+way|z11-[railway=tram][tunnel=yes][!"railway:track_ref"]::tunnels,
+way|z10-[railway=subway][tunnel=yes][!"railway:track_ref"]::tunnels,
+way|z10-[railway=light_rail][tunnel=yes][!"railway:track_ref"]::tunnels
 {
 	z-index: 4001;
 	text-position: line;

--- a/styles/standard.mapcss
+++ b/styles/standard.mapcss
@@ -53,9 +53,9 @@ way|z9-[railway=proposed][bridge=yes]::bridges,
 way|z9-[railway=construction][bridge=yes]::bridges,
 way|z9-[railway=preserved][bridge=yes]::bridges,
 way|z9-[railway=narrow_gauge][bridge=yes]::bridges,
-way|z9-[railway=tram][bridge=yes]::bridges,
-way|z9-[railway=subway][bridge=yes]::bridges,
-way|z9-[railway=light_rail][bridge=yes]::bridges
+way|z11-[railway=tram][bridge=yes]::bridges,
+way|z10-[railway=subway][bridge=yes]::bridges,
+way|z10-[railway=light_rail][bridge=yes]::bridges
 {
 	z-index: 1;
 	casing-width: 3.5;

--- a/styles/standard.mapcss
+++ b/styles/standard.mapcss
@@ -109,7 +109,17 @@ way[tunnel=yes][!"railway:track_ref"]::tunnels
 /*************************/
 /* tunnels color (white) */
 /*************************/
-way[tunnel=yes]::tunnels
+way|z2-[railway=rail][tunnel=yes]::tunnels,
+way|z9-[railway=disused][tunnel=yes]::tunnels,
+way|z9-[railway=abandoned][tunnel=yes]::tunnels,
+way|z9-[railway=razed][tunnel=yes]::tunnels,
+way|z9-[railway=proposed][tunnel=yes]::tunnels,
+way|z9-[railway=construction][tunnel=yes]::tunnels,
+way|z9-[railway=preserved][tunnel=yes]::tunnels,
+way|z9-[railway=narrow_gauge][tunnel=yes]::tunnels,
+way|z11-[railway=tram][tunnel=yes]::tunnels,
+way|z10-[railway=subway][tunnel=yes]::tunnels,
+way|z10-[railway=light_rail][tunnel=yes]::tunnels
 {
 	z-index: 4000;
 	width: 6;

--- a/styles/standard.mapcss
+++ b/styles/standard.mapcss
@@ -123,17 +123,17 @@ way[tunnel=yes]::tunnels
 /* refs and names                                                             */
 /* We have to exclude bridge and tunnels in order to prevent a label collison */
 /******************************************************************************/
-way[railway=rail][!service][!bridge][!tunnel],
-way[railway=disused][!service][!bridge][!tunnel],
-way[railway=abandoned][!service][!bridge][!tunnel],
-way[railway=razed][!service][!bridge][!tunnel],
-way[railway=proposed][!service][!bridge][!tunnel],
-way[railway=construction][!service][!bridge][!tunnel],
-way[railway=preserved][!service][!bridge][!tunnel],
-way[railway=narrow_gauge][!service][!bridge][!tunnel],
-way[railway=tram][!service][!bridge][!tunnel],
-way[railway=subway][!service][!bridge][!tunnel],
-way[railway=light_rail][!service][!bridge][!tunnel]
+way|z2-[railway=rail][!service][!bridge][!tunnel],
+way|z9-[railway=disused][!service][!bridge][!tunnel],
+way|z9-[railway=abandoned][!service][!bridge][!tunnel],
+way|z9-[railway=razed][!service][!bridge][!tunnel],
+way|z9-[railway=proposed][!service][!bridge][!tunnel],
+way|z9-[railway=construction][!service][!bridge][!tunnel],
+way|z9-[railway=preserved][!service][!bridge][!tunnel],
+way|z9-[railway=narrow_gauge][!service][!bridge][!tunnel],
+way|z11-[railway=tram][!service][!bridge][!tunnel],
+way|z10-[railway=subway][!service][!bridge][!tunnel],
+way|z10-[railway=light_rail][!service][!bridge][!tunnel]
 {
 	z-index: 10000;
 	text: eval(concat(tag("ref"), " ", tag("name")));


### PR DESCRIPTION
This prevents the bridges and tunnels from being rendered if the railway line is not rendered, e.g. tram lines on lower zoom levels.

Should fix #214.