### PR TITLE
Remove support of deprecated German signal tagging (tagging without DE-ESO:*)

### DIFF
--- a/styles/josm-additional.mapcss
+++ b/styles/josm-additional.mapcss
@@ -53,3 +53,43 @@ node|z16-[railway=signal][!"railway:signal:direction"]
 	icon-height: 16;
 	allow-overlap: true;
 }
+
+node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:main"=~/^(hp|hl|ks|sv|sk)/],
+node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:distant"=~/^(vr|hl|ks|sv|sk|db:ne|dr:so)/],
+node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"=~/^(db:|dr:){0,1}lf/],
+node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"=~/^(db:|dr:){0,1}lf/],
+node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:combined"=~/^(hl|ks|sv|sk)/],
+node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:crossing"=~/^(bü|dr:so|db:bü)/],
+node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:crossing_distant"=~/^(bü|dr:so|db:bü)/],
+node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:electricity"=~/^el/],
+node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:humping"=~/^ra/],
+node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:whistle"=~/^(pf|bü|db:bü|dr:so)/],
+node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:ring"=~/^(pf|bü|db:bü|dr:so)/],
+node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:route"=zs2],
+node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:route_distant"=zs2v],
+node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:wrong_road"=~/^(zs|dr:zs|db:zs)/],
+node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:stop"=ne5],
+node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:station_distant"=ne6],
+node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:resetting_switch"=ne13],
+node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:snowplow:order"],
+node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:snowplow"=ne7],
+node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:short_route"=zs13],
+node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:brake_test"=zp],
+node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:lzb"],
+node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:lzb_start"],
+node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:main:marker_light"],
+node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:distant:marker_light"],
+node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:combined:marker_light"],
+node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:minor:marker_light"],
+node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:minor:form"=light]["railway:signal:minor:states"="sh0;sh1"],
+node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:stop:description"]
+{
+	z-index: 10000;
+	/* high z-index to overwrite other stylesheets */
+	icon-image: "misc/deprecated.png";
+	/* misc/deprecated.png is part of the JOSM installation, 
+	   that's why it is not included at OpenRailwayMap repository */
+	icon-width: 16;
+	icon-height: 16;
+	allow-overlap: true;
+}

--- a/styles/maxspeed.mapcss
+++ b/styles/maxspeed.mapcss
@@ -895,8 +895,7 @@ way|z10-["construction:railway=rail"][maxspeed>380][maxspeed<=400]
 }
 
 /* German speed signals (Zs 10) */
-node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:db:zs10"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=none],
-node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="db:zs10"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=none]
+node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:db:zs10"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=none]
 {
 	z-index: 90;
 	icon-image: "icons/de/zs10-sign-44.png";
@@ -905,8 +904,7 @@ node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	allow-overlap: true;
 }
 
-node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:db:zs10"]["railway:signal:speed_limit:form"=light]["railway:signal:speed_limit:speed"=none],
-node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="db:zs10"]["railway:signal:speed_limit:form"=light]["railway:signal:speed_limit:speed"=none]
+node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:db:zs10"]["railway:signal:speed_limit:form"=light]["railway:signal:speed_limit:speed"=none]
 {
 	z-index: 95;
 	icon-image: "icons/de/zs10-light-44.png";
@@ -917,7 +915,6 @@ node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 
 /* German speed signals (Zs 3) */
 node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:zs3"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=10]
-node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="zs3"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=10]
 {
 	z-index: 100;
 	icon-image: "icons/de/zs3-10-sign-up-44.png";
@@ -926,8 +923,7 @@ node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	allow-overlap: true;
 }
 
-node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:zs3"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=20],
-node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="zs3"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=20]
+node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:zs3"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=20]
 {
 	z-index: 105;
 	icon-image: "icons/de/zs3-20-sign-up-44.png";
@@ -936,8 +932,7 @@ node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	allow-overlap: true;
 }
 
-node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:zs3"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=30],
-node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="zs3"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=30]
+node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:zs3"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=30]
 {
 	z-index: 110;
 	icon-image: "icons/de/zs3-30-sign-up-44.png";
@@ -946,8 +941,7 @@ node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	allow-overlap: true;
 }
 
-node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:zs3"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=40],
-node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="zs3"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=40]
+node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:zs3"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=40]
 {
 	z-index: 115;
 	icon-image: "icons/de/zs3-40-sign-up-44.png";
@@ -956,8 +950,7 @@ node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	allow-overlap: true;
 }
 
-node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:zs3"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=50],
-node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="zs3"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=50]
+node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:zs3"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=50]
 {
 	z-index: 120;
 	icon-image: "icons/de/zs3-50-sign-up-44.png";
@@ -966,8 +959,7 @@ node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	allow-overlap: true;
 }
 
-node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:zs3"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=60],
-node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="zs3"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=60]
+node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:zs3"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=60]
 {
 	z-index: 125;
 	icon-image: "icons/de/zs3-60-sign-up-44.png";
@@ -976,8 +968,7 @@ node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	allow-overlap: true;
 }
 
-node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:zs3"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=70],
-node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="zs3"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=70]
+node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:zs3"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=70]
 {
 	z-index: 130;
 	icon-image: "icons/de/zs3-70-sign-up-44.png";
@@ -986,8 +977,7 @@ node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	allow-overlap: true;
 }
 
-node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:zs3"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=80],
-node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="zs3"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=80]
+node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:zs3"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=80]
 {
 	z-index: 135;
 	icon-image: "icons/de/zs3-80-sign-up-44.png";
@@ -996,8 +986,7 @@ node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	allow-overlap: true;
 }
 
-node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:zs3"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=90],
-node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="zs3"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=90]
+node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:zs3"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=90]
 {
 	z-index: 140;
 	icon-image: "icons/de/zs3-90-sign-up-44.png";
@@ -1006,8 +995,7 @@ node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	allow-overlap: true;
 }
 
-node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:zs3"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=100],
-node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="zs3"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=100]
+node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:zs3"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=100]
 {
 	z-index: 145;
 	icon-image: "icons/de/zs3-100-sign-up-44.png";
@@ -1016,8 +1004,7 @@ node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	allow-overlap: true;
 }
 
-node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:zs3"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=110],
-node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="zs3"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=110]
+node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:zs3"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=110]
 {
 	z-index: 150;
 	icon-image: "icons/de/zs3-110-sign-up-44.png";
@@ -1026,8 +1013,7 @@ node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	allow-overlap: true;
 }
 
-node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:zs3"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=120],
-node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="zs3"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=120]
+node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:zs3"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=120]
 {
 	z-index: 155;
 	icon-image: "icons/de/zs3-120-sign-up-44.png";
@@ -1036,8 +1022,7 @@ node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	allow-overlap: true;
 }
 
-node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:zs3"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=130],
-node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="zs3"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=130]
+node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:zs3"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=130]
 {
 	z-index: 160;
 	icon-image: "icons/de/zs3-130-sign-up-44.png";
@@ -1046,8 +1031,7 @@ node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	allow-overlap: true;
 }
 
-node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:zs3"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=140],
-node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="zs3"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=140]
+node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:zs3"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=140]
 {
 	z-index: 165;
 	icon-image: "icons/de/zs3-140-sign-up-44.png";
@@ -1056,8 +1040,7 @@ node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	allow-overlap: true;
 }
 
-node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:zs3"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=150],
-node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="zs3"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=150]
+node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:zs3"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=150]
 {
 	z-index: 170;
 	icon-image: "icons/de/zs3-150-sign-up-44.png";
@@ -1066,8 +1049,7 @@ node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	allow-overlap: true;
 }
 
-node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:zs3"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=160],
-node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="zs3"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=160]
+node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:zs3"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=160]
 {
 	z-index: 175;
 	icon-image: "icons/de/zs3-160-sign-up-44.png";
@@ -1077,8 +1059,7 @@ node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 }
 
 /* German speed signals (Zs 3v) */
-node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:zs3v"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=10],
-node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"=zs3v]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=10]
+node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:zs3v"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=10]
 {
 	z-index: 200;
 	icon-image: "icons/de/zs3v-10-sign-down-44.png";
@@ -1087,8 +1068,7 @@ node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	allow-overlap: true;
 }
 
-node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:zs3v"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=20],
-node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"=zs3v]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=20]
+node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:zs3v"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=20]
 {
 	z-index: 205;
 	icon-image: "icons/de/zs3v-20-sign-down-44.png";
@@ -1097,8 +1077,7 @@ node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	allow-overlap: true;
 }
 
-node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:zs3v"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=30],
-node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"=zs3v]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=30]
+node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:zs3v"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=30]
 {
 	z-index: 210;
 	icon-image: "icons/de/zs3v-30-sign-down-44.png";
@@ -1107,8 +1086,7 @@ node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	allow-overlap: true;
 }
 
-node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:zs3v"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=40],
-node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"=zs3v]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=40]
+node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:zs3v"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=40]
 {
 	z-index: 215;
 	icon-image: "icons/de/zs3v-40-sign-down-44.png";
@@ -1117,8 +1095,7 @@ node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	allow-overlap: true;
 }
 
-node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:zs3v"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=50],
-node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"=zs3v]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=50]
+node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:zs3v"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=50]
 {
 	z-index: 220;
 	icon-image: "icons/de/zs3v-50-sign-down-44.png";
@@ -1127,8 +1104,7 @@ node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	allow-overlap: true;
 }
 
-node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:zs3v"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=60],
-node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"=zs3v]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=60]
+node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:zs3v"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=60]
 {
 	z-index: 225;
 	icon-image: "icons/de/zs3v-60-sign-down-44.png";
@@ -1137,8 +1113,7 @@ node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	allow-overlap: true;
 }
 
-node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:zs3v"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=70],
-node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"=zs3v]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=70]
+node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:zs3v"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=70]
 {
 	z-index: 230;
 	icon-image: "icons/de/zs3v-70-sign-down-44.png";
@@ -1147,8 +1122,7 @@ node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	allow-overlap: true;
 }
 
-node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:zs3v"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=80],
-node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"=zs3v]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=80]
+node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:zs3v"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=80]
 {
 	z-index: 235;
 	icon-image: "icons/de/zs3v-80-sign-down-44.png";
@@ -1157,8 +1131,7 @@ node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	allow-overlap: true;
 }
 
-node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:zs3v"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=90],
-node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"=zs3v]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=90]
+node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:zs3v"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=90]
 {
 	z-index: 240;
 	icon-image: "icons/de/zs3v-90-sign-down-44.png";
@@ -1167,8 +1140,7 @@ node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	allow-overlap: true;
 }
 
-node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:zs3v"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=100],
-node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"=zs3v]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=100]
+node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:zs3v"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=100]
 {
 	z-index: 245;
 	icon-image: "icons/de/zs3v-100-sign-down-44.png";
@@ -1177,8 +1149,7 @@ node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	allow-overlap: true;
 }
 
