### PR TITLE
German signal presets: reorder "off" in the list of possible states

### DIFF
--- a/josm-presets/de-signals-eso.xml
+++ b/josm-presets/de-signals-eso.xml
@@ -1873,9 +1873,9 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						de.text="Geschwindigkeit (km/h)"
 						delete_if_empty="true"
 						delimiter=";"
-						values="off;10;20;30;40;50;60;70;80;90;100;110;120;130;140;150;160;170;180;190;200;?"
-						display_values="off;10;20;30;40;50;60;70;80;90;100;110;120;130;140;150;160;170;180;190;200;unknown"
-						de.display_values="dunkel;10;20;30;40;50;60;70;80;90;100;110;120;130;140;150;160;170;180;190;200;unbekannt" />
+						values="10;20;30;40;50;60;70;80;90;100;110;120;130;140;150;160;170;180;190;200;off;?"
+						display_values="10;20;30;40;50;60;70;80;90;100;110;120;130;140;150;160;170;180;190;200;off;unknown"
+						de.display_values="10;20;30;40;50;60;70;80;90;100;110;120;130;140;150;160;170;180;190;200;dunkel;unbekannt" />
 					<combo key="railway:signal:speed_limit:height"
 						text="Signal height"
 						de.text="Signalbauform"
@@ -1924,9 +1924,9 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						de.text="Geschwindigkeit (km/h)"
 						delete_if_empty="true"
 						delimiter=";"
-						values="off;10;20;30;40;50;60;70;80;90;100;110;120;130;140;150;160;170;180;190;200;?"
-						display_values="off;10;20;30;40;50;60;70;80;90;100;110;120;130;140;150;160;170;180;190;200;unknown"
-						de.display_values="dunkel;10;20;30;40;50;60;70;80;90;100;110;120;130;140;150;160;170;180;190;200;unbekannt" />
+						values="10;20;30;40;50;60;70;80;90;100;110;120;130;140;150;160;170;180;190;200;off;?"
+						display_values="10;20;30;40;50;60;70;80;90;100;110;120;130;140;150;160;170;180;190;200;off;unknown"
+						de.display_values="10;20;30;40;50;60;70;80;90;100;110;120;130;140;150;160;170;180;190;200;dunkel;unbekannt" />
 					<combo key="railway:signal:speed_limit_distant:height"
 						text="Signal height"
 						de.text="Signalbauform"


### PR DESCRIPTION
The upcoming rendering and validator rules expect off to be at the end of the list, so make the presets add them there.