### PR TITLE
Some improvements of German signal tagging preset

### DIFF
--- a/josm-presets/de-signals-eso.xml
+++ b/josm-presets/de-signals-eso.xml
@@ -1860,10 +1860,11 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						display_values="Lichtsignal,Tafel"
 						default=""
 						delete_if_empty="true" />
-					<combo key="railway:signal:speed_limit:speed" default=""
+					<multiselect key="railway:signal:speed_limit:speed" 
 						text="Speed (km/h, in case of light signals separate the possible values (number or 'off') with ';')"
 						de.text="Geschwindigkeit (km/h, bei Lichtsignalen mögliche Werte (Zahl oder 'off') mit ';' trennen)"
 						delete_if_empty="true"
+						delimiter=","
 						values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,?"
 						display_values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,unknown"
 						de.display_values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,unbekannt" />
@@ -1910,10 +1911,11 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						display_values="Lichtsignal,Tafel"
 						default=""
 						delete_if_empty="true" />
-					<combo key="railway:signal:speed_limit_distant:speed" default=""
+					<multiselect key="railway:signal:speed_limit_distant:speed" 
 						text="Speed (km/h, in case of light signals separate the possible values(number or 'off') with ';')"
 						de.text="Geschwindigkeit (km/h, bei Lichtsignalen mögliche Werte (Zahl oder 'off') mit ';' trennen)"
 						delete_if_empty="true"
+						delimiter=","
 						values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,?"
 						display_values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,unknown"
 						de.display_values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,unbekannt" />
@@ -2136,8 +2138,8 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<key key="railway:signal:speed_limit:form"
 						value="sign" />
 					<combo key="railway:signal:speed_limit:speed" default=""
-						text="Speed (km/h, in case of light signals separate the possible values (number or 'off') with ';')"
-						de.text="Geschwindigkeit (km/h, bei Lichtsignalen mögliche Werte (Zahl oder 'off') mit ';' trennen)"
+						text="Speed (km/h)"
+						de.text="Geschwindigkeit (km/h)"
 						delete_if_empty="true"
 						values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,none"
 						display_values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,end (Zs 10, Lf 3)"
@@ -2193,8 +2195,8 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<key key="railway:signal:speed_limit_distant:form"
 						value="sign" />
 					<combo key="railway:signal:speed_limit_distant:speed" default=""
-						text="Speed (km/h, in case of light signals separate the possible values(number or 'off') with ';')"
-						de.text="Geschwindigkeit (km/h, bei Lichtsignalen mögliche Werte (Zahl oder 'off') mit ';' trennen)"
+						text="Speed (km/h)"
+						de.text="Geschwindigkeit (km/h)"
 						delete_if_empty="true"
 						values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,off"
 						display_values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,off"

--- a/josm-presets/de-signals-eso.xml
+++ b/josm-presets/de-signals-eso.xml
@@ -119,9 +119,9 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						de.text="Signalzustände"
 						delete_if_empty="true"
 						delimiter="|"
-						values="DE-ESO:hp0;DE-ESO:ks1;DE-ESO:ks2|DE-ESO:hp0;DE-ESO:ks1;DE-ESO:ks2;DE-ESO:kennlicht|DE-ESO:hp0;DE-ESO:ks1;DE-ESO:ks2;off"
-						de.display_values="Hp 0, Ks 1 und Ks 2|Hp 0, Ks 1, Ks 2 und Kennlicht|Hp 0, Ks 1, Ks 2 und Dunkelschaltung"
-						display_values="Hp 0, Ks 1 and Ks 2|Hp 0, Ks 1, Ks 2 and marker light|Hp 0, Ks 1, Ks 2 and dark" />
+						values="DE-ESO:hp0;DE-ESO:ks1;DE-ESO:ks2|DE-ESO:hp0;DE-ESO:ks1;DE-ESO:ks2;DE-ESO:kennlicht|DE-ESO:hp0;DE-ESO:ks1;DE-ESO:ks2;off|DE-ESO:hp0;DE-ESO:ks2"
+						de.display_values="Hp 0, Ks 1 und Ks 2|Hp 0, Ks 1, Ks 2 und Kennlicht|Hp 0, Ks 1, Ks 2 und Dunkelschaltung|nur Hp 0 (Halt) und Ks 2 (Halt erwarten)"
+						display_values="Hp 0, Ks 1 and Ks 2|Hp 0, Ks 1, Ks 2 and marker light|Hp 0, Ks 1, Ks 2 and dark|only Hp 0 and Ks 2" />
 					<check key="railway:signal:combined:shortened"
 						text="Shortened distance"
 						de.text="Verkürzter Bremsweg"
@@ -1867,14 +1867,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,?"
 						display_values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,unknown"
 						de.display_values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,unbekannt" />
-					<combo key="railway:signal:speed_limit:turn_direction"
-						text="Turn direction arrow – leave this key empty if there is no one."
-						de.text="Richtungspfeil – leer lassen, falls es keinen gibt."
-						values="left,through,right"
-						display_values="Left,Through,Right"
-						de.display_values="Links,Geradeaus,Rechts"
-						default=""
-						delete_if_empty="true" />
 					<combo key="railway:signal:speed_limit:height"
 						text="Signal height"
 						de.text="Signalbauform"
@@ -1925,14 +1917,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,?"
 						display_values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,unknown"
 						de.display_values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,unbekannt" />
