### PR TITLE
fix expression to match Zs3 and Zs3v light signals

### DIFF
--- a/styles/maxspeed.mapcss
+++ b/styles/maxspeed.mapcss
@@ -934,11 +934,12 @@ node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	allow-overlap: true;
 }
 /* German speed signals (Zs 3v) as light signals */
-node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:zs3v"]["railway:signal:speed_limit_distant:form"=light]["railway:signal:speed_limit_distant:speed"=~/^(1|2|3|4|5|6|7|8|9)0$/],
-node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:zs3v"]["railway:signal:speed_limit_distant:form"=light]["railway:signal:speed_limit_distant:speed"=~/^1(0|1|2)0$/]
+node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:zs3v"]["railway:signal:speed_limit_distant:form"=light]["railway:signal:speed_limit_distant:speed"=~/^(.*;)?(1|2|3|4|5|6|7|8|9)0(;.*)?$/],
+node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:zs3v"]["railway:signal:speed_limit_distant:form"=light]["railway:signal:speed_limit_distant:speed"=~/^(.*;)?1(0|1|2)0(;.*)?$/]
 {
 	z-index: eval(95 + tag("railway:signal:speed_limit_distant:speed")/2);
 }
+
 node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:zs3v"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=10]
 {
 	icon-image: "icons/de/zs3v-10-sign-down-44.png";
@@ -1091,8 +1092,8 @@ node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	allow-overlap: true;
 }
 /* German speed signals (Zs 3) as light signals*/
-node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:zs3"]["railway:signal:speed_limit:form"=light]["railway:signal:speed_limit:speed"=~/^(1|2|3|4|5|6|7|8|9)0$/],
-node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:zs3"]["railway:signal:speed_limit:form"=light]["railway:signal:speed_limit:speed"=~/^1(0|1|2)0$/]
+node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:zs3"]["railway:signal:speed_limit:form"=light]["railway:signal:speed_limit:speed"=~/^(.*;)?(1|2|3|4|5|6|7|8|9)0(;.*)?$/],
+node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:zs3"]["railway:signal:speed_limit:form"=light]["railway:signal:speed_limit:speed"=~/^(.*;)?1(0|1|2)0(;.*)?$/]
 {
 	z-index: eval(195 + tag("railway:signal:speed_limit:speed")/2);
 	icon-width: 14;


### PR DESCRIPTION
This would only match those signals that do only have a single state, so things like z-index were not set for signals with multiple states.