### PR TITLE
presets: drop company type from examples

### DIFF
--- a/josm-presets/at.xml
+++ b/josm-presets/at.xml
@@ -156,8 +156,8 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					default=""
 					delete_if_empty="true" />
 				<text key="operator"
-					text="Operator (e.g. 'ÖBB-Infrastruktur AG')"
-					de.text="Betreiber (z. B. 'ÖBB-Infrastruktur AG')"
+					text="Operator (e.g. 'ÖBB-Infrastruktur')"
+					de.text="Betreiber (z. B. 'ÖBB-Infrastruktur')"
 					default=""
 					delete_if_empty="true" />
 				<space />
@@ -282,8 +282,8 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					default=""
 					delete_if_empty="true" />
 				<text key="operator"
-					text="Operator (e.g. 'ÖBB-Infrastruktur AG')"
-					de.text="Betreiber (z. B. 'ÖBB-Infrastruktur AG')"
+					text="Operator (e.g. 'ÖBB-Infrastruktur')"
+					de.text="Betreiber (z. B. 'ÖBB-Infrastruktur')"
 					default=""
 					delete_if_empty="true" />
 				<space />
@@ -398,8 +398,8 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					default=""
 					delete_if_empty="true" />
 				<text key="operator"
-					text="Operator (e.g. 'ÖBB-Infrastruktur AG')"
-					de.text="Betreiber (z. B. 'ÖBB-Infrastruktur AG')"
+					text="Operator (e.g. 'ÖBB-Infrastruktur')"
+					de.text="Betreiber (z. B. 'ÖBB-Infrastruktur')"
 					default=""
 					delete_if_empty="true" />
 				<space />
@@ -509,8 +509,8 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					default=""
 					delete_if_empty="true" />
 				<text key="operator"
-					text="Operator (e.g. 'ÖBB-Infrastruktur AG')"
-					de.text="Betreiber (z. B. 'ÖBB-Infrastruktur AG')"
+					text="Operator (e.g. 'ÖBB-Infrastruktur')"
+					de.text="Betreiber (z. B. 'ÖBB-Infrastruktur')"
 					default=""
 					delete_if_empty="true" />
 				<space />
@@ -631,8 +631,8 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					default=""
 					delete_if_empty="true" />
 				<text key="operator"
-					text="Operator (e.g. 'ÖBB-Infrastruktur AG')"
-					de.text="Betreiber (z. B. 'ÖBB-Infrastruktur AG')"
+					text="Operator (e.g. 'ÖBB-Infrastruktur')"
+					de.text="Betreiber (z. B. 'ÖBB-Infrastruktur')"
 					default=""
 					delete_if_empty="true" />
 				<space />
@@ -790,8 +790,8 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					default=""
 					delete_if_empty="true" />
 				<text key="operator"
-					text="Operator (e.g. 'ÖBB-Infrastruktur AG')"
-					de.text="Betreiber (z. B. 'ÖBB-Infrastruktur AG')"
+					text="Operator (e.g. 'ÖBB-Infrastruktur')"
+					de.text="Betreiber (z. B. 'ÖBB-Infrastruktur')"
 					default=""
 					delete_if_empty="true" />
 				<space />
@@ -929,8 +929,8 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					default=""
 					delete_if_empty="true" />
 				<text key="operator"
-					text="Operator (e.g. 'ÖBB-Infrastruktur AG')"
-					de.text="Betreiber (z. B. 'ÖBB-Infrastruktur AG')"
+					text="Operator (e.g. 'ÖBB-Infrastruktur')"
+					de.text="Betreiber (z. B. 'ÖBB-Infrastruktur')"
 					default=""
 					delete_if_empty="true" />
 				<space />
@@ -1053,8 +1053,8 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					default=""
 					delete_if_empty="true" />
 				<text key="operator"
-					text="Operator (e.g. 'ÖBB-Infrastruktur AG')"
-					de.text="Betreiber (z. B. 'ÖBB-Infrastruktur AG')"
+					text="Operator (e.g. 'ÖBB-Infrastruktur')"
+					de.text="Betreiber (z. B. 'ÖBB-Infrastruktur')"
 					default=""
 					delete_if_empty="true" />
 				<space />
