### PR TITLE
validator: drop rules for unprefixed German signals

### DIFF
--- a/validator/de-openrailwaymap.validator.mapcss
+++ b/validator/de-openrailwaymap.validator.mapcss
@@ -153,51 +153,42 @@ way[railway][workrules=BOA]
 }
 
 /* ks and hl signals only exist as light signals */
-node[railway=signal][railway:signal:main=ks][railway:signal:main:form!=light],
-node[railway=signal][railway:signal:distant=ks][railway:signal:distant:form!=light],
-node[railway=signal][railway:signal:combined=ks][railway:signal:combined:form!=light],
 node[railway=signal][railway:signal:main="DE-ESO:ks"][railway:signal:main:form!=light],
 node[railway=signal][railway:signal:distant="DE-ESO:ks"][railway:signal:distant:form!=light],
 node[railway=signal][railway:signal:combined="DE-ESO:ks"][railway:signal:combined:form!=light],
-node[railway=signal][railway:signal:main=hl][railway:signal:main:form!=light],
-node[railway=signal][railway:signal:distant=hl][railway:signal:distant:form!=light],
-node[railway=signal][railway:signal:combined=hl][railway:signal:combined:form!=light],
 node[railway=signal][railway:signal:main="DE-ESO:hl"][railway:signal:main:form!=light],
 node[railway=signal][railway:signal:distant="DE-ESO:hl"][railway:signal:distant:form!=light],
 node[railway=signal][railway:signal:combined="DE-ESO:hl"][railway:signal:combined:form!=light]
 {
 	throwError: "{1.value} signals only exist as light signals";
-	assertMatch: "node railway=signal railway:signal:main=ks";
-	assertMatch: "node railway=signal railway:signal:main=ks railway:signal:main:form=semaphore";
-	assertMatch: "node railway=signal railway:signal:main=hl";
-	assertMatch: "node railway=signal railway:signal:main=hl railway:signal:main:form=semaphore";
-	assertNoMatch: "node railway=signal railway:signal:main=hl railway:signal:main:form=light";
-	assertNoMatch: "node railway=signal railway:signal:main=ks railway:signal:main:form=light";
+	assertMatch: "node railway=signal railway:signal:main=DE-ESO:ks";
+	assertMatch: "node railway=signal railway:signal:main=DE-ESO:ks railway:signal:main:form=semaphore";
+	assertMatch: "node railway=signal railway:signal:main=DE-ESO:hl";
+	assertMatch: "node railway=signal railway:signal:main=DE-ESO:hl railway:signal:main:form=semaphore";
+	assertNoMatch: "node railway=signal railway:signal:main=DE-ESO:hl railway:signal:main:form=light";
+	assertNoMatch: "node railway=signal railway:signal:main=DE-ESO:ks railway:signal:main:form=light";
 	fixAdd: "{2.key}=light";
 }
 
 /* hp signals only exist as semaphore or light signals */
-node[railway=signal][railway:signal:main=hp][railway:signal:main:form!=light][railway:signal:main:form!=semaphore],
-node[railway=signal][railway:signal:distant=vr][railway:signal:distant:form!=light][railway:signal:distant:form!=semaphore],
 node[railway=signal][railway:signal:main="DE-ESO:hp"][railway:signal:main:form!=light][railway:signal:main:form!=semaphore],
 node[railway=signal][railway:signal:distant="DE-ESO:vr"][railway:signal:distant:form!=light][railway:signal:distant:form!=semaphore]
 {
 	throwError: "hp signals only exist as semaphore or light signals";
-	assertMatch: "node railway=signal railway:signal:main=hp";
-	assertMatch: "node railway=signal railway:signal:main=hp railway:signal:main:form=typo";
-	assertNoMatch: "node railway=signal railway:signal:main=hp railway:signal:main:form=semaphore";
-	assertNoMatch: "node railway=signal railway:signal:main=hp railway:signal:main:form=light";
+	assertMatch: "node railway=signal railway:signal:main=DE-ESO:hp";
+	assertMatch: "node railway=signal railway:signal:main=DE-ESO:hp railway:signal:main:form=typo";
+	assertNoMatch: "node railway=signal railway:signal:main=DE-ESO:hp railway:signal:main:form=semaphore";
+	assertNoMatch: "node railway=signal railway:signal:main=DE-ESO:hp railway:signal:main:form=light";
 }
 
 /* KVB combined hp signals only exist as light signals */
-node[railway=signal][railway:signal:combined=hp][railway:signal:combined:form!=light],
 node[railway=signal][railway:signal:combined="DE-KVB:hp"][railway:signal:combined:form!=light]
 {
 	throwError: "KVB hp signals only exist as light signals";
-	assertMatch: "node railway=signal railway:signal:combined=hp";
+	assertMatch: "node railway=signal railway:signal:combined=DE-KVB:hp";
 	assertMatch: "node railway=signal railway:signal:combined=DE-KVB:hp railway:signal:combined:form=typo";
-	assertMatch: "node railway=signal railway:signal:combined=hp railway:signal:combined:form=semaphore";
-	assertNoMatch: "node railway=signal railway:signal:combined=hp railway:signal:combined:form=light";
+	assertMatch: "node railway=signal railway:signal:combined=DE-KVB:hp railway:signal:combined:form=semaphore";
+	assertNoMatch: "node railway=signal railway:signal:combined=DE-KVB:hp railway:signal:combined:form=light";
 	assertNoMatch: "node railway=signal railway:signal:combined=DE-KVB:hp railway:signal:combined:form=light";
 }
 
@@ -240,15 +231,11 @@ node["railway:signal:main"="DE-ESO:hp"]["railway:signal:distant:repeated"="yes"]
 
 /* German Ks signals can't be distant and main at the same place */
 node["railway:signal:main"="DE-ESO:ks"]["railway:signal:distant"],
-node["railway:signal:main"="ks"]["railway:signal:distant"],
-node["railway:signal:main"]["railway:signal:distant"="DE-ESO:ks"],
-node["railway:signal:main"]["railway:signal:distant"="ks"]
+node["railway:signal:main"]["railway:signal:distant"="DE-ESO:ks"]
 {
 	throwError: "German Ks signals can't have main and distant signal at the same place, try a combined signal instead";
 	assertMatch: "node railway=signal railway:signal:main=DE-ESO:ks railway:signal:distant=DE-ESO:vr";
-	assertMatch: "node railway=signal railway:signal:main=ks railway:signal:distant=DE-ESO:vr";
 	assertMatch: "node railway=signal railway:signal:main=DE-ESO:hp railway:signal:distant=DE-ESO:ks";
-	assertMatch: "node railway=signal railway:signal:main=DE-ESO:hp railway:signal:distant=ks";
 	assertNoMatch: "node railway=signal railway:signal:distant=DE-ESO:vr railway:signal:main=DE-ESO:hp";
 	assertNoMatch: "node railway=signal railway:signal:combined=DE-ESO:ks railway:signal:minor=DE-ESO:sh1";
 }


### PR DESCRIPTION
Those signals will itself trigger a warning for not being prefixed, the more
specific errors can be catched if the prefix was added.