### PR TITLE
validator: only warn about duplicate operator if it really is duplicate

### DIFF
--- a/validator/openrailwaymap.validator.mapcss
+++ b/validator/openrailwaymap.validator.mapcss
@@ -103,17 +103,22 @@ way[railway][railway!=platform][!workrules]
 }
 
 /* operator is not necessary for signals and milestones if equal to track operator */
-node[railway=signal][operator],
-node[railway=milestone][operator]
+way[railway][operator] > node[railway=signal][operator]
 {
-	throwWarning: "operator is not necessary for {0.value}s if equal to track operator";
-	assertMatch: "node railway=signal operator=DB";
-	assertMatch: "node railway=milestone operator=DB";
+	throwWarning: "operator is not necessary for signals if equal to track operator";
+/* 	assertMatch: "node railway=signal operator=DB ∈ way railway=rail operator=DB"; */
 	assertNoMatch: "node railway=signal";
+	assertNoMatch: "node railway=signal operator=DB";
+	assertNoMatch: "way railway=rail operator=DB";
+	assertNoMatch: "way railway=rail operator=DB";
+}
+way[railway][operator] > node[railway=milestone][operator]
+{
+	throwWarning: "operator is not necessary for milestones if equal to track operator";
+/* 	assertMatch: "node railway=milestone operator=DB ∈ way railway=rail operator=DB"; */
 	assertNoMatch: "way railway=rail operator=DB";
 	assertNoMatch: "node railway=milestone";
 	assertNoMatch: "way railway=rail operator=DB";
-	fixRemove: "operator";
 }
 
 /* supervised=* is deprecated, replace it with the new crossing:supervision=* */


### PR DESCRIPTION
Do not flag this tagging as error if the railway line has no operator set.