### PR TITLE
styles: display also those German Hl main and combined signals that do not have specific states

### DIFF
--- a/styles/signals.mapcss
+++ b/styles/signals.mapcss
@@ -1150,11 +1150,11 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-
 	allow-overlap: true;
 }
 
-/******************************************/
-/* DE main light signals type Hl which    */
-/*  - have no railway:signal:states=* tag */
-/******************************************/
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-ESO:hl"]["railway:signal:main:form"=light][!"railway:signal:main:states"]
+/**********************************************************************************/
+/* DE main light signals type Hl which                                            */
+/*  - have no railway:signal:main:states tag combination which has a special icon */
+/**********************************************************************************/
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-ESO:hl"]["railway:signal:main:form"=light]
 {
 	z-index: 10000;
 	text: "ref";
@@ -1257,11 +1257,11 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-
 	allow-overlap: true;
 }
 
-/*******************************************/
-/* DE combined light signals type Hl which */
-/*  - have no railway:signal:states=* tag  */
-/*******************************************/
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:combined"="DE-ESO:hl"]["railway:signal:combined:form"=light][!"railway:signal:combined:states"]
+/**************************************************************************************/
+/* DE combined light signals type Hl which                                            */
+/*  - have no railway:signal:combined:states tag combination which has a special icon */
+/**************************************************************************************/
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:combined"="DE-ESO:hl"]["railway:signal:combined:form"=light]
 {
 	z-index: 10000;
 	text: "ref";


### PR DESCRIPTION
There are rules for some special state combinations, and one for those signals
that have no states given. But signals which have states given, but none of
the special combination would not be rendered at all.

This should fix #301.