@@ -1597,8 +1597,8 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					default=""
 					delete_if_empty="true" />
 				<text key="operator"
-					text="Operator (e.g. 'ÖBB-Infrastruktur AG')"
-					de.text="Betreiber (z. B. 'ÖBB-Infrastruktur AG')"
+					text="Operator (e.g. 'ÖBB-Infrastruktur')"
+					de.text="Betreiber (z. B. 'ÖBB-Infrastruktur')"
 					default=""
 					delete_if_empty="true" />
 				<space />
@@ -1755,8 +1755,8 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					default=""
 					delete_if_empty="true" />
 				<text key="operator"
-					text="Operator (e.g. 'ÖBB-Infrastruktur AG')"
-					de.text="Betreiber (z. B. 'ÖBB-Infrastruktur AG')"
+					text="Operator (e.g. 'ÖBB-Infrastruktur')"
+					de.text="Betreiber (z. B. 'ÖBB-Infrastruktur')"
 					default=""
 					delete_if_empty="true" />
 				<space />
@@ -1912,8 +1912,8 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					default=""
 					delete_if_empty="true" />
 				<text key="operator"
-					text="Operator (e.g. 'ÖBB-Infrastruktur AG')"
-					de.text="Betreiber (z. B. 'ÖBB-Infrastruktur AG')"
+					text="Operator (e.g. 'ÖBB-Infrastruktur')"
+					de.text="Betreiber (z. B. 'ÖBB-Infrastruktur')"
 					default=""
 					delete_if_empty="true" />
 				<space />
@@ -2069,8 +2069,8 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					default=""
 					delete_if_empty="true" />
 				<text key="operator"
-					text="Operator (e.g. 'ÖBB-Infrastruktur AG')"
-					de.text="Betreiber (z. B. 'ÖBB-Infrastruktur AG')"
+					text="Operator (e.g. 'ÖBB-Infrastruktur')"
+					de.text="Betreiber (z. B. 'ÖBB-Infrastruktur')"
 					default=""
 					delete_if_empty="true" />
 				<space />
@@ -2228,8 +2228,8 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					default=""
 					delete_if_empty="true" />
 				<text key="operator"
-					text="Operator (e.g. 'ÖBB-Infrastruktur AG')"
-					de.text="Betreiber (z. B. 'ÖBB-Infrastruktur AG')"
+					text="Operator (e.g. 'ÖBB-Infrastruktur')"
+					de.text="Betreiber (z. B. 'ÖBB-Infrastruktur')"
 					default=""
 					delete_if_empty="true" />
 				<space />
@@ -2532,8 +2532,8 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					default=""
 					delete_if_empty="true" />
 				<text key="operator"
-					text="Operator (e.g. 'ÖBB-Infrastruktur AG')"
-					de.text="Betreiber (z. B. 'ÖBB-Infrastruktur AG')"
+					text="Operator (e.g. 'ÖBB-Infrastruktur')"
+					de.text="Betreiber (z. B. 'ÖBB-Infrastruktur')"
 					default=""
 					delete_if_empty="true" />
 				<text key="network"
@@ -2603,8 +2603,8 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					default=""
 					delete_if_empty="true" />
 				<text key="operator"
-					text="Operator (e.g. 'ÖBB-Infrastruktur AG')"
-					de.text="Betreiber (z. B. 'ÖBB-Infrastruktur AG')"
+					text="Operator (e.g. 'ÖBB-Infrastruktur')"
+					de.text="Betreiber (z. B. 'ÖBB-Infrastruktur')"
 					default=""
 					delete_if_empty="true" />
 				<text key="network"
@@ -2703,8 +2703,8 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					default=""
 					delete_if_empty="true" />
 				<text key="operator"
