### PR TITLE
Some updates to zs2, zs2v, zs3

### DIFF
--- a/josm-presets/de-signals-eso.xml
+++ b/josm-presets/de-signals-eso.xml
@@ -1773,13 +1773,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						de.text="Mögliche Anzeigewerte (getrennt durch ';', verwende '?', wenn du nicht alle Werte kennst)"
 						default=""
 						delete_if_empty="true" />
-					<combo key="railway:signal:route:form"
-						text="Type"
-						de.text="Typ"
-						values="sign,light"
-						display_values="Tafel,Leuchtanzeige"
-						default=""
-						delete_if_empty="true" />
 				</item>
 				<item name="Richtungsvoranzeiger (Zs 2v)" icon="de-zs2v-F-38.png" type="node">
 					<label text="Richtungsvoranzeiger (Zs 2v)" />
@@ -1812,13 +1805,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<text key="railway:signal:route_distant:states"
 						text="Signal states (separated by ';', use '?' if you don't know all possible values)"
 						de.text="Mögliche Anzeigewerte (getrennt durch ';', verwende '?', wenn du nicht alle Werte kennst)"
-						default=""
-						delete_if_empty="true" />
-					<combo key="railway:signal:route_distant:form"
-						text="Type"
-						de.text="Typ"
-						values="sign,light"
-						display_values="Tafel,Leuchtanzeige"
 						default=""
 						delete_if_empty="true" />
 				</item>
@@ -1859,13 +1845,13 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						default=""
 						delete_if_empty="true" />
 					<multiselect key="railway:signal:speed_limit:speed" 
-						text="Speed (km/h, in case of light signals separate the possible values (number or 'off') with ';')"
-						de.text="Geschwindigkeit (km/h, bei Lichtsignalen mögliche Werte (Zahl oder 'off') mit ';' trennen)"
+						text="Speed (kph)"
+						de.text="Geschwindigkeit (km/h)"
 						delete_if_empty="true"
 						delimiter=","
-						values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,?"
-						display_values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,unknown"
-						de.display_values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,unbekannt" />
+						values="off,10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,?"
+						display_values="off,10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,unknown"
+						de.display_values="dunkel,10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,unbekannt" />
 					<combo key="railway:signal:speed_limit:height"
 						text="Signal height"
 						de.text="Signalbauform"


### PR DESCRIPTION
zs2/zs2v cannot be fixed signs; zs3 might also be "off"/"dark" (note: There are speed signals that are not multiples of 10, such as "0.5" [5 kph]) which cannot be modelled through the current version of the template anymore)