### PR TITLE
German presets: fix syntax errors

### DIFF
--- a/josm-presets/de-signals-eso.xml
+++ b/josm-presets/de-signals-eso.xml
@@ -1775,7 +1775,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						default=""
 						delete_if_empty="true" />
 					<key key="railway:signal:route:form"
-						value="light">
+						value="light" />
 				</item>
 				<item name="Richtungsvoranzeiger (Zs 2v)" icon="de-zs2v-F-38.png" type="node">
 					<label text="Richtungsvoranzeiger (Zs 2v)" />
@@ -1811,7 +1811,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						default=""
 						delete_if_empty="true" />
 					<key key="railway:signal:route:form"
-						value="light">
+						value="light" />
 				</item>
 				<separator />
 				<item name="Geschwindigkeitsanzeiger (Zs 3)" icon="de-zs3-60-sign-up-32.png" type="node">


### PR DESCRIPTION
This was introduced in 7b3e395ed120ff3eed83dd657616477f45c35a28.