### PR TITLE
validator: fix wrong asserts

### DIFF
--- a/validator/openrailwaymap.validator.mapcss
+++ b/validator/openrailwaymap.validator.mapcss
@@ -43,7 +43,7 @@ way[railway][!operator]
 	throwOther: "Track without with operator";
 	assertMatch: "way railway=rail";
 	assertNoMatch: "node railway=rail operator=SNCF";
-	assertNoMatch: "area railway=rail";
+	assertNoMatch: "relation railway=rail";
 	assertNoMatch: "way railway=rail operator=SNCF";
 }
 
@@ -97,7 +97,7 @@ way[railway][!workrules]
 	throwOther: "Track without with workrules";
 	assertMatch: "way railway=rail";
 	assertNoMatch: "node railway=rail workrules=EBO";
-	assertNoMatch: "area railway=rail";
+	assertNoMatch: "relation railway=rail";
 	assertNoMatch: "way railway=rail workrules=EBO";
 }
 


### PR DESCRIPTION
When the text matches on ways, it will also trigger on areas. This has not been
noticed before because of JOSM bug #11370, where the "area" triggered an
assertion in JOSM itself, so the assert rules never got executed.