### PR TITLE
validator: correctly detect multiple states tagged for speed limit signs

### DIFF
--- a/validator/openrailwaymap.validator.mapcss
+++ b/validator/openrailwaymap.validator.mapcss
@@ -149,8 +149,8 @@ node[railway=signal]["railway:signal:minor_distant:form"=sign]["railway:signal:m
 node[railway=signal]["railway:signal:crossing:form"=sign]["railway:signal:crossing:states"],
 node[railway=signal]["railway:signal:crossing_distant:form"=sign]["railway:signal:crossing_distant:states"],
 node[railway=signal]["railway:signal:humping:form"=sign]["railway:signal:humping:states"],
-node[railway=signal]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:states"],
-node[railway=signal]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:states"],
+node[railway=signal]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=~/;/],
+node[railway=signal]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=~/;/],
 node[railway=signal]["railway:signal:route:form"=sign]["railway:signal:route:states"],
 node[railway=signal]["railway:signal:route_distant:form"=sign]["railway:signal:route_distant:states"],
 node[railway=signal]["railway:signal:wrong_road:form"=sign]["railway:signal:wrong_road:states"],
@@ -162,8 +162,10 @@ node[railway=signal]["railway:signal:brake_test:form"=sign]["railway:signal:brak
 {
 	throwError: "A sign cannot have different states.";
 	assertMatch: "node railway=signal railway:signal:main:states=hp0;hp1 railway:signal:main:form=sign";
+	assertMatch: "node railway=signal railway:signal:speed_limit:form=sign railway:signal:speed_limit:speed=80;90";
 	assertNoMatch: "node railway=signal railway:signal:main:states=hp0;hp1 railway:signal:main:form=semaphore";
 	assertNoMatch: "node railway=signal railway:signal:main:states=hp0;hp1 railway:signal:main:form=light";
+	assertNoMatch: "node railway=signal railway:signal:speed_limit:form=sign railway:signal:speed_limit:speed=80";
 }
 
 /* track numbers inside a station should be railway:track_ref, not name */


### PR DESCRIPTION
The tagging is different to most other signals, the states go into *:speed instead of *:states, and for those signals a sign may actually have exactly one "state".