-node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:zs3v"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=110],
-node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"=zs3v]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=110]
+node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:zs3v"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=110]
 {
 	z-index: 250;
 	icon-image: "icons/de/zs3v-110-sign-down-44.png";
@@ -1187,8 +1158,7 @@ node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	allow-overlap: true;
 }
 
-node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:zs3v"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=120],
-node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"=zs3v]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=120]
+node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:zs3v"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=120]
 {
 	z-index: 255;
 	icon-image: "icons/de/zs3v-120-sign-down-44.png";
@@ -1197,8 +1167,7 @@ node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	allow-overlap: true;
 }
 
-node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:zs3v"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=130],
-node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"=zs3v]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=130]
+node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:zs3v"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=130]
 {
 	z-index: 260;
 	icon-image: "icons/de/zs3v-130-sign-down-44.png";
@@ -1207,8 +1176,7 @@ node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	allow-overlap: true;
 }
 
-node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:zs3v"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=140],
-node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"=zs3v]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=140]
+node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:zs3v"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=140]
 {
 	z-index: 265;
 	icon-image: "icons/de/zs3v-140-sign-down-44.png";
@@ -1217,8 +1185,7 @@ node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	allow-overlap: true;
 }
 
-node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:zs3v"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=150],
-node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"=zs3v]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=150]
+node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:zs3v"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=150]
 {
 	z-index: 270;
 	icon-image: "icons/de/zs3v-150-sign-down-44.png";
@@ -1227,8 +1194,7 @@ node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	allow-overlap: true;
 }
 