-					<combo key="railway:signal:speed_limit_distant:turn_direction"
-						text="Turn direction arrow – leave this key empty if there is no one."
-						de.text="Richtungspfeil – leer lassen, falls es keinen gibt."
-						values="left,through,right"
-						display_values="Left,Through,Right"
-						de.display_values="Links,Geradeaus,Rechts"
-						default=""
-						delete_if_empty="true" />
 					<combo key="railway:signal:speed_limit_distant:height"
 						text="Signal height"
 						de.text="Signalbauform"
@@ -2149,13 +2133,8 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						<list_entry value="DE-ESO:db:lf5" display_value="Lf 5 DR" short_description="Anfangstafel Lf 5 (ex-DB)" />
 						<list_entry value="DE-ESO:dr:lf5" display_value="Lf 5 DR" short_description="Eckentafel Lf 5 (ex-DR)" />
 					</combo>
-					<combo key="railway:signal:speed_limit:form"
-						text="Signal form"
-						de.text="Anzeigeart"
-						values="light,sign"
-						display_values="Lichtsignal,Tafel"
-						default=""
-						delete_if_empty="true" />
+					<key key="railway:signal:speed_limit:form"
+						value="sign" />
 					<combo key="railway:signal:speed_limit:speed" default=""
 						text="Speed (km/h, in case of light signals separate the possible values (number or 'off') with ';')"
 						de.text="Geschwindigkeit (km/h, bei Lichtsignalen mögliche Werte (Zahl oder 'off') mit ';' trennen)"
@@ -2163,6 +2142,13 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,none"
 						display_values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,end (Zs 10, Lf 3)"
 						de.display_values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,Aufhebung (Zs 10; Lf 3)" />
+					<combo key="railway:signal:speed_limit:height"
+						text="Signal height"
+						de.text="Signalbauform"
+						values="normal,dwarf"
+						default=""
+						display_values="Mastbauform,Zwergsignal"
+						delete_if_empty="true" />
 					<combo key="railway:signal:speed_limit:turn_direction"
 						text="Turn direction arrow – leave this key empty if there is no one."
 						de.text="Richtungspfeil – leer lassen, falls es keinen gibt."
@@ -2170,13 +2156,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						display_values="Left,Through,Right"
 						de.display_values="Links,Geradeaus,Rechts"
 						default=""
-						delete_if_empty="true" />
-					<combo key="railway:signal:speed_limit:height"
-						text="Signal height"
-						de.text="Signalbauform"
-						values="normal,dwarf"
-						default=""
-						display_values="Mastbauform,Zwergsignal"
 						delete_if_empty="true" />
 				</item>
 				<item name="Geschwindigkeits-Ankündesignal" icon="de-lf6-60-sign-down-32.png" type="node">
@@ -2211,13 +2190,8 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						<list_entry value="DE-ESO:db:lf4" display_value="Lf 4 DB" short_description="Geschwindigkeitstafel Lf 4 (ex-DB)" />
 						<list_entry value="DE-ESO:dr:lf4" display_value="Lf 4" short_description="Geschwindigkeitstafel Lf 4 (ex-DR)" />
 					</combo>
-					<combo key="railway:signal:speed_limit_distant:form"
-						text="Signal form"
-						de.text="Anzeigeart"
-						values="light,sign"
-						display_values="Lichtsignal,Tafel"
-						default=""
-						delete_if_empty="true" />
+					<key key="railway:signal:speed_limit_distant:form"
+						value="sign" />
 					<combo key="railway:signal:speed_limit_distant:speed" default=""
 						text="Speed (km/h, in case of light signals separate the possible values(number or 'off') with ';')"
 						de.text="Geschwindigkeit (km/h, bei Lichtsignalen mögliche Werte (Zahl oder 'off') mit ';' trennen)"
@@ -2225,6 +2199,13 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,off"
 						display_values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,off"
 						de.display_values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,off" />
+					<combo key="railway:signal:speed_limit_distant:height"
+						text="Signal height"
+						de.text="Signalbauform"
+						values="normal,dwarf"
+						default=""
+						display_values="Mastbauform,Zwergsignal"
+						delete_if_empty="true" />
 					<combo key="railway:signal:speed_limit_distant:turn_direction"
 						text="Turn direction arrow – leave this key empty if there is no one."
 						de.text="Richtungspfeil – leer lassen, falls es keinen gibt."
@@ -2232,13 +2213,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						display_values="Left,Through,Right"
 						de.display_values="Links,Geradeaus,Rechts"
 						default=""
-						delete_if_empty="true" />
-					<combo key="railway:signal:speed_limit_distant:height"
-						text="Signal height"
-						de.text="Signalbauform"
-						values="normal,dwarf"
-						default=""
-						display_values="Mastbauform,Zwergsignal"
 						delete_if_empty="true" />
 				</item>
 			</group>

--- a/josm-presets/de-signals-eso.xml
+++ b/josm-presets/de-signals-eso.xml
@@ -1678,6 +1678,13 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						display_values="Ra 11 / Sh 1,-nur Tafel-"
 						default=""
 						delete_if_empty="true" />
+					<combo key="railway:signal:shunting:height"
+						text="Signal height"
+						de.text="Signalbauform"
+						values="normal,dwarf"
+						display_values="Mastbauform,Zwergsignal"
+						default=""
+						delete_if_empty="true" />
 				</item>
 				<item name="Abdrücksignal (Ra 6–Ra 9)" icon="de-humping.png" type="node">
 					<label text="Abdrücksignal (Ra 6–Ra 9)" />


### PR DESCRIPTION
- Lf 6 and Lf 7 cannot be light signals
- Zs 3 and Zs 3v do not have arrows