### PR TITLE
presets: link from H/V light main signals to distant ones

### DIFF
--- a/josm-presets/at-signals-v2.xml
+++ b/josm-presets/at-signals-v2.xml
@@ -146,6 +146,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				display_values="Ersatzsignal;Vorsichtssignal"
 				delete_if_empty="true" />
 			<space />
+			<preset_link preset_name="Lichtvorsignal" />
 			<preset_link preset_name="Geschwindigkeitsanzeiger" />
 			<preset_link preset_name="Geschwindigkeitsvoranzeiger" />
 			<preset_link preset_name="Verschubsignal" />

--- a/josm-presets/de-signals-eso.xml
+++ b/josm-presets/de-signals-eso.xml
@@ -856,6 +856,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						display_values="Ersatzsignal (ex-DB);Ersatzsignal (ex-DR);Vorsichtsignal;M-Tafel"
 						delete_if_empty="true" />
 					<space />
+					<preset_link preset_name="Vr-Licht-Vorsignal" />
 					<preset_link preset_name="Richtungsanzeiger (Zs 2)" />
 					<preset_link preset_name="Geschwindigkeitsanzeiger (Zs 3)" />
 					<preset_link preset_name="Sh-1-Licht" />


### PR DESCRIPTION
They are often at the same place, make tagging of them easier.