-node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:zs3v"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=160],
-node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"=zs3v]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=160]
+node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:zs3v"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=160]
 {
 	z-index: 275;
 	icon-image: "icons/de/zs3v-160-sign-down-44.png";
@@ -1238,8 +1204,7 @@ node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 }
 
 /* German line speed signals (Lf 7) */
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:lf7"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=10],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"=lf7]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=10]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:lf7"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=10]
 {
 	z-index: 300;
 	icon-image: "icons/de/lf7-10-sign-32.png";
@@ -1248,8 +1213,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	allow-overlap: true;
 }
 
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:lf7"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=20],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"=lf7]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=20]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:lf7"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=20]
 {
 	z-index: 305;
 	icon-image: "icons/de/lf7-20-sign-32.png";
@@ -1258,8 +1222,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	allow-overlap: true;
 }
 
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:lf7"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=30],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"=lf7]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=30]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:lf7"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=30]
 {
 	z-index: 310;
 	icon-image: "icons/de/lf7-30-sign-32.png";
@@ -1268,8 +1231,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	allow-overlap: true;
 }
 
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:lf7"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=40],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"=lf7]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=40]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:lf7"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=40]
 {
 	z-index: 315;
 	icon-image: "icons/de/lf7-40-sign-32.png";
@@ -1278,8 +1240,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	allow-overlap: true;
 }
 
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:lf7"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=50],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"=lf7]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=50]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:lf7"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=50]
 {
 	z-index: 320;
 	icon-image: "icons/de/lf7-50-sign-32.png";
@@ -1288,8 +1249,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	allow-overlap: true;
 }
 
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:lf7"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=60],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"=lf7]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=60]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:lf7"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=60]
 {
 	z-index: 325;
 	icon-image: "icons/de/lf7-60-sign-32.png";
@@ -1298,8 +1258,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	allow-overlap: true;
 }
 
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:lf7"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=70],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"=lf7]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=70]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:lf7"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=70]
 {
 	z-index: 330;
 	icon-image: "icons/de/lf7-70-sign-32.png";
@@ -1308,8 +1267,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	allow-overlap: true;
 }
 
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:lf7"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=80],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"=lf7]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=80]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:lf7"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=80]
 {
 	z-index: 335;
 	icon-image: "icons/de/lf7-80-sign-32.png";
@@ -1318,8 +1276,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	allow-overlap: true;
 }
 
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:lf7"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=90],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"=lf7]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=90]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:lf7"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=90]
 {
 	z-index: 340;
 	icon-image: "icons/de/lf7-90-sign-32.png";
@@ -1328,8 +1285,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	allow-overlap: true;
 }
 
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:lf7"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=100],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"=lf7]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=100]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:lf7"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=100]
 {
 	z-index: 345;
 	icon-image: "icons/de/lf7-100-sign-32.png";
@@ -1338,8 +1294,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	allow-overlap: true;
 }
 
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:lf7"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=110],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"=lf7]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=110]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:lf7"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=110]
 {
 	z-index: 350;
 	icon-image: "icons/de/lf7-110-sign-32.png";
@@ -1348,8 +1303,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	allow-overlap: true;
 }
 
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:lf7"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=120],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"=lf7]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=120]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:lf7"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=120]
 {
 	z-index: 355;
 	icon-image: "icons/de/lf7-120-sign-32.png";
@@ -1358,8 +1312,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	allow-overlap: true;
 }
 
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:lf7"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=130],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"=lf7]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=130]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:lf7"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=130]
 {
 	z-index: 360;
 	icon-image: "icons/de/lf7-130-sign-32.png";
@@ -1368,8 +1321,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	allow-overlap: true;
 }
 
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:lf7"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=140],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"=lf7]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=140]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:lf7"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=140]
 {
 	z-index: 365;
 	icon-image: "icons/de/lf7-140-sign-32.png";
@@ -1378,8 +1330,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	allow-overlap: true;
 }
 
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:lf7"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=150],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"=lf7]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=150]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:lf7"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=150]
 {
 	z-index: 370;
 	icon-image: "icons/de/lf7-150-sign-32.png";
@@ -1388,8 +1339,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	allow-overlap: true;
 }
 
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:lf7"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=160],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"=lf7]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=160]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:lf7"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=160]
 {
 	z-index: 375;
 	icon-image: "icons/de/lf7-160-sign-32.png";
@@ -1398,8 +1348,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	allow-overlap: true;
 }
 
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:lf7"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=170],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"=lf7]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=170]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:lf7"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=170]
 {
 	z-index: 380;
 	icon-image: "icons/de/lf7-170-sign-32.png";
@@ -1408,8 +1357,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	allow-overlap: true;
 }
 
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:lf7"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=180],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"=lf7]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=180]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:lf7"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=180]
 {
 	z-index: 390;
 	icon-image: "icons/de/lf7-180-sign-32.png";
@@ -1418,8 +1366,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	allow-overlap: true;
 }
 
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:lf7"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=190],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"=lf7]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=190]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:lf7"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=190]
 {
 	z-index: 395;
 	icon-image: "icons/de/lf7-190-sign-32.png";
@@ -1428,8 +1375,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	allow-overlap: true;
 }
 
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:lf7"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=200],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"=lf7]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=200]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:lf7"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=200]
 {
 	z-index: 399;
 	icon-image: "icons/de/lf7-200-sign-32.png";
@@ -1439,8 +1385,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 }
 
 /* German line speed signals (Lf 6) */
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:lf6"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=10],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"=lf6]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=10]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:lf6"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=10]
 {
 	z-index: 400;
 	icon-image: "icons/de/lf6-10-sign-down-44.png";
@@ -1449,8 +1394,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	allow-overlap: true;
 }
 
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:lf6"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=20],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"=lf6]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=20]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:lf6"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=20]
 {
 	z-index: 415;
 	icon-image: "icons/de/lf6-20-sign-down-44.png";
@@ -1459,8 +1403,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	allow-overlap: true;
 }
 
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:lf6"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=30],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"=lf6]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=30]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:lf6"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=30]
 {
 	z-index: 410;
 	icon-image: "icons/de/lf6-30-sign-down-44.png";
@@ -1469,8 +1412,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	allow-overlap: true;
 }
 
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:lf6"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=40],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"=lf6]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=40]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:lf6"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=40]
 {
 	z-index: 415;
 	icon-image: "icons/de/lf6-40-sign-down-44.png";
@@ -1479,8 +1421,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	allow-overlap: true;
 }
 
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:lf6"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=50],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"=lf6]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=50]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:lf6"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=50]
 {
 	z-index: 420;
 	icon-image: "icons/de/lf6-50-sign-down-44.png";
@@ -1489,8 +1430,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	allow-overlap: true;
 }
 
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:lf6"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=60],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"=lf6]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=60]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:lf6"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=60]
 {
 	z-index: 425;
 	icon-image: "icons/de/lf6-60-sign-down-44.png";
@@ -1499,8 +1439,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	allow-overlap: true;
 }
 
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:lf6"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=70],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"=lf6]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=70]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:lf6"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=70]
 {
 	z-index: 430;
 	icon-image: "icons/de/lf6-70-sign-down-44.png";
@@ -1509,8 +1448,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	allow-overlap: true;
 }
 
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:lf6"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=80],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"=lf6]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=80]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:lf6"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=80]
 {
 	z-index: 435;
 	icon-image: "icons/de/lf6-80-sign-down-44.png";
@@ -1519,8 +1457,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	allow-overlap: true;
 }
 
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:lf6"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=90],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"=lf6]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=90]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:lf6"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=90]
 {
 	z-index: 440;
 	icon-image: "icons/de/lf6-90-sign-down-44.png";
@@ -1529,8 +1466,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	allow-overlap: true;
 }
 
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:lf6"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=100],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"=lf6]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=100]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:lf6"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=100]
 {
 	z-index: 445;
 	icon-image: "icons/de/lf6-100-sign-down-44.png";
@@ -1539,8 +1475,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	allow-overlap: true;
 }
 
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:lf6"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=110],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"=lf6]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=110]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:lf6"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=110]
 {
 	z-index: 450;
 	icon-image: "icons/de/lf6-110-sign-down-44.png";
@@ -1549,8 +1484,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	allow-overlap: true;
 }
 
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:lf6"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=120],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"=lf6]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=120]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:lf6"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=120]
 {
 	z-index: 455;
 	icon-image: "icons/de/lf6-120-sign-down-44.png";
@@ -1559,8 +1493,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	allow-overlap: true;
 }
 
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:lf6"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=130],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"=lf6]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=130]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:lf6"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=130]
 {
 	z-index: 460;
 	icon-image: "icons/de/lf6-130-sign-down-44.png";
@@ -1569,8 +1502,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	allow-overlap: true;
 }
 
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:lf6"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=140],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"=lf6]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=140]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:lf6"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=140]
 {
 	z-index: 465;
 	icon-image: "icons/de/lf6-140-sign-down-44.png";
@@ -1579,8 +1511,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	allow-overlap: true;
 }
 
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:lf6"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=150],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"=lf6]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=150]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:lf6"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=150]
 {
 	z-index: 470;
 	icon-image: "icons/de/lf6-150-sign-down-44.png";
@@ -1589,8 +1520,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	allow-overlap: true;
 }
 
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:lf6"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=160],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"=lf6]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=160]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:lf6"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=160]
 {
 	z-index: 475;
 	icon-image: "icons/de/lf6-160-sign-down-44.png";
@@ -1599,8 +1529,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	allow-overlap: true;
 }
 
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:lf6"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=170],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"=lf6]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=170]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:lf6"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=170]
 {
 	z-index: 480;
 	icon-image: "icons/de/lf6-170-sign-down-44.png";
@@ -1609,8 +1538,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	allow-overlap: true;
 }
 
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:lf6"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=180],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"=lf6]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=180]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:lf6"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=180]
 {
 	z-index: 485;
 	icon-image: "icons/de/lf6-180-sign-down-44.png";
@@ -1619,8 +1547,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	allow-overlap: true;
 }
 
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:lf6"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=190],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"=lf6]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=190]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:lf6"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=190]
 {
 	z-index: 495;
 	icon-image: "icons/de/lf6-190-sign-down-44.png";
@@ -1629,8 +1556,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	allow-overlap: true;
 }
 
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:lf6"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=200],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"=lf6]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=200]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:lf6"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=200]
 {
 	z-index: 499;
 	icon-image: "icons/de/lf6-200-sign-down-44.png";

--- a/styles/signals.mapcss
+++ b/styles/signals.mapcss
@@ -45,9 +45,7 @@ way|z2-[railway=rail][usage=branch]
 /* DE crossing distant sign Bü 2 */
 /*********************************/
 node|z15-[railway=signal]["railway:signal:direction"]["railway:signal:crossing_distant"="DE-ESO:bü2"][!"railway:signal:crossing_distant:shortened"],
-node|z15-[railway=signal]["railway:signal:direction"]["railway:signal:crossing_distant"="DE-ESO:bü2"]["railway:signal:crossing_distant:shortened"=no],
-node|z15-[railway=signal]["railway:signal:direction"]["railway:signal:crossing_distant"="bü2"][!"railway:signal:crossing_distant:shortened"],
-node|z15-[railway=signal]["railway:signal:direction"]["railway:signal:crossing_distant"="bü2"]["railway:signal:crossing_distant:shortened"=no]
+node|z15-[railway=signal]["railway:signal:direction"]["railway:signal:crossing_distant"="DE-ESO:bü2"]["railway:signal:crossing_distant:shortened"=no]
 {
 	z-index: 500;
 	icon-image: "icons/de/bue2-ds-56.png";
@@ -60,8 +58,7 @@ node|z15-[railway=signal]["railway:signal:direction"]["railway:signal:crossing_d
 /*******************************************************/
 /* DE crossing distant sign Bü 2 with reduced distance */
 /*******************************************************/
-node|z15-[railway=signal]["railway:signal:direction"]["railway:signal:crossing_distant"="DE-ESO:bü2"]["railway:signal:crossing_distant:shortened"=yes],
-node|z15-[railway=signal]["railway:signal:direction"]["railway:signal:crossing_distant"="bü2"]["railway:signal:crossing_distant:shortened"=yes]
+node|z15-[railway=signal]["railway:signal:direction"]["railway:signal:crossing_distant"="DE-ESO:bü2"]["railway:signal:crossing_distant:shortened"=yes]
 {
 	z-index: 500;
 	icon-image: "icons/de/bue2-ds-reduced-distance-56.png";
@@ -74,8 +71,7 @@ node|z15-[railway=signal]["railway:signal:direction"]["railway:signal:crossing_d
 /*********************************/
 /* DE whistle sign Bü 4 (DS 301) */
 /*********************************/
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:whistle"="DE-ESO:db:bü4"],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:whistle"="db:bü4"]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:whistle"="DE-ESO:db:bü4"]
 {
 	z-index: 500;
 	icon-image: "icons/de/bue4-ds-32.png";
@@ -88,8 +84,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:whistle"="
 /*******************************************************************/
 /* DE whistle sign Bü 4 (DS 301) for trains not stopping at a halt */
 /*******************************************************************/
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:whistle"="DE-ESO:db:bü4"]["railway:signal:ring:only_transit"=yes],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:whistle"="db:bü4"]["railway:signal:ring:only_transit"=yes]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:whistle"="DE-ESO:db:bü4"]["railway:signal:ring:only_transit"=yes]
 {
 	z-index: 500;
 	icon-image: "icons/de/bue4-ds-only-transit-43.png";
@@ -102,8 +97,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:whistle"="
 /*********************************/
 /* DE whistle sign Pf 1 (DV 301) */
 /********************************/
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:whistle"="DE-ESO:dr:pf1"],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:whistle"="dr:pf1"]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:whistle"="DE-ESO:dr:pf1"]
 {
 	z-index: 500;
 	icon-image: "icons/de/pf1-dv-32.png";
@@ -115,8 +109,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:whistle"="
 /*******************************************************************/
 /* DE whistle sign Pf 1 (DV 301) for trains not stopping at a halt */
 /*******************************************************************/
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:whistle"="DE-ESO:db:pf1"]["railway:signal:ring:only_transit"=yes],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:whistle"="db:pf1"]["railway:signal:ring:only_transit"=yes]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:whistle"="DE-ESO:db:pf1"]["railway:signal:ring:only_transit"=yes]
 {
 	z-index: 500;
 	icon-image: "icons/de/pf1-dv-only-transit-43.png";
@@ -128,8 +121,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:whistle"="
 /*********************/
 /* DE ring sign Bü 5 */
 /*********************/
-node|z15-[railway=signal]["railway:signal:direction"]["railway:signal:ring"="DE-ESO:bü5"],
-node|z15-[railway=signal]["railway:signal:direction"]["railway:signal:ring"="bü5"]
+node|z15-[railway=signal]["railway:signal:direction"]["railway:signal:ring"="DE-ESO:bü5"]
 {
 	z-index: 500;
 	icon-image: "icons/de/bue5-ds-32.png";
@@ -142,8 +134,7 @@ node|z15-[railway=signal]["railway:signal:direction"]["railway:signal:ring"="bü
 /*******************************************************/
 /* DE ring sign Bü 5 for trains not stopping at a halt */
 /*******************************************************/
-node|z15-[railway=signal]["railway:signal:direction"]["railway:signal:ring"="DE-ESO:bü5"]["railway:signal:ring:only_transit"=yes],
-node|z15-[railway=signal]["railway:signal:direction"]["railway:signal:ring"="bü5"]["railway:signal:ring:only_transit"=yes]
+node|z15-[railway=signal]["railway:signal:direction"]["railway:signal:ring"="DE-ESO:bü5"]["railway:signal:ring:only_transit"=yes]
 {
 	z-index: 500;
 	icon-image: "icons/de/bue5-only-transit-43.png";
@@ -156,10 +147,6 @@ node|z15-[railway=signal]["railway:signal:direction"]["railway:signal:ring"="bü
 /****************************************************/
 /* DE crossing signal Bü 0/1 which cannot show Bü 1 */
 /****************************************************/
-node|z15-[railway=signal]["railway:signal:direction"]["railway:signal:crossing"="bü"][!"railway:signal:crossing:shortened"][!"railway:signal:crossing:repeated"]["railway:signal:crossing:form"=sign],
-node|z15-[railway=signal]["railway:signal:direction"]["railway:signal:crossing"="bü"][!"railway:signal:crossing:shortened"]["railway:signal:crossing:repeated"=no]["railway:signal:crossing:form"=sign],
-node|z15-[railway=signal]["railway:signal:direction"]["railway:signal:crossing"="bü"]["railway:signal:crossing:shortened"=no][!"railway:signal:crossing:repeated"]["railway:signal:crossing:form"=sign],
-node|z15-[railway=signal]["railway:signal:direction"]["railway:signal:crossing"="bü"]["railway:signal:crossing:shortened"=no]["railway:signal:crossing:repeated"=no]["railway:signal:crossing:form"=sign],
 node|z15-[railway=signal]["railway:signal:direction"]["railway:signal:crossing"="DE-ESO:bü"][!"railway:signal:crossing:shortened"][!"railway:signal:crossing:repeated"]["railway:signal:crossing:form"=sign],
 node|z15-[railway=signal]["railway:signal:direction"]["railway:signal:crossing"="DE-ESO:bü"][!"railway:signal:crossing:shortened"]["railway:signal:crossing:repeated"=no]["railway:signal:crossing:form"=sign],
 node|z15-[railway=signal]["railway:signal:direction"]["railway:signal:crossing"="DE-ESO:bü"]["railway:signal:crossing:shortened"=no][!"railway:signal:crossing:repeated"]["railway:signal:crossing:form"=sign],
@@ -177,9 +164,7 @@ node|z15-[railway=signal]["railway:signal:direction"]["railway:signal:crossing"=
 /* DE crossing signal Bü 0/1 which cannot show Bü 1 and are repeaters */
 /**********************************************************************/
 node|z15-[railway=signal]["railway:signal:direction"]["railway:signal:crossing"="DE-ESO:bü"][!"railway:signal:crossing:shortened"]["railway:signal:crossing:repeated"=yes]["railway:signal:crossing:form"=sign],
-node|z15-[railway=signal]["railway:signal:direction"]["railway:signal:crossing"="DE-ESO:bü"]["railway:signal:crossing:shortened"=no]["railway:signal:crossing:repeated"=yes]["railway:signal:crossing:form"=sign],
-node|z15-[railway=signal]["railway:signal:direction"]["railway:signal:crossing"="bü"][!"railway:signal:crossing:shortened"]["railway:signal:crossing:repeated"=yes]["railway:signal:crossing:form"=sign],
-node|z15-[railway=signal]["railway:signal:direction"]["railway:signal:crossing"="bü"]["railway:signal:crossing:shortened"=no]["railway:signal:crossing:repeated"=yes]["railway:signal:crossing:form"=sign]
+node|z15-[railway=signal]["railway:signal:direction"]["railway:signal:crossing"="DE-ESO:bü"]["railway:signal:crossing:shortened"=no]["railway:signal:crossing:repeated"=yes]["railway:signal:crossing:form"=sign]
 {
 	z-index: 500;
 	icon-image: "icons/de/bue0-ds-repeated-42.png";
@@ -193,9 +178,7 @@ node|z15-[railway=signal]["railway:signal:direction"]["railway:signal:crossing"=
 /* DE crossing signal Bü 0/1 which cannot show Bü 1 and are shortened */
 /**********************************************************************/
 node|z15-[railway=signal]["railway:signal:direction"]["railway:signal:crossing"="DE-ESO:bü"]["railway:signal:crossing:shortened"=yes]["railway:signal:crossing:repeated"=no]["railway:signal:crossing:form"=sign],
-node|z15-[railway=signal]["railway:signal:direction"]["railway:signal:crossing"="DE-ESO:bü"]["railway:signal:crossing:shortened"=yes][!"railway:signal:crossing:repeated"]["railway:signal:crossing:form"=sign],
-node|z15-[railway=signal]["railway:signal:direction"]["railway:signal:crossing"="bü"]["railway:signal:crossing:shortened"=yes]["railway:signal:crossing:repeated"=no]["railway:signal:crossing:form"=sign],
-node|z15-[railway=signal]["railway:signal:direction"]["railway:signal:crossing"="bü"]["railway:signal:crossing:shortened"=yes][!"railway:signal:crossing:repeated"]["railway:signal:crossing:form"=sign]
+node|z15-[railway=signal]["railway:signal:direction"]["railway:signal:crossing"="DE-ESO:bü"]["railway:signal:crossing:shortened"=yes][!"railway:signal:crossing:repeated"]["railway:signal:crossing:form"=sign]
 {
 	z-index: 500;
 	icon-image: "icons/de/bue0-ds-shortened-42.png";
@@ -211,11 +194,7 @@ node|z15-[railway=signal]["railway:signal:direction"]["railway:signal:crossing"=
 node|z15-[railway=signal]["railway:signal:direction"]["railway:signal:crossing"="DE-ESO:bü"][!"railway:signal:crossing:shortened"][!"railway:signal:crossing:repeated"]["railway:signal:crossing:form"=light],
 node|z15-[railway=signal]["railway:signal:direction"]["railway:signal:crossing"="DE-ESO:bü"][!"railway:signal:crossing:shortened"]["railway:signal:crossing:repeated"=no]["railway:signal:crossing:form"=light],
 node|z15-[railway=signal]["railway:signal:direction"]["railway:signal:crossing"="DE-ESO:bü"]["railway:signal:crossing:shortened"=no][!"railway:signal:crossing:repeated"]["railway:signal:crossing:form"=light],
-node|z15-[railway=signal]["railway:signal:direction"]["railway:signal:crossing"="DE-ESO:bü"]["railway:signal:crossing:shortened"=no]["railway:signal:crossing:repeated"=no]["railway:signal:crossing:form"=light],
-node|z15-[railway=signal]["railway:signal:direction"]["railway:signal:crossing"="bü"][!"railway:signal:crossing:shortened"][!"railway:signal:crossing:repeated"]["railway:signal:crossing:form"=light],
-node|z15-[railway=signal]["railway:signal:direction"]["railway:signal:crossing"="bü"][!"railway:signal:crossing:shortened"]["railway:signal:crossing:repeated"=no]["railway:signal:crossing:form"=light],
-node|z15-[railway=signal]["railway:signal:direction"]["railway:signal:crossing"="bü"]["railway:signal:crossing:shortened"=no][!"railway:signal:crossing:repeated"]["railway:signal:crossing:form"=light],
-node|z15-[railway=signal]["railway:signal:direction"]["railway:signal:crossing"="bü"]["railway:signal:crossing:shortened"=no]["railway:signal:crossing:repeated"=no]["railway:signal:crossing:form"=light]
+node|z15-[railway=signal]["railway:signal:direction"]["railway:signal:crossing"="DE-ESO:bü"]["railway:signal:crossing:shortened"=no]["railway:signal:crossing:repeated"=no]["railway:signal:crossing:form"=light]
 {
 	z-index: 500;
 	icon-image: "icons/de/bue1-ds-32.png";
@@ -229,9 +208,7 @@ node|z15-[railway=signal]["railway:signal:direction"]["railway:signal:crossing"=
 /* DE crossing signal Bü 0/1 which can show Bü 1 and are repeaters */
 /*******************************************************************/
 node|z15-[railway=signal]["railway:signal:direction"]["railway:signal:crossing"="DE-ESO:bü"][!"railway:signal:crossing:shortened"]["railway:signal:crossing:repeated"=yes]["railway:signal:crossing:form"=light],
-node|z15-[railway=signal]["railway:signal:direction"]["railway:signal:crossing"="DE-ESO:bü"]["railway:signal:crossing:shortened"=no]["railway:signal:crossing:repeated"=yes]["railway:signal:crossing:form"=light],
-node|z15-[railway=signal]["railway:signal:direction"]["railway:signal:crossing"="bü"][!"railway:signal:crossing:shortened"]["railway:signal:crossing:repeated"=yes]["railway:signal:crossing:form"=light],
-node|z15-[railway=signal]["railway:signal:direction"]["railway:signal:crossing"="bü"]["railway:signal:crossing:shortened"=no]["railway:signal:crossing:repeated"=yes]["railway:signal:crossing:form"=light]
+node|z15-[railway=signal]["railway:signal:direction"]["railway:signal:crossing"="DE-ESO:bü"]["railway:signal:crossing:shortened"=no]["railway:signal:crossing:repeated"=yes]["railway:signal:crossing:form"=light]
 {
 	z-index: 500;
 	icon-image: "icons/de/bue1-ds-repeated-42.png";
@@ -245,9 +222,7 @@ node|z15-[railway=signal]["railway:signal:direction"]["railway:signal:crossing"=
 /* DE crossing signal Bü 0/1 which can show Bü 1 and are shortened */
 /*******************************************************************/
 node|z15-[railway=signal]["railway:signal:direction"]["railway:signal:crossing"="DE-ESO:bü"]["railway:signal:crossing:shortened"=yes]["railway:signal:crossing:repeated"=no]["railway:signal:crossing:form"=light],
-node|z15-[railway=signal]["railway:signal:direction"]["railway:signal:crossing"="DE-ESO:bü"]["railway:signal:crossing:shortened"=yes][!"railway:signal:crossing:repeated"]["railway:signal:crossing:form"=light],
-node|z15-[railway=signal]["railway:signal:direction"]["railway:signal:crossing"="bü"]["railway:signal:crossing:shortened"=yes]["railway:signal:crossing:repeated"=no]["railway:signal:crossing:form"=light],
-node|z15-[railway=signal]["railway:signal:direction"]["railway:signal:crossing"="bü"]["railway:signal:crossing:shortened"=yes][!"railway:signal:crossing:repeated"]["railway:signal:crossing:form"=light]
+node|z15-[railway=signal]["railway:signal:direction"]["railway:signal:crossing"="DE-ESO:bü"]["railway:signal:crossing:shortened"=yes][!"railway:signal:crossing:repeated"]["railway:signal:crossing:form"=light]
 {
 	z-index: 500;
 	icon-image: "icons/de/bue1-ds-shortened-42.png";
@@ -263,11 +238,7 @@ node|z15-[railway=signal]["railway:signal:direction"]["railway:signal:crossing"=
 node|z15-[railway=signal]["railway:signal:direction"]["railway:signal:crossing"="DE-ESO:so16"][!"railway:signal:crossing:shortened"][!"railway:signal:crossing:repeated"]["railway:signal:crossing:form"=light],
 node|z15-[railway=signal]["railway:signal:direction"]["railway:signal:crossing"="DE-ESO:so16"][!"railway:signal:crossing:shortened"]["railway:signal:crossing:repeated"=no]["railway:signal:crossing:form"=light],
 node|z15-[railway=signal]["railway:signal:direction"]["railway:signal:crossing"="DE-ESO:so16"]["railway:signal:crossing:shortened"=no][!"railway:signal:crossing:repeated"]["railway:signal:crossing:form"=light],
-node|z15-[railway=signal]["railway:signal:direction"]["railway:signal:crossing"="DE-ESO:so16"]["railway:signal:crossing:shortened"=no]["railway:signal:crossing:repeated"=no]["railway:signal:crossing:form"=light],
-node|z15-[railway=signal]["railway:signal:direction"]["railway:signal:crossing"="so16"][!"railway:signal:crossing:shortened"][!"railway:signal:crossing:repeated"]["railway:signal:crossing:form"=light],
-node|z15-[railway=signal]["railway:signal:direction"]["railway:signal:crossing"="so16"][!"railway:signal:crossing:shortened"]["railway:signal:crossing:repeated"=no]["railway:signal:crossing:form"=light],
-node|z15-[railway=signal]["railway:signal:direction"]["railway:signal:crossing"="so16"]["railway:signal:crossing:shortened"=no][!"railway:signal:crossing:repeated"]["railway:signal:crossing:form"=light],
-node|z15-[railway=signal]["railway:signal:direction"]["railway:signal:crossing"="so16"]["railway:signal:crossing:shortened"=no]["railway:signal:crossing:repeated"=no]["railway:signal:crossing:form"=light]
+node|z15-[railway=signal]["railway:signal:direction"]["railway:signal:crossing"="DE-ESO:so16"]["railway:signal:crossing:shortened"=no]["railway:signal:crossing:repeated"=no]["railway:signal:crossing:form"=light]
 {
 	z-index: 500;
 	icon-image: "icons/de/bue1-dv-32.png";
@@ -281,9 +252,7 @@ node|z15-[railway=signal]["railway:signal:direction"]["railway:signal:crossing"=
 /* DE crossing signal Bü 0/1 (ex. So 16a/b) which can show Bü 1 and are repeaters */
 /**********************************************************************************/
 node|z15-[railway=signal]["railway:signal:direction"]["railway:signal:crossing"="DE-ESO:so16"][!"railway:signal:crossing:shortened"]["railway:signal:crossing:repeated"=yes]["railway:signal:crossing:form"=light],
-node|z15-[railway=signal]["railway:signal:direction"]["railway:signal:crossing"="DE-ESO:so16"]["railway:signal:crossing:shortened"=no]["railway:signal:crossing:repeated"=yes]["railway:signal:crossing:form"=light],
-node|z15-[railway=signal]["railway:signal:direction"]["railway:signal:crossing"="so16"][!"railway:signal:crossing:shortened"]["railway:signal:crossing:repeated"=yes]["railway:signal:crossing:form"=light],
-node|z15-[railway=signal]["railway:signal:direction"]["railway:signal:crossing"="so16"]["railway:signal:crossing:shortened"=no]["railway:signal:crossing:repeated"=yes]["railway:signal:crossing:form"=light]
+node|z15-[railway=signal]["railway:signal:direction"]["railway:signal:crossing"="DE-ESO:so16"]["railway:signal:crossing:shortened"=no]["railway:signal:crossing:repeated"=yes]["railway:signal:crossing:form"=light]
 {
 	z-index: 500;
 	icon-image: "icons/de/bue1-dv-repeated-42.png";
@@ -297,9 +266,7 @@ node|z15-[railway=signal]["railway:signal:direction"]["railway:signal:crossing"=
 /* DE crossing signal Bü 0/1 (ex. So 16a/b) which can show Bü 1 and are shortened */
 /**********************************************************************************/
 node|z15-[railway=signal]["railway:signal:direction"]["railway:signal:crossing"="DE-ESO:so16"]["railway:signal:crossing:shortened"=yes]["railway:signal:crossing:repeated"=no]["railway:signal:crossing:form"=light],
-node|z15-[railway=signal]["railway:signal:direction"]["railway:signal:crossing"="DE-ESO:so16"]["railway:signal:crossing:shortened"=yes][!"railway:signal:crossing:repeated"]["railway:signal:crossing:form"=light],
-node|z15-[railway=signal]["railway:signal:direction"]["railway:signal:crossing"="so16"]["railway:signal:crossing:shortened"=yes]["railway:signal:crossing:repeated"=no]["railway:signal:crossing:form"=light],
-node|z15-[railway=signal]["railway:signal:direction"]["railway:signal:crossing"="so16"]["railway:signal:crossing:shortened"=yes][!"railway:signal:crossing:repeated"]["railway:signal:crossing:form"=light]
+node|z15-[railway=signal]["railway:signal:direction"]["railway:signal:crossing"="DE-ESO:so16"]["railway:signal:crossing:shortened"=yes][!"railway:signal:crossing:repeated"]["railway:signal:crossing:form"=light]
 {
 	z-index: 500;
 	icon-image: "icons/de/bue1-dv-shortened-42.png";
@@ -312,8 +279,7 @@ node|z15-[railway=signal]["railway:signal:direction"]["railway:signal:crossing"=
 /********************************/
 /* DE station distant sign Ne 6 */
 /********************************/
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:station_distant"="DE-ESO:ne6"]["railway:signal:station_distant:form"=sign],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:station_distant"="ne6"]["railway:signal:station_distant:form"=sign]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:station_distant"="DE-ESO:ne6"]["railway:signal:station_distant:form"=sign]
 {
 	z-index: 550;
 	icon-image: "icons/de/ne6-48.png";
@@ -345,7 +311,6 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="AT-
 /*********************/
 /* DE stop post Ne 5 */
 /*********************/
-node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:stop"=ne5]["railway:signal:stop:form"=sign],
 node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:stop"="DE-ESO:ne5"]["railway:signal:stop:form"=sign]
 {
 	z-index: 1000;
@@ -360,7 +325,6 @@ node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:stop"="DE-
 /* DE shunting stop sign Ra 10               */
 /* AT shunting stop sign "Verschubhalttafel" */
 /*********************************************/
-node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:shunting"=ra10]["railway:signal:shunting:form"=sign],
 node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:shunting"="DE-ESO:ra10"]["railway:signal:shunting:form"=sign],
 node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:shunting"="AT-V2:verschubhalttafel"]["railway:signal:shunting:form"=sign]
 {
@@ -375,8 +339,7 @@ node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:shunting"=
 /********************************************/
 /* DE minor semaphore dwarf signals type Sh */
 /********************************************/
-node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:minor"="DE-ESO:sh"]["railway:signal:minor:form"=semaphore]["railway:signal:minor:height"=dwarf],
-node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:minor"=sh]["railway:signal:minor:form"=semaphore]["railway:signal:minor:height"=dwarf]
+node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:minor"="DE-ESO:sh"]["railway:signal:minor:form"=semaphore]["railway:signal:minor:height"=dwarf]
 {
 	z-index: 2000;
 	text: "ref";
@@ -397,7 +360,6 @@ node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:minor"=sh]
 /* DE shunting signal Ra 11 without Sh 1          */
 /* AT Wartesignal ohne "Verschubverbot aufgehoben */
 /**************************************************/
-node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:shunting"=ra11]["railway:signal:shunting:form"=sign],
 node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:shunting"="DE-ESO:ra11"]["railway:signal:shunting:form"=sign],
 node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:shunting"="AT-V2:wartesignal"]["railway:signal:shunting:form"=sign]
 {
@@ -412,7 +374,6 @@ node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:shunting"=
 /**************************************/
 /* DE shunting signal Ra 11 with Sh 1 */
 /**************************************/
-node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:shunting"=ra11]["railway:signal:shunting:form"=light]["railway:signal:shunting:states"="ra11;sh1"],
 node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:shunting"="DE-ESO:ra11"]["railway:signal:shunting:form"=light]["railway:signal:shunting:states"="DE-ESO:ra11;DE-ESO:sh1"]
 {
 	z-index: 2800;
@@ -426,7 +387,6 @@ node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:shunting"=
 /********************************************/
 /* DE shunting signal Ra 11b (without Sh 1) */
 /********************************************/
-node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:shunting"=ra11b]["railway:signal:shunting:form"=sign]["railway:signal:shunting:form"=sign],
 node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:shunting"="DE-ESO:ra11b"]["railway:signal:shunting:form"=sign]["railway:signal:shunting:form"=sign]
 {
 	z-index: 2800;
@@ -440,8 +400,7 @@ node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:shunting"=
 /****************************************/
 /* DE minor light dwarf signals type Sh */
 /****************************************/
-node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:minor"="DE-ESO:sh"]["railway:signal:minor:form"=light]["railway:signal:minor:height"=dwarf],
-node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:minor"=sh]["railway:signal:minor:form"=light]["railway:signal:minor:height"=dwarf]
+node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:minor"="DE-ESO:sh"]["railway:signal:minor:form"=light]["railway:signal:minor:height"=dwarf]
 {
 	z-index: 3000;
 	text: "ref";
@@ -462,9 +421,7 @@ node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:minor"=sh]
 /* DE minor semaphore signals type Sh */
 /**************************************/
 node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:minor"="DE-ESO:sh"]["railway:signal:minor:form"=semaphore]["railway:signal:minor:height"=normal],
-node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:minor"="DE-ESO:sh"]["railway:signal:minor:form"=semaphore][!"railway:signal:minor:height"],
-node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:minor"=sh]["railway:signal:minor:form"=semaphore]["railway:signal:minor:height"=normal],
-node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:minor"=sh]["railway:signal:minor:form"=semaphore][!"railway:signal:minor:height"]
+node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:minor"="DE-ESO:sh"]["railway:signal:minor:form"=semaphore][!"railway:signal:minor:height"]
 {
 	z-index: 4000;
 	text: "ref";
@@ -484,7 +441,6 @@ node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:minor"=sh]
 /******************/
 /* DE signal Sh 2 */
 /******************/
-node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:minor"=sh2],
 node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:minor"="DE-ESO:sh2"]
 {
 	z-index: 4010;
@@ -498,9 +454,7 @@ node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:minor"="DE
 /* DE minor light signals type Sh */
 /**********************************/
 node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:minor"="DE-ESO:sh"]["railway:signal:minor:form"=light]["railway:signal:minor:height"=normal],
-node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:minor"="DE-ESO:sh"]["railway:signal:minor:form"=light][!"railway:signal:minor:height"],
-node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:minor"=sh]["railway:signal:minor:form"=light]["railway:signal:minor:height"=normal],
-node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:minor"=sh]["railway:signal:minor:form"=light][!"railway:signal:minor:height"]
+node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:minor"="DE-ESO:sh"]["railway:signal:minor:form"=light][!"railway:signal:minor:height"]
 {
 	z-index: 5000;
 	text: "ref";
@@ -535,11 +489,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-
 node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:ks"]["railway:signal:distant:form"=light]["railway:signal:distant:states"="DE-ESO:ks1;DE-ESO:ks2"]["railway:signal:distant:shortened"="no"]["railway:signal:distant:repeated"="no"],
 node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:ks"]["railway:signal:distant:form"=light]["railway:signal:distant:states"="DE-ESO:ks1;DE-ESO:ks2"][!"railway:signal:distant:shortened"]["railway:signal:distant:repeated"="no"],
 node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:ks"]["railway:signal:distant:form"=light]["railway:signal:distant:states"="DE-ESO:ks1;DE-ESO:ks2"]["railway:signal:distant:shortened"="no"][!"railway:signal:distant:repeated"],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:ks"]["railway:signal:distant:form"=light]["railway:signal:distant:states"="DE-ESO:ks1;DE-ESO:ks2"][!"railway:signal:distant:shortened"][!"railway:signal:distant:repeated"],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"=ks]["railway:signal:distant:form"=light]["railway:signal:distant:states"="ks1;ks2"]["railway:signal:distant:shortened"="no"]["railway:signal:distant:repeated"="no"],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"=ks]["railway:signal:distant:form"=light]["railway:signal:distant:states"="ks1;ks2"]["railway:signal:distant:shortened"="no"][!"railway:signal:distant:repeated"],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"=ks]["railway:signal:distant:form"=light]["railway:signal:distant:states"="ks1;ks2"][!"railway:signal:distant:shortened"]["railway:signal:distant:repeated"="no"],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"=ks]["railway:signal:distant:form"=light]["railway:signal:distant:states"="ks1;ks2"][!"railway:signal:distant:shortened"][!"railway:signal:distant:repeated"]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:ks"]["railway:signal:distant:form"=light]["railway:signal:distant:states"="DE-ESO:ks1;DE-ESO:ks2"][!"railway:signal:distant:shortened"][!"railway:signal:distant:repeated"]
 {
 	z-index: 8000;
 	text: "ref";
@@ -559,8 +509,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"=k
 /**************************************/
 /* DE repeated distant signal type Ks */
 /**************************************/
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:ks"]["railway:signal:distant:form"=light]["railway:signal:distant:states"="DE-ESO:ks1;DE-ESO:ks2"]["railway:signal:distant:repeated"="yes"],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"=ks]["railway:signal:distant:form"=light]["railway:signal:distant:states"="ks1;ks2"]["railway:signal:distant:repeated"="yes"]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:ks"]["railway:signal:distant:form"=light]["railway:signal:distant:states"="DE-ESO:ks1;DE-ESO:ks2"]["railway:signal:distant:repeated"="yes"]
 {
 	z-index: 8000;
 	text: "ref";
@@ -580,8 +529,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"=k
 /***************************************/
 /* DE shortened distant signal type Ks */
 /***************************************/
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:ks"]["railway:signal:distant:form"=light]["railway:signal:distant:states"="DE-ESO:ks1;DE-ESO:ks2"]["railway:signal:distant:shortened"="yes"],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"=ks]["railway:signal:distant:form"=light]["railway:signal:distant:states"="ks1;ks2"]["railway:signal:distant:shortened"="yes"]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:ks"]["railway:signal:distant:form"=light]["railway:signal:distant:states"="DE-ESO:ks1;DE-ESO:ks2"]["railway:signal:distant:shortened"="yes"]
 {
 	z-index: 8000;
 	text: "ref";
@@ -606,9 +554,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"=k
 /*  - OR have railway:signal:states=* tag that does neither include Vr1 nor Vr2 */
 /********************************************************************************/
 node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:vr"]["railway:signal:distant:form"=light]["railway:signal:distant:repeated"=yes][!"railway:signal:main"]["railway:signal:distant:states"!~/vr(1|2)/],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:vr"]["railway:signal:distant:form"=light]["railway:signal:distant:shortened"=yes][!"railway:signal:main"]["railway:signal:distant:states"!~/vr(1|2)/],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"=vr]["railway:signal:distant:form"=light]["railway:signal:distant:repeated"=yes][!"railway:signal:main"]["railway:signal:distant:states"!~/vr(1|2)/],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"=vr]["railway:signal:distant:form"=light]["railway:signal:distant:shortened"=yes][!"railway:signal:main"]["railway:signal:distant:states"!~/vr(1|2)/]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:vr"]["railway:signal:distant:form"=light]["railway:signal:distant:shortened"=yes][!"railway:signal:main"]["railway:signal:distant:states"!~/vr(1|2)/]
 {
 	z-index: 8500;
 	text: "ref";
@@ -805,8 +751,7 @@ node|z18-[railway=signal]["railway:signal:direction"]["railway:signal:train_prot
 /*  - have no railway:signal:states=* tag                                       */
 /*  - OR have railway:signal:states=* tag that does neither include Vr1 nor Vr2 */
 /********************************************************************************/
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:vr"]["railway:signal:distant:form"=semaphore][!"railway:signal:main"]["railway:signal:distant:states"!~/vr(1|2)/],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"=vr]["railway:signal:distant:form"=semaphore][!"railway:signal:main"]["railway:signal:distant:states"!~/vr(1|2)/]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:vr"]["railway:signal:distant:form"=semaphore][!"railway:signal:main"]["railway:signal:distant:states"!~/vr(1|2)/]
 {
 	z-index: 9000;
 	text: "ref";
@@ -829,8 +774,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"=v
 /*  - can display Vr 1                        */
 /*  - cannot display Vr 2                     */
 /**********************************************/
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:vr"]["railway:signal:distant:form"=semaphore][!"railway:signal:main"]["railway:signal:distant:states"=~/vr1/]["railway:signal:distant:states"!~/vr2/],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"=vr]["railway:signal:distant:form"=semaphore][!"railway:signal:main"]["railway:signal:distant:states"=~/vr1/]["railway:signal:distant:states"!~/vr2/]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:vr"]["railway:signal:distant:form"=semaphore][!"railway:signal:main"]["railway:signal:distant:states"=~/vr1/]["railway:signal:distant:states"!~/vr2/]
 {
 	z-index: 9000;
 	text: "ref";
@@ -852,8 +796,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"=v
 /*  - do not share post with a main signal    */
 /*  - can display Vr 2                        */
 /**********************************************/
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:vr"]["railway:signal:distant:form"=semaphore][!"railway:signal:main"]["railway:signal:distant:states"]["railway:signal:distant:states"=~/vr2/],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"=vr]["railway:signal:distant:form"=semaphore][!"railway:signal:main"]["railway:signal:distant:states"]["railway:signal:distant:states"=~/vr2/]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:vr"]["railway:signal:distant:form"=semaphore][!"railway:signal:main"]["railway:signal:distant:states"]["railway:signal:distant:states"=~/vr2/]
 {
 	z-index: 9000;
 	text: "ref";
@@ -881,11 +824,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"=v
 node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:vr"]["railway:signal:distant:form"=light]["railway:signal:distant:repeated"=no]["railway:signal:distant:shortened"=no][!"railway:signal:main"]["railway:signal:distant:states"!~/vr(1|2)/],
 node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:vr"]["railway:signal:distant:form"=light][!"railway:signal:distant:repeated"]["railway:signal:distant:shortened"=no][!"railway:signal:main"]["railway:signal:distant:states"!~/vr(1|2)/],
 node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:vr"]["railway:signal:distant:form"=light]["railway:signal:distant:repeated"=no][!"railway:signal:distant:shortened"][!"railway:signal:main"]["railway:signal:distant:states"!~/vr(1|2)/],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:vr"]["railway:signal:distant:form"=light][!"railway:signal:distant:repeated"][!"railway:signal:distant:shortened"][!"railway:signal:main"]["railway:signal:distant:states"!~/vr(1|2)/],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"=vr]["railway:signal:distant:form"=light]["railway:signal:distant:repeated"=no]["railway:signal:distant:shortened"=no][!"railway:signal:main"]["railway:signal:distant:states"!~/vr(1|2)/],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"=vr]["railway:signal:distant:form"=light][!"railway:signal:distant:repeated"]["railway:signal:distant:shortened"=no][!"railway:signal:main"]["railway:signal:distant:states"!~/vr(1|2)/],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"=vr]["railway:signal:distant:form"=light]["railway:signal:distant:repeated"=no][!"railway:signal:distant:shortened"][!"railway:signal:main"]["railway:signal:distant:states"!~/vr(1|2)/],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"=vr]["railway:signal:distant:form"=light][!"railway:signal:distant:repeated"][!"railway:signal:distant:shortened"][!"railway:signal:main"]["railway:signal:distant:states"!~/vr(1|2)/]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:vr"]["railway:signal:distant:form"=light][!"railway:signal:distant:repeated"][!"railway:signal:distant:shortened"][!"railway:signal:main"]["railway:signal:distant:states"!~/vr(1|2)/]
 {
 	z-index: 9000;
 	text: "ref";
@@ -913,11 +852,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"=v
 node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:vr"]["railway:signal:distant:form"=light]["railway:signal:distant:repeated"=no]["railway:signal:distant:shortened"=no][!"railway:signal:main"]["railway:signal:distant:states"]["railway:signal:distant:states"=~/vr1/]["railway:signal:distant:states"!~/vr2/],
 node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:vr"]["railway:signal:distant:form"=light][!"railway:signal:distant:repeated"]["railway:signal:distant:shortened"=no][!"railway:signal:main"]["railway:signal:distant:states"]["railway:signal:distant:states"=~/vr1/]["railway:signal:distant:states"!~/vr2/],
 node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:vr"]["railway:signal:distant:form"=light]["railway:signal:distant:repeated"=no][!"railway:signal:distant:shortened"][!"railway:signal:main"]["railway:signal:distant:states"]["railway:signal:distant:states"=~/vr1/]["railway:signal:distant:states"!~/vr2/],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:vr"]["railway:signal:distant:form"=light][!"railway:signal:distant:repeated"][!"railway:signal:distant:shortened"][!"railway:signal:main"]["railway:signal:distant:states"]["railway:signal:distant:states"=~/vr1/]["railway:signal:distant:states"!~/vr2/],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"=vr]["railway:signal:distant:form"=light]["railway:signal:distant:repeated"=no]["railway:signal:distant:shortened"=no][!"railway:signal:main"]["railway:signal:distant:states"]["railway:signal:distant:states"=~/vr1/]["railway:signal:distant:states"!~/vr2/],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"=vr]["railway:signal:distant:form"=light][!"railway:signal:distant:repeated"]["railway:signal:distant:shortened"=no][!"railway:signal:main"]["railway:signal:distant:states"]["railway:signal:distant:states"=~/vr1/]["railway:signal:distant:states"!~/vr2/],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"=vr]["railway:signal:distant:form"=light]["railway:signal:distant:repeated"=no][!"railway:signal:distant:shortened"][!"railway:signal:main"]["railway:signal:distant:states"]["railway:signal:distant:states"=~/vr1/]["railway:signal:distant:states"!~/vr2/],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"=vr]["railway:signal:distant:form"=light][!"railway:signal:distant:repeated"][!"railway:signal:distant:shortened"][!"railway:signal:main"]["railway:signal:distant:states"]["railway:signal:distant:states"=~/vr1/]["railway:signal:distant:states"!~/vr2/]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:vr"]["railway:signal:distant:form"=light][!"railway:signal:distant:repeated"][!"railway:signal:distant:shortened"][!"railway:signal:main"]["railway:signal:distant:states"]["railway:signal:distant:states"=~/vr1/]["railway:signal:distant:states"!~/vr2/]
 {
 	z-index: 9000;
 	text: "ref";
@@ -942,9 +877,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"=v
 /*  - can display Vr 2                          */
 /************************************************/
 node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:vr"]["railway:signal:distant:form"=light]["railway:signal:distant:repeated"=no][!"railway:signal:main"]["railway:signal:distant:states"]["railway:signal:distant:states"=~/vr2/],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:vr"]["railway:signal:distant:form"=light][!"railway:signal:distant:repeated"][!"railway:signal:main"]["railway:signal:distant:states"]["railway:signal:distant:states"=~/vr2/],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"=vr]["railway:signal:distant:form"=light]["railway:signal:distant:repeated"=no][!"railway:signal:main"]["railway:signal:distant:states"]["railway:signal:distant:states"=~/vr2/],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"=vr]["railway:signal:distant:form"=light][!"railway:signal:distant:repeated"][!"railway:signal:main"]["railway:signal:distant:states"]["railway:signal:distant:states"=~/vr2/]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:vr"]["railway:signal:distant:form"=light][!"railway:signal:distant:repeated"][!"railway:signal:main"]["railway:signal:distant:states"]["railway:signal:distant:states"=~/vr2/]
 {
 	z-index: 9000;
 	text: "ref";
@@ -966,7 +899,6 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"=v
 /* AT Kreuztafel                                */
 /************************************************/
 node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:so106"]["railway:signal:distant:form"=sign],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="so106"]["railway:signal:distant:form"=sign],
 node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="AT-V2:kreuztafel"]["railway:signal:distant:form"=sign]
 {
 	z-index: 9000;
@@ -988,9 +920,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="
 /* DE distant signal replacement by sign Ne 2 */
 /**********************************************/
 node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:db:ne2"]["railway:signal:distant:form"=sign]["railway:signal:distant:shortened"=no],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:db:ne2"]["railway:signal:distant:form"=sign][!"railway:signal:distant:shortened"],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="db:ne2"]["railway:signal:distant:form"=sign]["railway:signal:distant:shortened"=no],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="db:ne2"]["railway:signal:distant:form"=sign][!"railway:signal:distant:shortened"]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:db:ne2"]["railway:signal:distant:form"=sign][!"railway:signal:distant:shortened"]
 {
 	z-index: 9000;
 	text: "ref";
@@ -1011,8 +941,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="
 /* DE distant signal replacement by sign Ne 2 with reduced distance */
 /* variant used in West Germany                                     */
 /********************************************************************/
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:db:ne2"]["railway:signal:distant:form"=sign]["railway:signal:distant:shortened"=yes],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="db:ne2"]["railway:signal:distant:form"=sign]["railway:signal:distant:shortened"=yes]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:db:ne2"]["railway:signal:distant:form"=sign]["railway:signal:distant:shortened"=yes]
 {
 	z-index: 9000;
 	text: "ref";
@@ -1033,8 +962,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="
 /* DE distant signal replacement by sign Ne 2 with reduced distance */
 /* variant used in East Germany                                     */
 /********************************************************************/
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:dr:so3"]["railway:signal:distant:form"=sign]["railway:signal:distant:shortened"=yes],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="dr:so3"]["railway:signal:distant:form"=sign]["railway:signal:distant:shortened"=yes]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:dr:so3"]["railway:signal:distant:form"=sign]["railway:signal:distant:shortened"=yes]
 {
 	z-index: 9000;
 	text: "ref";
@@ -1056,9 +984,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="
 /*  - have no railway:signal:states=* tag  */
 /*******************************************/
 node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-ESO:hp"]["railway:signal:main:form"=semaphore][!"railway:signal:main:states"],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"=hp]["railway:signal:main:form"=semaphore][!"railway:signal:main:states"],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-ESO:hp"]["railway:signal:main:form"=semaphore]["railway:signal:main:states"]["railway:signal:main:states"!~/hp(1|2)/],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"=hp]["railway:signal:main:form"=semaphore]["railway:signal:main:states"]["railway:signal:main:states"!~/hp(1|2)/]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-ESO:hp"]["railway:signal:main:form"=semaphore]["railway:signal:main:states"]["railway:signal:main:states"!~/hp(1|2)/]
 {
 	z-index: 10000;
 	text: "ref";
@@ -1079,8 +1005,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"=hp][
 /* DE main semaphore signals type Hp which */
 /*  - cannot display Hp 2                  */
 /*******************************************/
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-ESO:hp"]["railway:signal:main:form"=semaphore]["railway:signal:main:states"]["railway:signal:main:states"!~/hp2/]["railway:signal:main:states"=~/hp1/],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"=hp]["railway:signal:main:form"=semaphore]["railway:signal:main:states"]["railway:signal:main:states"!~/hp2/]["railway:signal:main:states"=~/hp1/]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-ESO:hp"]["railway:signal:main:form"=semaphore]["railway:signal:main:states"]["railway:signal:main:states"!~/hp2/]["railway:signal:main:states"=~/hp1/]
 {
 	z-index: 10000;
 	text: "ref";
@@ -1101,8 +1026,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"=hp][
 /* DE main semaphore signals type Hp which */
 /*  - can display Hp 2                     */
 /*******************************************/
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-ESO:hp"]["railway:signal:main:form"=semaphore]["railway:signal:main:states"]["railway:signal:main:states"=~/hp2/],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"=hp]["railway:signal:main:form"=semaphore]["railway:signal:main:states"]["railway:signal:main:states"=~/hp2/]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-ESO:hp"]["railway:signal:main:form"=semaphore]["railway:signal:main:states"]["railway:signal:main:states"=~/hp2/]
 {
 	z-index: 10000;
 	text: "ref";
@@ -1124,9 +1048,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"=hp][
 /*  - have no railway:signal:states=* tag */
 /******************************************/
 node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-ESO:hp"]["railway:signal:main:form"=light][!"railway:signal:main:states"],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"=hp]["railway:signal:main:form"=light][!"railway:signal:main:states"],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-ESO:hp"]["railway:signal:main:form"=light]["railway:signal:main:states"]["railway:signal:main:states"!~/hp(1|2)/],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"=hp]["railway:signal:main:form"=light]["railway:signal:main:states"]["railway:signal:main:states"!~/hp(1|2)/]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-ESO:hp"]["railway:signal:main:form"=light]["railway:signal:main:states"]["railway:signal:main:states"!~/hp(1|2)/]
 {
 	z-index: 10000;
 	text: "ref";
@@ -1147,8 +1069,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"=hp][
 /* DE main light signals type Hp which */
 /*  - cannot display Hp 2              */
 /***************************************/
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-ESO:hp"]["railway:signal:main:form"=light]["railway:signal:main:states"]["railway:signal:main:states"!~/hp2/]["railway:signal:main:states"=~/hp1/],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"=hp]["railway:signal:main:form"=light]["railway:signal:main:states"]["railway:signal:main:states"!~/hp2/]["railway:signal:main:states"=~/hp1/]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-ESO:hp"]["railway:signal:main:form"=light]["railway:signal:main:states"]["railway:signal:main:states"!~/hp2/]["railway:signal:main:states"=~/hp1/]
 {
 	z-index: 10000;
 	text: "ref";
@@ -1169,8 +1090,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"=hp][
 /* DE main light signals type Hp which */
 /*  - can display Hp 2                 */
 /***************************************/
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-ESO:hp"]["railway:signal:main:form"=light]["railway:signal:main:states"]["railway:signal:main:states"=~/hp2/],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"=hp]["railway:signal:main:form"=light]["railway:signal:main:states"]["railway:signal:main:states"=~/hp2/]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-ESO:hp"]["railway:signal:main:form"=light]["railway:signal:main:states"]["railway:signal:main:states"=~/hp2/]
 {
 	z-index: 10000;
 	text: "ref";
@@ -1191,8 +1111,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"=hp][
 /* DE main light signals type Hl which    */
 /*  - have no railway:signal:states=* tag */
 /******************************************/
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-ESO:hl"]["railway:signal:main:form"=light][!"railway:signal:main:states"],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"=hl]["railway:signal:main:form"=light][!"railway:signal:main:states"]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-ESO:hl"]["railway:signal:main:form"=light][!"railway:signal:main:states"]
 {
 	z-index: 10000;
 	text: "ref";
@@ -1213,8 +1132,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"=hl][
 /* DE main light signals type Hl which  */
 /*  - cannot display Hl 2, Hl 3a, Hl 3b */
 /****************************************/
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-ESO:hl"]["railway:signal:main:form"=light]["railway:signal:main:states"]["railway:signal:main:states"!~/hl(2|3(a|b))/],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"=hl]["railway:signal:main:form"=light]["railway:signal:main:states"]["railway:signal:main:states"!~/hl(2|3(a|b))/]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-ESO:hl"]["railway:signal:main:form"=light]["railway:signal:main:states"]["railway:signal:main:states"!~/hl(2|3(a|b))/]
 {
 	z-index: 10000;
 	text: "ref";
@@ -1235,8 +1153,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"=hl][
 /* DE main light signals type Hl which */
 /*  - cannot display Hl 3b and Hl 2    */
 /***************************************/
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-ESO:hl"]["railway:signal:main:form"=light]["railway:signal:main:states"]["railway:signal:main:states"!~/hl(2|3b)/]["railway:signal:main:states"=~/hl3a/],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"=hl]["railway:signal:main:form"=light]["railway:signal:main:states"]["railway:signal:main:states"!~/hl(2|3b)/]["railway:signal:main:states"=~/hl3a/]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-ESO:hl"]["railway:signal:main:form"=light]["railway:signal:main:states"]["railway:signal:main:states"!~/hl(2|3b)/]["railway:signal:main:states"=~/hl3a/]
 {
 	z-index: 10000;
 	text: "ref";
@@ -1258,8 +1175,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"=hl][
 /*  - can display Hl 3a, Hl 3b         */
 /*  - cannot display Hl 2              */
 /***************************************/
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-ESO:hl"]["railway:signal:main:form"=light]["railway:signal:main:states"]["railway:signal:main:states"!~/hl2/]["railway:signal:main:states"=~/hl3b/]["railway:signal:main:states"=~/hl3a/],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"=hl]["railway:signal:main:form"=light]["railway:signal:main:states"]["railway:signal:main:states"!~/hl2/]["railway:signal:main:states"=~/hl3b/]["railway:signal:main:states"=~/hl3a/]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-ESO:hl"]["railway:signal:main:form"=light]["railway:signal:main:states"]["railway:signal:main:states"!~/hl2/]["railway:signal:main:states"=~/hl3b/]["railway:signal:main:states"=~/hl3a/]
 {
 	z-index: 10000;
 	text: "ref";
@@ -1282,9 +1198,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"=hl][
 /*  - don't have to be able to display Hl 3b */
 /*********************************************/
 node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-ESO:hl"]["railway:signal:main:form"=light]["railway:signal:main:states"]["railway:signal:main:states"=~/hl3a/]["railway:signal:main:states"=~/hl2/]["railway:signal:main:states"!~/hl3b/],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-ESO:hl"]["railway:signal:main:form"=light]["railway:signal:main:states"]["railway:signal:main:states"=~/hl3a/]["railway:signal:main:states"=~/hl2/]["railway:signal:main:states"=~/hl3b/],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"=hl]["railway:signal:main:form"=light]["railway:signal:main:states"]["railway:signal:main:states"=~/hl3a/]["railway:signal:main:states"=~/hl2/]["railway:signal:main:states"!~/hl3b/],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"=hl]["railway:signal:main:form"=light]["railway:signal:main:states"]["railway:signal:main:states"=~/hl3a/]["railway:signal:main:states"=~/hl2/]["railway:signal:main:states"=~/hl3b/]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-ESO:hl"]["railway:signal:main:form"=light]["railway:signal:main:states"]["railway:signal:main:states"=~/hl3a/]["railway:signal:main:states"=~/hl2/]["railway:signal:main:states"=~/hl3b/]
 {
 	z-index: 10000;
 	text: "ref";
@@ -1305,8 +1219,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"=hl][
 /* DE combined light signals type Hl which */
 /*  - have no railway:signal:states=* tag  */
 /*******************************************/
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:combined"="DE-ESO:hl"]["railway:signal:combined:form"=light][!"railway:signal:combined:states"],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:combined"=hl]["railway:signal:combined:form"=light][!"railway:signal:combined:states"]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:combined"="DE-ESO:hl"]["railway:signal:combined:form"=light][!"railway:signal:combined:states"]
 {
 	z-index: 10000;
 	text: "ref";
@@ -1327,8 +1240,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:combined"=
 /* DE combined light signals type Hl which */
 /*  - cannot display Hl 11, Hl 12a, Hl 12b */
 /*******************************************/
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:combined"="DE-ESO:hl"]["railway:signal:combined:form"=light]["railway:signal:combined:states"]["railway:signal:combined:states"!~/hl1(1|2(a|b))/],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:combined"=hl]["railway:signal:combined:form"=light]["railway:signal:combined:states"]["railway:signal:combined:states"!~/hl1(1|2(a|b))/]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:combined"="DE-ESO:hl"]["railway:signal:combined:form"=light]["railway:signal:combined:states"]["railway:signal:combined:states"!~/hl1(1|2(a|b))/]
 {
 	z-index: 10000;
 	text: "ref";
@@ -1349,8 +1261,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:combined"=
 /* DE combined light signals type Hl which */
 /*  - cannot display Hl 12b and Hl 11      */
 /*******************************************/
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:combined"="DE-ESO:hl"]["railway:signal:combined:form"=light]["railway:signal:combined:states"]["railway:signal:combined:states"!~/hl1(1|2b)/]["railway:signal:combined:states"=~/hl12a/],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:combined"=hl]["railway:signal:combined:form"=light]["railway:signal:combined:states"]["railway:signal:combined:states"!~/hl1(1|2b)/]["railway:signal:combined:states"=~/hl12a/]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:combined"="DE-ESO:hl"]["railway:signal:combined:form"=light]["railway:signal:combined:states"]["railway:signal:combined:states"!~/hl1(1|2b)/]["railway:signal:combined:states"=~/hl12a/]
 {
 	z-index: 10000;
 	text: "ref";
@@ -1372,8 +1283,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:combined"=
 /*  - can display Hl 12a, Hl 12b           */
 /*  - cannot display Hl 11                 */
 /*******************************************/
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:combined"="DE-ESO:hl"]["railway:signal:combined:form"=light]["railway:signal:combined:states"]["railway:signal:combined:states"!~/hl11/]["railway:signal:combined:states"=~/hl12b/]["railway:signal:combined:states"=~/hl12a/],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:combined"=hl]["railway:signal:combined:form"=light]["railway:signal:combined:states"]["railway:signal:combined:states"!~/hl11/]["railway:signal:combined:states"=~/hl12b/]["railway:signal:combined:states"=~/hl12a/]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:combined"="DE-ESO:hl"]["railway:signal:combined:form"=light]["railway:signal:combined:states"]["railway:signal:combined:states"!~/hl11/]["railway:signal:combined:states"=~/hl12b/]["railway:signal:combined:states"=~/hl12a/]
 {
 	z-index: 10000;
 	text: "ref";
@@ -1396,9 +1306,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:combined"=
 /*  - don't have to be able to display Hl 12b */
 /**********************************************/
 node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:combined"="DE-ESO:hl"]["railway:signal:combined:form"=light]["railway:signal:combined:states"]["railway:signal:combined:states"=~/hl12a/]["railway:signal:combined:states"=~/hl11/]["railway:signal:combined:states"!~/hl12b/],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:combined"="DE-ESO:hl"]["railway:signal:combined:form"=light]["railway:signal:combined:states"]["railway:signal:combined:states"=~/hl12a/]["railway:signal:combined:states"=~/hl11/]["railway:signal:combined:states"=~/hl12b/],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:combined"=hl]["railway:signal:combined:form"=light]["railway:signal:combined:states"]["railway:signal:combined:states"=~/hl12a/]["railway:signal:combined:states"=~/hl11/]["railway:signal:combined:states"!~/hl12b/],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:combined"=hl]["railway:signal:combined:form"=light]["railway:signal:combined:states"]["railway:signal:combined:states"=~/hl12a/]["railway:signal:combined:states"=~/hl11/]["railway:signal:combined:states"=~/hl12b/]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:combined"="DE-ESO:hl"]["railway:signal:combined:form"=light]["railway:signal:combined:states"]["railway:signal:combined:states"=~/hl12a/]["railway:signal:combined:states"=~/hl11/]["railway:signal:combined:states"=~/hl12b/]
 {
 	z-index: 10000;
 	text: "ref";
@@ -1420,8 +1328,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:combined"=
 /* - which cannot show Hp 0          */
 /* - which can show Sv 0             */
 /*************************************/
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:combined"="DE-ESO:sv"]["railway:signal:combined:states"!~/hp0/]["railway:signal:combined:states"=~/sv0/],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:combined"=sv]["railway:signal:combined:states"!~/hp0/]["railway:signal:combined:states"=~/sv0/]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:combined"="DE-ESO:sv"]["railway:signal:combined:states"!~/hp0/]["railway:signal:combined:states"=~/sv0/]
 {
 	z-index: 10000;
 	text: "ref";
@@ -1484,8 +1391,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-
 /* DE combined light signals type Sv */
 /* - which can show Hp 0             */
 /*************************************/
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:combined"="DE-ESO:sv"]["railway:signal:combined:states"=~/hp0/],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:combined"=sv]["railway:signal:combined:states"=~/hp0/]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:combined"="DE-ESO:sv"]["railway:signal:combined:states"=~/hp0/]
 {
 	z-index: 10001;
 	text: "ref";
@@ -1505,8 +1411,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:combined"=
 /**************************/
 /* DE main signal type Ks */
 /**************************/
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-ESO:ks"]["railway:signal:main:form"=light]["railway:signal:main:states"="DE-ESO:hp0;DE-ESO:ks1"],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"=ks]["railway:signal:main:form"=light]["railway:signal:main:states"="hp0;ks1"]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-ESO:ks"]["railway:signal:main:form"=light]["railway:signal:main:states"="DE-ESO:hp0;DE-ESO:ks1"]
 {
 	z-index: 10100;
 	text: "ref";
@@ -1527,9 +1432,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"=ks][
 /* DE combined signal type Ks */
 /******************************/
 node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:combined"="DE-ESO:ks"]["railway:signal:combined:form"=light]["railway:signal:combined:states"="DE-ESO:hp0;DE-ESO:ks1;DE-ESO:ks2"]["railway:signal:combined:shortened"="no"],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:combined"="DE-ESO:ks"]["railway:signal:combined:form"=light]["railway:signal:combined:states"="DE-ESO:hp0;DE-ESO:ks1;DE-ESO:ks2"][!"railway:signal:combined:shortened"],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:combined"=ks]["railway:signal:combined:form"=light]["railway:signal:combined:states"="hp0;ks1;ks2"]["railway:signal:combined:shortened"="no"],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:combined"=ks]["railway:signal:combined:form"=light]["railway:signal:combined:states"="hp0;ks1;ks2"][!"railway:signal:combined:shortened"]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:combined"="DE-ESO:ks"]["railway:signal:combined:form"=light]["railway:signal:combined:states"="DE-ESO:hp0;DE-ESO:ks1;DE-ESO:ks2"][!"railway:signal:combined:shortened"]
 {
 	z-index: 10200;
 	text: "ref";
@@ -1549,8 +1452,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:combined"=
 /****************************************/
 /* DE shortened combined signal type Ks */
 /****************************************/
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:combined"="DE-ESO:ks"]["railway:signal:combined:form"=light]["railway:signal:combined:states"="DE-ESO:hp0;DE-ESO:ks1;DE-ESO:ks2"]["railway:signal:combined:shortened"="yes"],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:combined"=ks]["railway:signal:combined:form"=light]["railway:signal:combined:states"="hp0;ks1;ks2"]["railway:signal:combined:shortened"="yes"]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:combined"="DE-ESO:ks"]["railway:signal:combined:form"=light]["railway:signal:combined:states"="DE-ESO:hp0;DE-ESO:ks1;DE-ESO:ks2"]["railway:signal:combined:shortened"="yes"]
 {
 	z-index: 10200;
 	text: "ref";

--- a/styles/signals.mapcss
+++ b/styles/signals.mapcss
@@ -520,8 +520,7 @@ node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:minor"=sh]
 /***************************/
 /* DE main entry sign Ne 1 */
 /***************************/
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-ESO:ne1"]["railway:signal:main:form"=sign]["railway:signal:main:function"=entry],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="ne1"]["railway:signal:main:form"=sign]["railway:signal:main:function"=entry]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-ESO:ne1"]["railway:signal:main:form"=sign]["railway:signal:main:function"=entry]
 {
 	z-index: 8000;
 	icon-image: "icons/de/ne1-32.png";
@@ -693,9 +692,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="
 /*  - cannot display Vr 2                  */
 /*******************************************/
 node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:vr"]["railway:signal:distant:form"=light]["railway:signal:distant:repeated"=yes][!"railway:signal:main"]["railway:signal:distant:states"=~/vr1/]["railway:signal:distant:states"!~/vr2/],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:vr"]["railway:signal:distant:form"=light]["railway:signal:distant:shortened"=yes][!"railway:signal:main"]["railway:signal:distant:states"=~/vr1/]["railway:signal:distant:states"!~/vr2/],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"=vr]["railway:signal:distant:form"=light]["railway:signal:distant:repeated"=yes][!"railway:signal:main"]["railway:signal:distant:states"=~/vr1/]["railway:signal:distant:states"!~/vr2/],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"=vr]["railway:signal:distant:form"=light]["railway:signal:distant:shortened"=yes][!"railway:signal:main"]["railway:signal:distant:states"=~/vr1/]["railway:signal:distant:states"!~/vr2/]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:vr"]["railway:signal:distant:form"=light]["railway:signal:distant:shortened"=yes][!"railway:signal:main"]["railway:signal:distant:states"=~/vr1/]["railway:signal:distant:states"!~/vr2/]
 {
 	z-index: 8500;
 	text: "ref";
@@ -719,9 +716,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"=v
 /*  - can display Vr 2                     */
 /*******************************************/
 node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:vr"]["railway:signal:distant:form"=light]["railway:signal:distant:repeated"=yes][!"railway:signal:main"]["railway:signal:distant:states"]["railway:signal:distant:states"=~/vr2/],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:vr"]["railway:signal:distant:form"=light]["railway:signal:distant:shortened"=yes][!"railway:signal:main"]["railway:signal:distant:states"]["railway:signal:distant:states"=~/vr2/],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"=vr]["railway:signal:distant:form"=light]["railway:signal:distant:repeated"=yes][!"railway:signal:main"]["railway:signal:distant:states"]["railway:signal:distant:states"=~/vr2/],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"=vr]["railway:signal:distant:form"=light]["railway:signal:distant:shortened"=yes][!"railway:signal:main"]["railway:signal:distant:states"]["railway:signal:distant:states"=~/vr2/]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:vr"]["railway:signal:distant:form"=light]["railway:signal:distant:shortened"=yes][!"railway:signal:main"]["railway:signal:distant:states"]["railway:signal:distant:states"=~/vr2/]
 {
 	z-index: 8500;
 	text: "ref";
@@ -742,9 +737,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"=v
 /* DE distant light signals type Hl */
 /************************************/
 node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:hl"]["railway:signal:distant:form"=light]["railway:signal:distant:repeated"=no][!"railway:signal:main"],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:hl"]["railway:signal:distant:form"=light][!"railway:signal:distant:repeated"][!"railway:signal:main"],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"=hl]["railway:signal:distant:form"=light]["railway:signal:distant:repeated"=no][!"railway:signal:main"],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"=hl]["railway:signal:distant:form"=light][!"railway:signal:distant:repeated"][!"railway:signal:main"]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:hl"]["railway:signal:distant:form"=light][!"railway:signal:distant:repeated"][!"railway:signal:main"]
 {
 	z-index: 8500;
 	text: "ref";


### PR DESCRIPTION
This removes the support of signals whose values do not have a national or operator prefix.

Today I finished [my mechanical edit](https://wiki.openstreetmap.org/wiki/User:Nakaner/Mechanical_Edit_German_on_Railway_Signals) which added these prefixes.