### PR TITLE
use stricter regular expressions to match signal states

### DIFF
--- a/styles/signals.mapcss
+++ b/styles/signals.mapcss
@@ -1028,8 +1028,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="
 /* DE main semaphore signals type Hp which */
 /*  - have no railway:signal:states=* tag  */
 /*******************************************/
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-ESO:hp"]["railway:signal:main:form"=semaphore][!"railway:signal:main:states"],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-ESO:hp"]["railway:signal:main:form"=semaphore]["railway:signal:main:states"]["railway:signal:main:states"!~/^(.*;)?DE-ESO:hp(1|2)(;.*)?$/]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-ESO:hp"]["railway:signal:main:form"=semaphore]["railway:signal:main:states"!~/^(.*;)?DE-ESO:hp(1|2)(;.*)?$/]
 {
 	z-index: 10000;
 	text: "ref";
@@ -1050,7 +1049,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-
 /* DE main semaphore signals type Hp which */
 /*  - cannot display Hp 2                  */
 /*******************************************/
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-ESO:hp"]["railway:signal:main:form"=semaphore]["railway:signal:main:states"]["railway:signal:main:states"!~/^(.*;)?DE-ESO:hp2(;.*)?$/]["railway:signal:main:states"=~/^(.*;)?DE-ESO:hp1(;.*)?$/]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-ESO:hp"]["railway:signal:main:form"=semaphore]["railway:signal:main:states"!~/^(.*;)?DE-ESO:hp2(;.*)?$/]["railway:signal:main:states"=~/^(.*;)?DE-ESO:hp1(;.*)?$/]
 {
 	z-index: 10000;
 	text: "ref";
@@ -1071,7 +1070,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-
 /* DE main semaphore signals type Hp which */
 /*  - can display Hp 2                     */
 /*******************************************/
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-ESO:hp"]["railway:signal:main:form"=semaphore]["railway:signal:main:states"]["railway:signal:main:states"=~/^(.*;)?DE-ESO:hp2(;.*)?$/]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-ESO:hp"]["railway:signal:main:form"=semaphore]["railway:signal:main:states"=~/^(.*;)?DE-ESO:hp2(;.*)?$/]
 {
 	z-index: 10000;
 	text: "ref";
@@ -1092,8 +1091,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-
 /* DE main light signals type Hp which    */
 /*  - have no railway:signal:states=* tag */
 /******************************************/
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-ESO:hp"]["railway:signal:main:form"=light][!"railway:signal:main:states"],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-ESO:hp"]["railway:signal:main:form"=light]["railway:signal:main:states"]["railway:signal:main:states"!~/^(.*;)?DE-ESO:hp(1|2)(;.*)?$/]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-ESO:hp"]["railway:signal:main:form"=light]["railway:signal:main:states"!~/^(.*;)?DE-ESO:hp(1|2)(;.*)?$/]
 {
 	z-index: 10000;
 	text: "ref";
@@ -1114,7 +1112,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-
 /* DE main light signals type Hp which */
 /*  - cannot display Hp 2              */
 /***************************************/
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-ESO:hp"]["railway:signal:main:form"=light]["railway:signal:main:states"]["railway:signal:main:states"!~/^(.*;)?DE-ESO:hp2(;.*)?$/]["railway:signal:main:states"=~/^(.*;)?DE-ESO:hp1(;.*)?$/]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-ESO:hp"]["railway:signal:main:form"=light]["railway:signal:main:states"!~/^(.*;)?DE-ESO:hp2(;.*)?$/]["railway:signal:main:states"=~/^(.*;)?DE-ESO:hp1(;.*)?$/]
 {
 	z-index: 10000;
 	text: "ref";
@@ -1135,7 +1133,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-
 /* DE main light signals type Hp which */
 /*  - can display Hp 2                 */
 /***************************************/
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-ESO:hp"]["railway:signal:main:form"=light]["railway:signal:main:states"]["railway:signal:main:states"=~/^(.*;)?DE-ESO:hp2(;.*)?$/]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-ESO:hp"]["railway:signal:main:form"=light]["railway:signal:main:states"=~/^(.*;)?DE-ESO:hp2(;.*)?$/]
 {
 	z-index: 10000;
 	text: "ref";
@@ -1198,7 +1196,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-
 /* DE main light signals type Hl which */
 /*  - cannot display Hl 3b and Hl 2    */
 /***************************************/
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-ESO:hl"]["railway:signal:main:form"=light]["railway:signal:main:states"]["railway:signal:main:states"!~/^(.*;)?DE-ESO:hl(2|3b)(;.*)?$/]["railway:signal:main:states"=~/^(.*;)?DE-ESO:hl3a(;.*)?$/]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-ESO:hl"]["railway:signal:main:form"=light]["railway:signal:main:states"!~/^(.*;)?DE-ESO:hl(2|3b)(;.*)?$/]["railway:signal:main:states"=~/^(.*;)?DE-ESO:hl3a(;.*)?$/]
 {
 	z-index: 10000;
 	text: "ref";
@@ -1220,7 +1218,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-
 /*  - can display Hl 3a, Hl 3b         */
 /*  - cannot display Hl 2              */
 /***************************************/
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-ESO:hl"]["railway:signal:main:form"=light]["railway:signal:main:states"]["railway:signal:main:states"!~/^(.*;)?DE-ESO:hl2(;.*)?$/]["railway:signal:main:states"=~/^(.*;)?DE-ESO:hl3b(;.*)?$/]["railway:signal:main:states"=~/^(.*;)?DE-ESO:hl3a(;.*)?$/]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-ESO:hl"]["railway:signal:main:form"=light]["railway:signal:main:states"!~/^(.*;)?DE-ESO:hl2(;.*)?$/]["railway:signal:main:states"=~/^(.*;)?DE-ESO:hl3b(;.*)?$/]["railway:signal:main:states"=~/^(.*;)?DE-ESO:hl3a(;.*)?$/]
 {
 	z-index: 10000;
 	text: "ref";
@@ -1242,7 +1240,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-
 /*  - can display Hl 2, Hl 3a                */
 /*  - don't have to be able to display Hl 3b */
 /*********************************************/
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-ESO:hl"]["railway:signal:main:form"=light]["railway:signal:main:states"]["railway:signal:main:states"=~/^(.*;)?DE-ESO:hl3a(;.*)?$/]["railway:signal:main:states"=~/^(.*;)?DE-ESO:hl2(;.*)?$/]["railway:signal:main:states"!~/^(.*;)?DE-ESO:hl3b(;.*)?$/]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-ESO:hl"]["railway:signal:main:form"=light]["railway:signal:main:states"=~/^(.*;)?DE-ESO:hl3a(;.*)?$/]["railway:signal:main:states"=~/^(.*;)?DE-ESO:hl2(;.*)?$/]["railway:signal:main:states"!~/^(.*;)?DE-ESO:hl3b(;.*)?$/]
 {
 	z-index: 10000;
 	text: "ref";

--- a/styles/signals.mapcss
+++ b/styles/signals.mapcss
@@ -575,8 +575,8 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="
 /*  - have no railway:signal:states=* tag                                       */
 /*  - OR have railway:signal:states=* tag that does neither include Vr1 nor Vr2 */
 /********************************************************************************/
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:vr"]["railway:signal:distant:form"=light]["railway:signal:distant:repeated"=yes][!"railway:signal:main"]["railway:signal:distant:states"!~/vr(1|2)/],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:vr"]["railway:signal:distant:form"=light]["railway:signal:distant:shortened"=yes][!"railway:signal:main"]["railway:signal:distant:states"!~/vr(1|2)/]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:vr"]["railway:signal:distant:form"=light]["railway:signal:distant:repeated"=yes][!"railway:signal:main"]["railway:signal:distant:states"!~/^(.*;)?DE-ESO:vr(1|2)(;.*)?$/],
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:vr"]["railway:signal:distant:form"=light]["railway:signal:distant:shortened"=yes][!"railway:signal:main"]["railway:signal:distant:states"!~/^(.*;)?DE-ESO:vr(1|2)(;.*)?$/]
 {
 	z-index: 8500;
 	text: "ref";
@@ -659,8 +659,8 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="
 /*  - can display Vr 1                     */
 /*  - cannot display Vr 2                  */
 /*******************************************/
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:vr"]["railway:signal:distant:form"=light]["railway:signal:distant:repeated"=yes][!"railway:signal:main"]["railway:signal:distant:states"=~/vr1/]["railway:signal:distant:states"!~/vr2/],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:vr"]["railway:signal:distant:form"=light]["railway:signal:distant:shortened"=yes][!"railway:signal:main"]["railway:signal:distant:states"=~/vr1/]["railway:signal:distant:states"!~/vr2/]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:vr"]["railway:signal:distant:form"=light]["railway:signal:distant:repeated"=yes][!"railway:signal:main"]["railway:signal:distant:states"=~/^(.*;)?DE-ESO:vr1(;.*)?$/]["railway:signal:distant:states"!~/^(.*;)?DE-ESO:vr2(;.*)?$/],
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:vr"]["railway:signal:distant:form"=light]["railway:signal:distant:shortened"=yes][!"railway:signal:main"]["railway:signal:distant:states"=~/^(.*;)?DE-ESO:vr1(;.*)?$/]["railway:signal:distant:states"!~/^(.*;)?DE-ESO:vr2(;.*)?$/]
 {
 	z-index: 8500;
 	text: "ref";
@@ -683,8 +683,8 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="
 /*  - do not share post with a main signal */
 /*  - can display Vr 2                     */
 /*******************************************/
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:vr"]["railway:signal:distant:form"=light]["railway:signal:distant:repeated"=yes][!"railway:signal:main"]["railway:signal:distant:states"]["railway:signal:distant:states"=~/vr2/],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:vr"]["railway:signal:distant:form"=light]["railway:signal:distant:shortened"=yes][!"railway:signal:main"]["railway:signal:distant:states"]["railway:signal:distant:states"=~/vr2/]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:vr"]["railway:signal:distant:form"=light]["railway:signal:distant:repeated"=yes][!"railway:signal:main"]["railway:signal:distant:states"]["railway:signal:distant:states"=~/^(.*;)?DE-ESO:vr2(;.*)?$/],
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:vr"]["railway:signal:distant:form"=light]["railway:signal:distant:shortened"=yes][!"railway:signal:main"]["railway:signal:distant:states"]["railway:signal:distant:states"=~/^(.*;)?DE-ESO:vr2(;.*)?$/]
 {
 	z-index: 8500;
 	text: "ref";
@@ -796,7 +796,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:train_prot
 /*  - have no railway:signal:states=* tag                                       */
 /*  - OR have railway:signal:states=* tag that does neither include Vr1 nor Vr2 */
 /********************************************************************************/
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:vr"]["railway:signal:distant:form"=semaphore][!"railway:signal:main"]["railway:signal:distant:states"!~/vr(1|2)/]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:vr"]["railway:signal:distant:form"=semaphore][!"railway:signal:main"]["railway:signal:distant:states"!~/^(.*;)?DE-ESO:vr(1|2)(;.*)?$/]
 {
 	z-index: 9000;
 	text: "ref";
@@ -819,7 +819,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="
 /*  - can display Vr 1                        */
 /*  - cannot display Vr 2                     */
 /**********************************************/
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:vr"]["railway:signal:distant:form"=semaphore][!"railway:signal:main"]["railway:signal:distant:states"=~/vr1/]["railway:signal:distant:states"!~/vr2/]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:vr"]["railway:signal:distant:form"=semaphore][!"railway:signal:main"]["railway:signal:distant:states"=~/^(.*;)?DE-ESO:vr1(;.*)?$/]["railway:signal:distant:states"!~/^(.*;)?DE-ESO:vr2(;.*)?$/]
 {
 	z-index: 9000;
 	text: "ref";
@@ -841,7 +841,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="
 /*  - do not share post with a main signal    */
 /*  - can display Vr 2                        */
 /**********************************************/
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:vr"]["railway:signal:distant:form"=semaphore][!"railway:signal:main"]["railway:signal:distant:states"]["railway:signal:distant:states"=~/vr2/]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:vr"]["railway:signal:distant:form"=semaphore][!"railway:signal:main"]["railway:signal:distant:states"]["railway:signal:distant:states"=~/^(.*;)?DE-ESO:vr2(;.*)?$/]
 {
 	z-index: 9000;
 	text: "ref";
@@ -866,10 +866,10 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="
 /*  - have no railway:signal:states=* tag                                       */
 /*  - OR have railway:signal:states=* tag that does neither include Vr1 nor Vr2 */
 /********************************************************************************/
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:vr"]["railway:signal:distant:form"=light]["railway:signal:distant:repeated"=no]["railway:signal:distant:shortened"=no][!"railway:signal:main"]["railway:signal:distant:states"!~/vr(1|2)/],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:vr"]["railway:signal:distant:form"=light][!"railway:signal:distant:repeated"]["railway:signal:distant:shortened"=no][!"railway:signal:main"]["railway:signal:distant:states"!~/vr(1|2)/],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:vr"]["railway:signal:distant:form"=light]["railway:signal:distant:repeated"=no][!"railway:signal:distant:shortened"][!"railway:signal:main"]["railway:signal:distant:states"!~/vr(1|2)/],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:vr"]["railway:signal:distant:form"=light][!"railway:signal:distant:repeated"][!"railway:signal:distant:shortened"][!"railway:signal:main"]["railway:signal:distant:states"!~/vr(1|2)/]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:vr"]["railway:signal:distant:form"=light]["railway:signal:distant:repeated"=no]["railway:signal:distant:shortened"=no][!"railway:signal:main"]["railway:signal:distant:states"!~/^(.*;)?DE-ESO:vr(1|2)(;.*)?$/],
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:vr"]["railway:signal:distant:form"=light][!"railway:signal:distant:repeated"]["railway:signal:distant:shortened"=no][!"railway:signal:main"]["railway:signal:distant:states"!~/^(.*;)?DE-ESO:vr(1|2)(;.*)?$/],
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:vr"]["railway:signal:distant:form"=light]["railway:signal:distant:repeated"=no][!"railway:signal:distant:shortened"][!"railway:signal:main"]["railway:signal:distant:states"!~/^(.*;)?DE-ESO:vr(1|2)(;.*)?$/],
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:vr"]["railway:signal:distant:form"=light][!"railway:signal:distant:repeated"][!"railway:signal:distant:shortened"][!"railway:signal:main"]["railway:signal:distant:states"!~/^(.*;)?DE-ESO:vr(1|2)(;.*)?$/]
 {
 	z-index: 9000;
 	text: "ref";
@@ -894,10 +894,10 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="
 /*  - can display Vr 1                          */
 /*  - cannot display Vr 2                       */
 /************************************************/
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:vr"]["railway:signal:distant:form"=light]["railway:signal:distant:repeated"=no]["railway:signal:distant:shortened"=no][!"railway:signal:main"]["railway:signal:distant:states"]["railway:signal:distant:states"=~/vr1/]["railway:signal:distant:states"!~/vr2/],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:vr"]["railway:signal:distant:form"=light][!"railway:signal:distant:repeated"]["railway:signal:distant:shortened"=no][!"railway:signal:main"]["railway:signal:distant:states"]["railway:signal:distant:states"=~/vr1/]["railway:signal:distant:states"!~/vr2/],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:vr"]["railway:signal:distant:form"=light]["railway:signal:distant:repeated"=no][!"railway:signal:distant:shortened"][!"railway:signal:main"]["railway:signal:distant:states"]["railway:signal:distant:states"=~/vr1/]["railway:signal:distant:states"!~/vr2/],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:vr"]["railway:signal:distant:form"=light][!"railway:signal:distant:repeated"][!"railway:signal:distant:shortened"][!"railway:signal:main"]["railway:signal:distant:states"]["railway:signal:distant:states"=~/vr1/]["railway:signal:distant:states"!~/vr2/]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:vr"]["railway:signal:distant:form"=light]["railway:signal:distant:repeated"=no]["railway:signal:distant:shortened"=no][!"railway:signal:main"]["railway:signal:distant:states"]["railway:signal:distant:states"=~/^(.*;)?DE-ESO:vr1(;.*)?$/]["railway:signal:distant:states"!~/^(.*;)?DE-ESO:vr2(;.*)?$/],
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:vr"]["railway:signal:distant:form"=light][!"railway:signal:distant:repeated"]["railway:signal:distant:shortened"=no][!"railway:signal:main"]["railway:signal:distant:states"]["railway:signal:distant:states"=~/^(.*;)?DE-ESO:vr1(;.*)?$/]["railway:signal:distant:states"!~/^(.*;)?DE-ESO:vr2(;.*)?$/],
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:vr"]["railway:signal:distant:form"=light]["railway:signal:distant:repeated"=no][!"railway:signal:distant:shortened"][!"railway:signal:main"]["railway:signal:distant:states"]["railway:signal:distant:states"=~/^(.*;)?DE-ESO:vr1(;.*)?$/]["railway:signal:distant:states"!~/^(.*;)?DE-ESO:vr2(;.*)?$/],
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:vr"]["railway:signal:distant:form"=light][!"railway:signal:distant:repeated"][!"railway:signal:distant:shortened"][!"railway:signal:main"]["railway:signal:distant:states"]["railway:signal:distant:states"=~/^(.*;)?DE-ESO:vr1(;.*)?$/]["railway:signal:distant:states"!~/^(.*;)?DE-ESO:vr2(;.*)?$/]
 {
 	z-index: 9000;
 	text: "ref";
@@ -921,8 +921,8 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="
 /*  - do not share post with a main signal      */
 /*  - can display Vr 2                          */
 /************************************************/
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:vr"]["railway:signal:distant:form"=light]["railway:signal:distant:repeated"=no][!"railway:signal:main"]["railway:signal:distant:states"]["railway:signal:distant:states"=~/vr2/],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:vr"]["railway:signal:distant:form"=light][!"railway:signal:distant:repeated"][!"railway:signal:main"]["railway:signal:distant:states"]["railway:signal:distant:states"=~/vr2/]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:vr"]["railway:signal:distant:form"=light]["railway:signal:distant:repeated"=no][!"railway:signal:main"]["railway:signal:distant:states"]["railway:signal:distant:states"=~/^(.*;)?DE-ESO:vr2(;.*)?$/],
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:vr"]["railway:signal:distant:form"=light][!"railway:signal:distant:repeated"][!"railway:signal:main"]["railway:signal:distant:states"]["railway:signal:distant:states"=~/^(.*;)?DE-ESO:vr2(;.*)?$/]
 {
 	z-index: 9000;
 	text: "ref";
@@ -1029,7 +1029,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="
 /*  - have no railway:signal:states=* tag  */
 /*******************************************/
 node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-ESO:hp"]["railway:signal:main:form"=semaphore][!"railway:signal:main:states"],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-ESO:hp"]["railway:signal:main:form"=semaphore]["railway:signal:main:states"]["railway:signal:main:states"!~/hp(1|2)/]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-ESO:hp"]["railway:signal:main:form"=semaphore]["railway:signal:main:states"]["railway:signal:main:states"!~/^(.*;)?DE-ESO:hp(1|2)(;.*)?$/]
 {
 	z-index: 10000;
 	text: "ref";
@@ -1050,7 +1050,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-
 /* DE main semaphore signals type Hp which */
 /*  - cannot display Hp 2                  */
 /*******************************************/
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-ESO:hp"]["railway:signal:main:form"=semaphore]["railway:signal:main:states"]["railway:signal:main:states"!~/hp2/]["railway:signal:main:states"=~/hp1/]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-ESO:hp"]["railway:signal:main:form"=semaphore]["railway:signal:main:states"]["railway:signal:main:states"!~/^(.*;)?DE-ESO:hp2(;.*)?$/]["railway:signal:main:states"=~/^(.*;)?DE-ESO:hp1(;.*)?$/]
 {
 	z-index: 10000;
 	text: "ref";
@@ -1071,7 +1071,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-
 /* DE main semaphore signals type Hp which */
 /*  - can display Hp 2                     */
 /*******************************************/
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-ESO:hp"]["railway:signal:main:form"=semaphore]["railway:signal:main:states"]["railway:signal:main:states"=~/hp2/]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-ESO:hp"]["railway:signal:main:form"=semaphore]["railway:signal:main:states"]["railway:signal:main:states"=~/^(.*;)?DE-ESO:hp2(;.*)?$/]
 {
 	z-index: 10000;
 	text: "ref";
@@ -1093,7 +1093,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-
 /*  - have no railway:signal:states=* tag */
 /******************************************/
 node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-ESO:hp"]["railway:signal:main:form"=light][!"railway:signal:main:states"],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-ESO:hp"]["railway:signal:main:form"=light]["railway:signal:main:states"]["railway:signal:main:states"!~/hp(1|2)/]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-ESO:hp"]["railway:signal:main:form"=light]["railway:signal:main:states"]["railway:signal:main:states"!~/^(.*;)?DE-ESO:hp(1|2)(;.*)?$/]
 {
 	z-index: 10000;
 	text: "ref";
@@ -1114,7 +1114,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-
 /* DE main light signals type Hp which */
 /*  - cannot display Hp 2              */
 /***************************************/
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-ESO:hp"]["railway:signal:main:form"=light]["railway:signal:main:states"]["railway:signal:main:states"!~/hp2/]["railway:signal:main:states"=~/hp1/]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-ESO:hp"]["railway:signal:main:form"=light]["railway:signal:main:states"]["railway:signal:main:states"!~/^(.*;)?DE-ESO:hp2(;.*)?$/]["railway:signal:main:states"=~/^(.*;)?DE-ESO:hp1(;.*)?$/]
 {
 	z-index: 10000;
 	text: "ref";
@@ -1135,7 +1135,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-
 /* DE main light signals type Hp which */
 /*  - can display Hp 2                 */
 /***************************************/
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-ESO:hp"]["railway:signal:main:form"=light]["railway:signal:main:states"]["railway:signal:main:states"=~/hp2/]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-ESO:hp"]["railway:signal:main:form"=light]["railway:signal:main:states"]["railway:signal:main:states"=~/^(.*;)?DE-ESO:hp2(;.*)?$/]
 {
 	z-index: 10000;
 	text: "ref";
@@ -1177,7 +1177,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-
 /* DE main light signals type Hl which  */
 /*  - cannot display Hl 2, Hl 3a, Hl 3b */
 /****************************************/
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-ESO:hl"]["railway:signal:main:form"=light]["railway:signal:main:states"]["railway:signal:main:states"!~/hl(2|3(a|b))/]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-ESO:hl"]["railway:signal:main:form"=light]["railway:signal:main:states"]["railway:signal:main:states"!~/^(.*;)?DE-ESO:hl(2|3(a|b))(;.*)?$/]
 {
 	z-index: 10000;
 	text: "ref";
@@ -1198,7 +1198,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-
 /* DE main light signals type Hl which */
 /*  - cannot display Hl 3b and Hl 2    */
 /***************************************/
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-ESO:hl"]["railway:signal:main:form"=light]["railway:signal:main:states"]["railway:signal:main:states"!~/hl(2|3b)/]["railway:signal:main:states"=~/hl3a/]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-ESO:hl"]["railway:signal:main:form"=light]["railway:signal:main:states"]["railway:signal:main:states"!~/^(.*;)?DE-ESO:hl(2|3b)(;.*)?$/]["railway:signal:main:states"=~/^(.*;)?DE-ESO:hl3a(;.*)?$/]
 {
 	z-index: 10000;
 	text: "ref";
@@ -1220,7 +1220,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-
 /*  - can display Hl 3a, Hl 3b         */
 /*  - cannot display Hl 2              */
 /***************************************/
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-ESO:hl"]["railway:signal:main:form"=light]["railway:signal:main:states"]["railway:signal:main:states"!~/hl2/]["railway:signal:main:states"=~/hl3b/]["railway:signal:main:states"=~/hl3a/]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-ESO:hl"]["railway:signal:main:form"=light]["railway:signal:main:states"]["railway:signal:main:states"!~/^(.*;)?DE-ESO:hl2(;.*)?$/]["railway:signal:main:states"=~/^(.*;)?DE-ESO:hl3b(;.*)?$/]["railway:signal:main:states"=~/^(.*;)?DE-ESO:hl3a(;.*)?$/]
 {
 	z-index: 10000;
 	text: "ref";
@@ -1242,7 +1242,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-
 /*  - can display Hl 2, Hl 3a                */
 /*  - don't have to be able to display Hl 3b */
 /*********************************************/
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-ESO:hl"]["railway:signal:main:form"=light]["railway:signal:main:states"]["railway:signal:main:states"=~/hl3a/]["railway:signal:main:states"=~/hl2/]["railway:signal:main:states"!~/hl3b/]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-ESO:hl"]["railway:signal:main:form"=light]["railway:signal:main:states"]["railway:signal:main:states"=~/^(.*;)?DE-ESO:hl3a(;.*)?$/]["railway:signal:main:states"=~/^(.*;)?DE-ESO:hl2(;.*)?$/]["railway:signal:main:states"!~/^(.*;)?DE-ESO:hl3b(;.*)?$/]
 {
 	z-index: 10000;
 	text: "ref";
@@ -1284,7 +1284,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:combined"=
 /* DE combined light signals type Hl which */
 /*  - cannot display Hl 11, Hl 12a, Hl 12b */
 /*******************************************/
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:combined"="DE-ESO:hl"]["railway:signal:combined:form"=light]["railway:signal:combined:states"]["railway:signal:combined:states"!~/hl1(1|2(a|b))/]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:combined"="DE-ESO:hl"]["railway:signal:combined:form"=light]["railway:signal:combined:states"]["railway:signal:combined:states"!~/^(.*;)?DE-ESO:hl1(1|2(a|b))(;.*)?$/]
 {
 	z-index: 10000;
 	text: "ref";
@@ -1305,7 +1305,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:combined"=
 /* DE combined light signals type Hl which */
 /*  - cannot display Hl 12b and Hl 11      */
 /*******************************************/
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:combined"="DE-ESO:hl"]["railway:signal:combined:form"=light]["railway:signal:combined:states"]["railway:signal:combined:states"!~/hl1(1|2b)/]["railway:signal:combined:states"=~/hl12a/]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:combined"="DE-ESO:hl"]["railway:signal:combined:form"=light]["railway:signal:combined:states"]["railway:signal:combined:states"!~/^(.*;)?DE-ESO:hl1(1|2b)(;.*)?$/]["railway:signal:combined:states"=~/^(.*;)?DE-ESO:hl12a(;.*)?$/]
 {
 	z-index: 10000;
 	text: "ref";
@@ -1327,7 +1327,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:combined"=
 /*  - can display Hl 12a, Hl 12b           */
 /*  - cannot display Hl 11                 */
 /*******************************************/
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:combined"="DE-ESO:hl"]["railway:signal:combined:form"=light]["railway:signal:combined:states"]["railway:signal:combined:states"!~/hl11/]["railway:signal:combined:states"=~/hl12b/]["railway:signal:combined:states"=~/hl12a/]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:combined"="DE-ESO:hl"]["railway:signal:combined:form"=light]["railway:signal:combined:states"]["railway:signal:combined:states"!~/^(.*;)?DE-ESO:hl11(;.*)?$/]["railway:signal:combined:states"=~/^(.*;)?DE-ESO:hl12b(;.*)?$/]["railway:signal:combined:states"=~/^(.*;)?DE-ESO:hl12a(;.*)?$/]
 {
 	z-index: 10000;
 	text: "ref";
@@ -1349,7 +1349,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:combined"=
 /*  - can display Hl 11, Hl 12a               */
 /*  - don't have to be able to display Hl 12b */
 /**********************************************/
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:combined"="DE-ESO:hl"]["railway:signal:combined:form"=light]["railway:signal:combined:states"]["railway:signal:combined:states"=~/hl12a/]["railway:signal:combined:states"=~/hl11/]["railway:signal:combined:states"!~/hl12b/]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:combined"="DE-ESO:hl"]["railway:signal:combined:form"=light]["railway:signal:combined:states"]["railway:signal:combined:states"=~/^(.*;)?DE-ESO:hl12a(;.*)?$/]["railway:signal:combined:states"=~/^(.*;)?DE-ESO:hl11(;.*)?$/]["railway:signal:combined:states"!~/^(.*;)?DE-ESO:hl12b(;.*)?$/]
 {
 	z-index: 10000;
 	text: "ref";
@@ -1371,7 +1371,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:combined"=
 /* - which cannot show Hp 0          */
 /* - which can show Sv 0             */
 /*************************************/
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:combined"="DE-ESO:sv"]["railway:signal:combined:states"!~/hp0/]["railway:signal:combined:states"=~/sv0/]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:combined"="DE-ESO:sv"]["railway:signal:combined:states"!~/^(.*;)?DE-ESO:hp0(;.*)?$/]["railway:signal:combined:states"=~/^(.*;)?DE-ESO:sv0(;.*)?$/]
 {
 	z-index: 10000;
 	text: "ref";
@@ -1434,7 +1434,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-
 /* DE combined light signals type Sv */
 /* - which can show Hp 0             */
 /*************************************/
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:combined"="DE-ESO:sv"]["railway:signal:combined:states"=~/hp0/]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:combined"="DE-ESO:sv"]["railway:signal:combined:states"=~/^(.*;)?DE-ESO:hp0(;.*)?$/]
 {
 	z-index: 10001;
 	text: "ref";


### PR DESCRIPTION
Make sure that the given signal state is an entire state and not just a random substring in the states. Also require states for DE-ESO signals to have DE-ESO: prefix.