### PR TITLE
add a Makefile containing a simple rule to check preset syntax

### DIFF
--- a/josm-presets/Makefile
+++ b/josm-presets/Makefile
@@ -1,0 +1,4 @@
+.phony: check
+
+check: *.xml
+	xmllint --noout *.xml


### PR DESCRIPTION
This will catch syntax errors like bad tag nesting.