### PR TITLE
presets: reorder the possible signal states to match the signal type

### DIFF
--- a/josm-presets/de-signals-eso.xml
+++ b/josm-presets/de-signals-eso.xml
@@ -1519,8 +1519,8 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<combo key="railway:signal:minor:states"
 						text="Displayed signals"
 						de.text="Angezeigte Signalbilder"
-						values="DE-ESO:sh0;DE-ESO:sh1,DE-ESO:hp0;DE-ESO:sh1,DE-ESO:hp0;DE-ESO:kennlicht"
-						display_values="Formsignal (Sh 0/Sh 1),Lichtsignal (Hp 0/Sh 1),Zugdeckungssignal (Hp 0/Kennlicht)"
+						values="DE-ESO:hp0;DE-ESO:sh1,DE-ESO:sh0;DE-ESO:sh1,DE-ESO:hp0;DE-ESO:kennlicht"
+						display_values="Lichtsignal (Hp 0/Sh 1),Formsignal (Sh 0/Sh 1),Zugdeckungssignal (Hp 0/Kennlicht)"
 						default=""
 						delete_if_empty="true" />
 					<space />


### PR DESCRIPTION
The signal type has light signals first, so offer the signal states for light
signals first, too.