### PR TITLE
styles: detect missing icons in "make check"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+.phony: check
+
+PHP := php
+
+check-php: *.php api/*.php
+
+check:
+	for pf in $$(find . -name '*.php'); do \
+		$(PHP) -l $${pf} || exit 1; \
+	done
+	make -C josm-presets $@
+	make -C styles $@

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,8 @@ PHP := php
 check-php: *.php api/*.php
 
 check:
-	for pf in $$(find . -name '*.php'); do \
+	@for pf in $$(find . -name '*.php'); do \
 		$(PHP) -l $${pf} || exit 1; \
 	done
-	make -C josm-presets $@
-	make -C styles $@
+	@make -C josm-presets $@
+	@make -C styles $@

--- a/josm-presets/Makefile
+++ b/josm-presets/Makefile
@@ -1,4 +1,4 @@
 .phony: check
 
 check: *.xml
-	xmllint --noout *.xml
+	@xmllint --noout *.xml

--- a/styles/Makefile
+++ b/styles/Makefile
@@ -11,3 +11,10 @@ clean:
 	rm -f $(JSFILES)
 	rm -f $(patsubst %.js,%.png,$(JSFILES))
 	rm -f parsetab.py
+
+check: $(JSFILES)
+	if [ -n "`grep 'var external_images = ' $^ | grep -v 'var external_images = \[\];$$'`" ]; then \
+		echo "bad image references found:"; \
+		grep 'var external_images = ' $^ | grep -v 'var external_images = \[\];$$'; \
+		false; \
+	fi

--- a/styles/Makefile
+++ b/styles/Makefile
@@ -13,11 +13,11 @@ clean:
 	rm -f parsetab.py
 
 check: $(JSFILES)
-	if [ -n "`grep 'var external_images = ' $^ | grep -v 'var external_images = \[\];$$'`" ]; then \
+	@if [ -n "`grep 'var external_images = ' $^ | grep -v 'var external_images = \[\];$$'`" ]; then \
 		echo "bad image references found:"; \
-		grep 'var external_images = ' $^ | grep -v 'var external_images = \[\];$$'; \
+		@grep 'var external_images = ' $^ | grep -v 'var external_images = \[\];$$'; \
 		false; \
 	fi
-	for i in $(JSFILES); do \
+	@for i in $(JSFILES); do \
 		python -m json.tool < $${i}on > /dev/null || exit 1; \
 	done

--- a/styles/Makefile
+++ b/styles/Makefile
@@ -18,3 +18,6 @@ check: $(JSFILES)
 		grep 'var external_images = ' $^ | grep -v 'var external_images = \[\];$$'; \
 		false; \
 	fi
+	for i in $(JSFILES); do \
+		python -m json.tool < $${i}on > /dev/null || exit 1; \
+	done


### PR DESCRIPTION
The way OpenRailwayMap currently works there simply are no external icons. If something shows up there then an image link is broken and can be flagged as error.

While at it check for syntax errors in PHP files.