-					text="Operator (e.g. 'ÖBB-Infrastruktur AG')"
-					de.text="Betreiber (z. B. 'ÖBB-Infrastruktur AG')"
+					text="Operator (e.g. 'ÖBB-Infrastruktur')"
+					de.text="Betreiber (z. B. 'ÖBB-Infrastruktur')"
 					default=""
 					delete_if_empty="true" />
 				<text key="start_date"
@@ -2744,8 +2744,8 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					default=""
 					delete_if_empty="true" />
 				<text key="operator"
-					text="Operator (e.g. 'ÖBB-Infrastruktur AG')"
-					de.text="Betreiber (z. B. 'ÖBB-Infrastruktur AG')"
+					text="Operator (e.g. 'ÖBB-Infrastruktur')"
+					de.text="Betreiber (z. B. 'ÖBB-Infrastruktur')"
 					default=""
 					delete_if_empty="true" />
 				<text key="start_date"
@@ -2786,8 +2786,8 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					default=""
 					delete_if_empty="true" />
 				<text key="operator"
-					text="Operator (e.g. 'ÖBB-Infrastruktur AG')"
-					de.text="Betreiber (z. B. 'ÖBB-Infrastruktur AG')"
+					text="Operator (e.g. 'ÖBB-Infrastruktur')"
+					de.text="Betreiber (z. B. 'ÖBB-Infrastruktur')"
 					default=""
 					delete_if_empty="true" />
 				<text key="start_date"
@@ -2828,8 +2828,8 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					default=""
 					delete_if_empty="true" />
 				<text key="operator"
-					text="Operator (e.g. 'ÖBB-Infrastruktur AG')"
-					de.text="Betreiber (z. B. 'ÖBB-Infrastruktur AG')"
+					text="Operator (e.g. 'ÖBB-Infrastruktur')"
+					de.text="Betreiber (z. B. 'ÖBB-Infrastruktur')"
 					default=""
 					delete_if_empty="true" />
 				<text key="start_date"
@@ -2870,8 +2870,8 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					default=""
 					delete_if_empty="true" />
 				<text key="operator"
-					text="Operator (e.g. 'ÖBB-Infrastruktur AG')"
-					de.text="Betreiber (z. B. 'ÖBB-Infrastruktur AG')"
+					text="Operator (e.g. 'ÖBB-Infrastruktur')"
+					de.text="Betreiber (z. B. 'ÖBB-Infrastruktur')"
 					default=""
 					delete_if_empty="true" />
 				<text key="start_date"
@@ -2956,8 +2956,8 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					default="off"
 					delete_if_empty="true" />
 				<text key="operator"
-					text="Operator (e.g. 'ÖBB-Personenverkehr AG')"
-					de.text="Betreiber (z. B. 'ÖBB-Personenverkehr AG')"
+					text="Operator (e.g. 'ÖBB-Personenverkehr')"
+					de.text="Betreiber (z. B. 'ÖBB-Personenverkehr')"
 					default=""
 					delete_if_empty="true" />
 				<text key="network"
@@ -3028,8 +3028,8 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					default=""
 					delete_if_empty="true" />
 				<text key="operator"
-					text="Operator (e.g. 'ÖBB-Infrastruktur AG')"
-					de.text="Betreiber (z. B. 'ÖBB-Infrastruktur AG')"
+					text="Operator (e.g. 'ÖBB-Infrastruktur')"
+					de.text="Betreiber (z. B. 'ÖBB-Infrastruktur')"
 					default=""
 					delete_if_empty="true" />
 				<check key="train"
@@ -3116,8 +3116,8 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				default=""
 				delete_if_empty="true" />
 			<text key="operator"
-				text="Operator (e.g. 'ÖBB-Infrastruktur AG')"
-				de.text="Betreiber (z. B. 'ÖBB-Infrastruktur AG')"
+				text="Operator (e.g. 'ÖBB-Infrastruktur')"
+				de.text="Betreiber (z. B. 'ÖBB-Infrastruktur')"
 				default=""
 				delete_if_empty="true" />
 			<text key="wikipedia"
