### PR TITLE
add DE-ESO:* prefix to railway:signal:minor at German derail template

### DIFF
--- a/josm-presets/de.xml
+++ b/josm-presets/de.xml
@@ -2541,7 +2541,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					default="off"
 					delete_if_empty="true" />
 				<key key="railway:signal:minor"
-					value="sh" />
+					value="DE-ESO:sh" />
 				<combo key="railway:signal:minor:states"
 					text="Signal states"
 					de.text="Signalzustände"


### PR DESCRIPTION
`DE-ESO:` was missing at tagging preset of German derailers. See diff.