### PR TITLE
show deactivation cross for crossing and shunting signals on the correct zoom levels

### DIFF
--- a/styles/signals.mapcss
+++ b/styles/signals.mapcss
@@ -1644,12 +1644,12 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:combined"=
 node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main:deactivated"=yes]::deactivatedcross,
 node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant:deactivated"=yes]::deactivatedcross,
 node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:combined:deactivated"=yes]::deactivatedcross,
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:shunting:deactivated"=yes]::deactivatedcross,
+node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:shunting:deactivated"=yes]::deactivatedcross,
 /*node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main_repeated:deactivated"=yes]::deactivatedcross,*/
 node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:minor:deactivated"=yes]::deactivatedcross,
 /*node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:minor_distant:deactivated"=yes]::deactivatedcross,*/
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:crossing:deactivated"=yes]::deactivatedcross,
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:crossing_distant:deactivated"=yes]::deactivatedcross /*,
+node|z15-[railway=signal]["railway:signal:direction"]["railway:signal:crossing:deactivated"=yes]::deactivatedcross,
+node|z15-[railway=signal]["railway:signal:direction"]["railway:signal:crossing_distant:deactivated"=yes]::deactivatedcross /*,
 node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:humping:deactivated"=yes]::deactivatedcross,
 node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:route:deactivated"=yes]::deactivatedcross,
 node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:route_distant:deactivated"=yes]::deactivatedcross,


### PR DESCRIPTION
The signals itself would only be shown on level 15 or 17.

This fixes #390.