### PR TITLE
Ne14/Blockkennzeichen

### DIFF
--- a/josm-presets/de-signals-eso.xml
+++ b/josm-presets/de-signals-eso.xml
@@ -2463,14 +2463,14 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					delete_if_empty="true" />
 			</item>
 			<item name="ETCS-Halt-Tafel (Ne 14, ETCS Stop Marker)" icon="etcs-stop-marker-arrow-left-32.png" type="node">
-				<label text="ETCS-Halt-Tafel (Ne14), auch bekannt als ETCS Stop Marker oder Blechrakete" />
-				<label text="Wird als Punkt auf dem Gleis erfasst." />
+				<label text="ETCS-Halt-Tafel (Ne14), auch bekannt als ETCS Stop Marker" />
+				<label text="Wird als Punkt auf dem Gleis erfasst. Steht am Hauptsignal oder virtuellem Signal (Level 2 ohne Signale)." />
 				<space />
 				<key key="railway"
 					value="signal" />
 				<text key="ref"
-					text="Block reference"
-					de.text="Blockbezeichner"
+					text="Signal ref"
+					de.text="Signalbezeichner"
 					default=""
 					delete_if_empty="true" />
 				<check key="railway:signal:train_protection:deactivated"
@@ -2499,8 +2499,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					delete_if_empty="true" />
 				<key key="railway:signal:train_protection"
 					value="DE-ESO:ne14" /> 
-				<key key="railway:signal:train_protection:type"
-					value="block_marker" />
 				<key key="railway:signal:train_protection:form"
 					value="sign" />
 			</item>
@@ -2682,9 +2680,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<item name="Blockkennzeichen" icon="de/blockkennzeichen-28.png" type="node">
 				<label text="Blockkennzeichen (ETCS/LZB)" />
 				<label text="Wird als Punkt auf dem Gleis erfasst." />
-				<space />
-				<label text="ETCS-Halt-Tafel (Ne 14)/Blechrakete siehe …" />
-				<preset_link preset_name="ETCS-Halt-Tafel (Ne 14, ETCS Stop Marker)" />
 				<space />
 				<key key="railway"
 					value="signal" />


### PR DESCRIPTION
A Blockkennzeichen is used with LZB or ETCS.

It does NOT have an Ne14.

The Ne14 is only used at virtual main signals.

A "Blechrakete" is a Zs10!