@@ -3621,8 +3621,8 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<key key="shop"
 				value="ticket" />
 			<text key="operator"
-				text="Operator (e.g. 'ÖBB Personenverkehr AG')"
-				de.text="Betreiber (z. B. 'ÖBB Personenverkehr AG')"
+				text="Operator (e.g. 'ÖBB Personenverkehr')"
+				de.text="Betreiber (z. B. 'ÖBB Personenverkehr')"
 				default=""
 				delete_if_empty="true" />
 			<text key="name"
@@ -3855,8 +3855,8 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					default="off"
 					delete_if_empty="true" />
 				<text key="operator"
-					text="Operator (e.g. 'ÖBB Infrastruktur AG')"
-					de.text="Betreiber (z. B. 'ÖBB Infrastruktur AG')"
+					text="Operator (e.g. 'ÖBB Infrastruktur')"
+					de.text="Betreiber (z. B. 'ÖBB Infrastruktur')"
 					default=""
 					delete_if_empty="true" />
 			</item>

--- a/josm-presets/de.xml
+++ b/josm-presets/de.xml
@@ -177,8 +177,8 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					default=""
 					delete_if_empty="true" />
 				<text key="operator"
-					text="Operator (e.g. 'DB Netz AG')"
-					de.text="Betreiber (z. B. 'DB Netz AG')"
+					text="Operator (e.g. 'DB Netz')"
+					de.text="Betreiber (z. B. 'DB Netz')"
 					default=""
 					delete_if_empty="true" />
 				<space />
@@ -311,8 +311,8 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					default=""
 					delete_if_empty="true" />
 				<text key="operator"
-					text="Operator (e.g. 'DB Netz AG')"
-					de.text="Betreiber (z. B. 'DB Netz AG')"
+					text="Operator (e.g. 'DB Netz')"
+					de.text="Betreiber (z. B. 'DB Netz')"
 					default=""
 					delete_if_empty="true" />
 				<space />
@@ -435,8 +435,8 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					default=""
 					delete_if_empty="true" />
 				<text key="operator"
-					text="Operator (e.g. 'DB Netz AG')"
-					de.text="Betreiber (z. B. 'DB Netz AG')"
+					text="Operator (e.g. 'DB Netz')"
+					de.text="Betreiber (z. B. 'DB Netz')"
 					default=""
 					delete_if_empty="true" />
 				<space />
@@ -554,8 +554,8 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					default=""
 					delete_if_empty="true" />
 				<text key="operator"
-					text="Operator (e.g. 'DB Netz AG')"
-					de.text="Betreiber (z. B. 'DB Netz AG')"
+					text="Operator (e.g. 'DB Netz')"
+					de.text="Betreiber (z. B. 'DB Netz')"
 					default=""
 					delete_if_empty="true" />
 				<space />
@@ -702,8 +702,8 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					default=""
 					delete_if_empty="true" />
 				<text key="operator"
-					text="Operator (e.g. 'DB Netz AG')"
-					de.text="Betreiber (z. B. 'DB Netz AG')"
+					text="Operator (e.g. 'DB Netz')"
+					de.text="Betreiber (z. B. 'DB Netz')"
 					default=""
 					delete_if_empty="true" />
 				<space />
@@ -864,8 +864,8 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					default=""
 					delete_if_empty="true" />
 				<text key="operator"
-					text="Operator (e.g. 'DB Netz AG')"
-					de.text="Betreiber (z. B. 'DB Netz AG')"
+					text="Operator (e.g. 'DB Netz')"
+					de.text="Betreiber (z. B. 'DB Netz')"
 					default=""
 					delete_if_empty="true" />
 				<space />
@@ -1006,8 +1006,8 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					default=""
 					delete_if_empty="true" />
 				<text key="operator"
-					text="Operator (e.g. 'DB Netz AG')"
-					de.text="Betreiber (z. B. 'DB Netz AG')"
+					text="Operator (e.g. 'DB Netz')"
+					de.text="Betreiber (z. B. 'DB Netz')"
 					default=""
 					delete_if_empty="true" />
 				<space />
