### PR TITLE
presets: use the default JOSM icon for level_crossing

### DIFF
--- a/josm-presets/at.xml
+++ b/josm-presets/at.xml
@@ -3368,7 +3368,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			</roles>
 		</item>
 		<separator />
-		<item name="Level Crossing" de.name="Bahnübergang" icon="de-crossing.png" type="node">
+		<item name="Level Crossing" de.name="Bahnübergang" icon="presets/level_crossing.png" type="node">
 			<label text="Bahnübergang" />
 			<space />
 			<key key="railway"

--- a/josm-presets/de.xml
+++ b/josm-presets/de.xml
@@ -3505,7 +3505,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			</roles>
 		</item>
 		<separator />
-		<item name="Level Crossing" de.name="Bahnübergang" icon="de-crossing.png" type="node">
+		<item name="Level Crossing" de.name="Bahnübergang" icon="presets/level_crossing.png" type="node">
 			<label text="Bahnübergang" />
 			<space />
 			<key key="railway"


### PR DESCRIPTION
The custom one that was referenced does not exist, so simply use the default one.