### PR TITLE
style: use higher z-index for milestones on full kilometers

### DIFF
--- a/styles/standard.mapcss
+++ b/styles/standard.mapcss
@@ -631,6 +631,10 @@ node|z11-[railway=milestone]
 	text-halo-radius: 0.5;
 	text-halo-color: white;
 }
+node|z11-[railway=milestone]["railway:position"=~/\.0$/]
+{
+	z-index: 601;
+}
 
 /************/
 /* stations */


### PR DESCRIPTION
In case all milestones are tagged those should give a better rendering as the full kilometers are more likely to appear.

This implements half of #276.