@@ -1132,8 +1132,8 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					default=""
 					delete_if_empty="true" />
 				<text key="operator"
-					text="Operator (e.g. 'DB Netz AG')"
-					de.text="Betreiber (z. B. 'DB Netz AG')"
+					text="Operator (e.g. 'DB Netz')"
+					de.text="Betreiber (z. B. 'DB Netz')"
 					default=""
 					delete_if_empty="true" />
 				<space />
@@ -1698,8 +1698,8 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					default=""
 					delete_if_empty="true" />
 				<text key="operator"
-					text="Operator (e.g. 'DB Netz AG')"
-					de.text="Betreiber (z. B. 'DB Netz AG')"
+					text="Operator (e.g. 'DB Netz')"
+					de.text="Betreiber (z. B. 'DB Netz')"
 					default=""
 					delete_if_empty="true" />
 				<space />
@@ -1872,8 +1872,8 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					default=""
 					delete_if_empty="true" />
 				<text key="operator"
-					text="Operator (e.g. 'DB Netz AG')"
-					de.text="Betreiber (z. B. 'DB Netz AG')"
+					text="Operator (e.g. 'DB Netz')"
+					de.text="Betreiber (z. B. 'DB Netz')"
 					default=""
 					delete_if_empty="true" />
 				<space />
@@ -2033,8 +2033,8 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					default=""
 					delete_if_empty="true" />
 				<text key="operator"
-					text="Operator (e.g. 'DB Netz AG')"
-					de.text="Betreiber (z. B. 'DB Netz AG')"
+					text="Operator (e.g. 'DB Netz')"
+					de.text="Betreiber (z. B. 'DB Netz')"
 					default=""
 					delete_if_empty="true" />
 				<space />
@@ -2194,8 +2194,8 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					default=""
 					delete_if_empty="true" />
 				<text key="operator"
-					text="Operator (e.g. 'DB Netz AG')"
-					de.text="Betreiber (z. B. 'DB Netz AG')"
+					text="Operator (e.g. 'DB Netz')"
+					de.text="Betreiber (z. B. 'DB Netz')"
 					default=""
 					delete_if_empty="true" />
 				<space />
@@ -2356,8 +2356,8 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					default=""
 					delete_if_empty="true" />
 				<text key="operator"
-					text="Operator (e.g. 'DB Netz AG')"
-					de.text="Betreiber (z. B. 'DB Netz AG')"
+					text="Operator (e.g. 'DB Netz')"
+					de.text="Betreiber (z. B. 'DB Netz')"
 					default=""
 					delete_if_empty="true" />
 				<space />
@@ -2669,8 +2669,8 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					default=""
 					delete_if_empty="true" />
 				<text key="operator"
-					text="Operator (e.g. 'DB Station&amp;Service AG')"
-					de.text="Betreiber (z. B. 'DB Station&amp;Service AG')"
+					text="Operator (e.g. 'DB Station&amp;Service')"
+					de.text="Betreiber (z. B. 'DB Station&amp;Service')"
 					default=""
 					delete_if_empty="true" />
 				<text key="network"
@@ -2740,8 +2740,8 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					default=""
 					delete_if_empty="true" />
 				<text key="operator"
-					text="Operator (e.g. 'DB Station&amp;Service AG')"
-					de.text="Betreiber (z. B. 'DB Station&amp;Service AG')"
+					text="Operator (e.g. 'DB Station&amp;Service')"
+					de.text="Betreiber (z. B. 'DB Station&amp;Service')"
 					default=""
 					delete_if_empty="true" />
 				<text key="network"
@@ -2840,8 +2840,8 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					default=""
 					delete_if_empty="true" />
 				<text key="operator"
-					text="Operator (e.g. 'DB Netz AG')"
-					de.text="Betreiber (z. B. 'DB Netz AG')"
+					text="Operator (e.g. 'DB Netz')"
+					de.text="Betreiber (z. B. 'DB Netz')"
 					default=""
 					delete_if_empty="true" />
 				<text key="start_date"
