### PR TITLE
render track name on bridges and tunnels if no specific name is set

### DIFF
--- a/styles/standard.mapcss
+++ b/styles/standard.mapcss
@@ -65,7 +65,7 @@ way|z12-[bridge=yes][!"railway:track_ref"].tracks::bridges
 	font-style: italic;
 	text-halo-radius: 1;
 	text-halo-color: white;
-	text: eval(join(" ", tag("ref"), tag("bridge:name")));
+	text: eval(join(" ", tag("ref"), any(tag("bridge:name"), tag("name"))));
 }
 
 /*******************************************/
@@ -96,7 +96,7 @@ way|z10-[tunnel=yes][!"railway:track_ref"].tracks::tunnels
 	font-style: italic;
 	text-halo-radius: 1;
 	text-halo-color: white;
-	text: eval(join(" ", tag("ref"), tag("tunnel:name")));
+	text: eval(join(" ", tag("ref"), any(tag("tunnel:name"), tag("name"))));
 }
 
 /*************************/


### PR DESCRIPTION
If a bridge or tunnel does not have a more specific name set (i.e. bridge:name
or tunnel:name) then just show the name of the track it is part of.

Currently one does not get any name if the bridge does not have it's own name (or that is not tagged), or if the bridge name is put into *name*. After this merge you will always get a text (given any of *name* and *bridge:name* is set, but the case that the bridge name is written into *name* can't be spotted. Since it can't be clearly spotted before anyway I don't think this is a regression.