@@ -2881,8 +2881,8 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					default=""
 					delete_if_empty="true" />
 				<text key="operator"
-					text="Operator (e.g. 'DB Netz AG')"
-					de.text="Betreiber (z. B. 'DB Netz AG')"
+					text="Operator (e.g. 'DB Netz')"
+					de.text="Betreiber (z. B. 'DB Netz')"
 					default=""
 					delete_if_empty="true" />
 				<text key="start_date"
@@ -2923,8 +2923,8 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					default=""
 					delete_if_empty="true" />
 				<text key="operator"
-					text="Operator (e.g. 'DB Netz AG')"
-					de.text="Betreiber (z. B. 'DB Netz AG')"
+					text="Operator (e.g. 'DB Netz')"
+					de.text="Betreiber (z. B. 'DB Netz')"
 					default=""
 					delete_if_empty="true" />
 				<text key="start_date"
@@ -2965,8 +2965,8 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					default=""
 					delete_if_empty="true" />
 				<text key="operator"
-					text="Operator (e.g. 'DB Netz AG')"
-					de.text="Betreiber (z. B. 'DB Netz AG')"
+					text="Operator (e.g. 'DB Netz')"
+					de.text="Betreiber (z. B. 'DB Netz')"
 					default=""
 					delete_if_empty="true" />
 				<text key="start_date"
@@ -3007,8 +3007,8 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					default=""
 					delete_if_empty="true" />
 				<text key="operator"
-					text="Operator (e.g. 'DB Netz AG')"
-					de.text="Betreiber (z. B. 'DB Netz AG')"
+					text="Operator (e.g. 'DB Netz')"
+					de.text="Betreiber (z. B. 'DB Netz')"
 					default=""
 					delete_if_empty="true" />
 				<text key="start_date"
@@ -3093,8 +3093,8 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					default="off"
 					delete_if_empty="true" />
 				<text key="operator"
-					text="Operator (e.g. 'DB Netz AG' or 'DB Station&amp;Service AG')"
-					de.text="Betreiber (z. B. 'DB Netz AG' oder 'DB Station&amp;Service AG')"
+					text="Operator (e.g. 'DB Netz' or 'DB Station&amp;Service')"
+					de.text="Betreiber (z. B. 'DB Netz' oder 'DB Station&amp;Service')"
 					default=""
 					delete_if_empty="true" />
 				<text key="network"
@@ -3165,8 +3165,8 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					default=""
 					delete_if_empty="true" />
 				<text key="operator"
-					text="Operator (e.g. 'DB Netz AG' or 'DB Station&amp;Service AG')"
-					de.text="Betreiber (z. B. 'DB Netz AG' oder 'DB Station&amp;Service AG')"
+					text="Operator (e.g. 'DB Netz' or 'DB Station&amp;Service')"
+					de.text="Betreiber (z. B. 'DB Netz' oder 'DB Station&amp;Service')"
 					default=""
 					delete_if_empty="true" />
 				<check key="train"
@@ -3253,8 +3253,8 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				default=""
 				delete_if_empty="true" />
 			<text key="operator"
-				text="Operator (e.g. 'DB Netz AG')"
-				de.text="Betreiber (z. B. 'DB Netz AG')"
+				text="Operator (e.g. 'DB Netz')"
+				de.text="Betreiber (z. B. 'DB Netz')"
 				default=""
 				delete_if_empty="true" />
 			<text key="wikipedia"
@@ -3993,8 +3993,8 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					default="off"
 					delete_if_empty="true" />
 				<text key="operator"
-					text="Operator (e.g. 'DB Netz AG')"
-					de.text="Betreiber (z. B. 'DB Netz AG')"
+					text="Operator (e.g. 'DB Netz')"
+					de.text="Betreiber (z. B. 'DB Netz')"
 					default=""
 					delete_if_empty="true" />
 			</item>


### PR DESCRIPTION
http://wiki.openstreetmap.org/wiki/DE:Key:operator suggests to leave out the company form.