### PR TITLE
maxspeed style: fix z-index for German Zs3 light signals

### DIFF
--- a/styles/maxspeed.mapcss
+++ b/styles/maxspeed.mapcss
@@ -933,13 +933,6 @@ node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	icon-height: 19;
 	allow-overlap: true;
 }
-/* German speed signals (Zs 3v) as light signals */
-node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:zs3v"]["railway:signal:speed_limit_distant:form"=light]["railway:signal:speed_limit_distant:speed"=~/^(.*;)?(1|2|3|4|5|6|7|8|9)0(;.*)?$/],
-node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:zs3v"]["railway:signal:speed_limit_distant:form"=light]["railway:signal:speed_limit_distant:speed"=~/^(.*;)?1(0|1|2)0(;.*)?$/]
-{
-	z-index: eval(95 + tag("railway:signal:speed_limit_distant:speed")/2);
-}
-
 node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:zs3v"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=10]
 {
 	icon-image: "icons/de/zs3v-10-sign-down-44.png";
@@ -948,8 +941,10 @@ node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 {
 	icon-image: "icons/de/zs3v-20-sign-down-44.png";
 }
+/* German speed signals (Zs 3v) as light signals */
 node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:zs3v"]["railway:signal:speed_limit_distant:form"=light]["railway:signal:speed_limit_distant:speed"~=20]
 {
+	z-index: 105;
 	icon-image: "icons/de/zs3v-20-light-38.png";
 	icon-width: 14;
 	icon-height: 19;
@@ -961,6 +956,7 @@ node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 }
 node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:zs3v"]["railway:signal:speed_limit_distant:form"=light]["railway:signal:speed_limit_distant:speed"~=30]
 {
+	z-index: 110;
 	icon-image: "icons/de/zs3v-30-light-38.png";
 	icon-width: 14;
 	icon-height: 19;
@@ -972,6 +968,7 @@ node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 }
 node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:zs3v"]["railway:signal:speed_limit_distant:form"=light]["railway:signal:speed_limit_distant:speed"~=40]
 {
+	z-index: 115;
 	icon-image: "icons/de/zs3v-40-light-38.png";
 	icon-width: 14;
 	icon-height: 19;
@@ -983,6 +980,7 @@ node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 }
 node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:zs3v"]["railway:signal:speed_limit_distant:form"=light]["railway:signal:speed_limit_distant:speed"~=50]
 {
+	z-index: 120;
 	icon-image: "icons/de/zs3v-50-light-38.png";
 	icon-width: 14;
 	icon-height: 19;
@@ -994,6 +992,7 @@ node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 }
 node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:zs3v"]["railway:signal:speed_limit_distant:form"=light]["railway:signal:speed_limit_distant:speed"~=60]
 {
+	z-index: 125;
 	icon-image: "icons/de/zs3v-60-light-38.png";
 	icon-width: 14;
 	icon-height: 19;
@@ -1005,6 +1004,7 @@ node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 }
 node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:zs3v"]["railway:signal:speed_limit_distant:form"=light]["railway:signal:speed_limit_distant:speed"~=70]
 {
+	z-index: 130;
 	icon-image: "icons/de/zs3v-70-light-38.png";
 	icon-width: 14;
 	icon-height: 19;
@@ -1016,6 +1016,7 @@ node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 }
 node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:zs3v"]["railway:signal:speed_limit_distant:form"=light]["railway:signal:speed_limit_distant:speed"~=80]
 {
+	z-index: 135;
 	icon-image: "icons/de/zs3v-80-light-38.png";
 	icon-width: 14;
 	icon-height: 19;
@@ -1027,6 +1028,7 @@ node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 }
 node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:zs3v"]["railway:signal:speed_limit_distant:form"=light]["railway:signal:speed_limit_distant:speed"~=90]
 {
+	z-index: 140;
 	icon-image: "icons/de/zs3v-90-light-38.png";
 	icon-width: 14;
 	icon-height: 19;
@@ -1038,6 +1040,7 @@ node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 }
 node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:zs3v"]["railway:signal:speed_limit_distant:form"=light]["railway:signal:speed_limit_distant:speed"~=100]
 {
+	z-index: 145;
 	icon-image: "icons/de/zs3v-100-light-38.png";
 	icon-width: 14;
 	icon-height: 19;
@@ -1049,6 +1052,7 @@ node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 }
 node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:zs3v"]["railway:signal:speed_limit_distant:form"=light]["railway:signal:speed_limit_distant:speed"~=110]
 {
+	z-index: 150;
 	icon-image: "icons/de/zs3v-110-light-38.png";
 	icon-width: 14;
 	icon-height: 19;
@@ -1060,6 +1064,7 @@ node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 }
 node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:zs3v"]["railway:signal:speed_limit_distant:form"=light]["railway:signal:speed_limit_distant:speed"~=120]
 {
+	z-index: 155;
 	icon-image: "icons/de/zs3v-120-light-38.png";
 	icon-width: 14;
 	icon-height: 19;
@@ -1091,15 +1096,6 @@ node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	icon-height: 19;
 	allow-overlap: true;
 }
-/* German speed signals (Zs 3) as light signals*/
-node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:zs3"]["railway:signal:speed_limit:form"=light]["railway:signal:speed_limit:speed"=~/^(.*;)?(1|2|3|4|5|6|7|8|9)0(;.*)?$/],
-node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:zs3"]["railway:signal:speed_limit:form"=light]["railway:signal:speed_limit:speed"=~/^(.*;)?1(0|1|2)0(;.*)?$/]
-{
-	z-index: eval(195 + tag("railway:signal:speed_limit:speed")/2);
-	icon-width: 14;
-	icon-height: 19;
-	allow-overlap: true;
-}
 node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:zs3"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=10]
 {
 	icon-image: "icons/de/zs3-10-sign-up-44.png";
@@ -1108,8 +1104,10 @@ node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 {
 	icon-image: "icons/de/zs3-20-sign-up-44.png";
 }
+/* German speed signals (Zs 3) as light signals*/
 node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:zs3"]["railway:signal:speed_limit:form"=light]["railway:signal:speed_limit:speed"~=20]
 {
+	z-index: 205;
 	icon-image: "icons/de/zs3-20-light-38.png";
 	icon-width: 14;
 	icon-height: 19;
@@ -1121,6 +1119,7 @@ node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 }
 node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:zs3"]["railway:signal:speed_limit:form"=light]["railway:signal:speed_limit:speed"~=30]
 {
+	z-index: 210;
 	icon-image: "icons/de/zs3-30-light-38.png";
 	icon-width: 14;
 	icon-height: 19;
@@ -1132,6 +1131,7 @@ node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 }
 node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:zs3"]["railway:signal:speed_limit:form"=light]["railway:signal:speed_limit:speed"~=40]
 {
+	z-index: 215;
 	icon-image: "icons/de/zs3-40-light-38.png";
 	icon-width: 14;
 	icon-height: 19;
@@ -1143,6 +1143,7 @@ node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 }
 node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:zs3"]["railway:signal:speed_limit:form"=light]["railway:signal:speed_limit:speed"~=50]
 {
+	z-index: 220;
 	icon-image: "icons/de/zs3-50-light-38.png";
 	icon-width: 14;
 	icon-height: 19;
@@ -1154,6 +1155,7 @@ node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 }
 node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:zs3"]["railway:signal:speed_limit:form"=light]["railway:signal:speed_limit:speed"~=60]
 {
+	z-index: 225;
 	icon-image: "icons/de/zs3-60-light-38.png";
 	icon-width: 14;
 	icon-height: 19;
@@ -1165,6 +1167,7 @@ node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 }
 node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:zs3"]["railway:signal:speed_limit:form"=light]["railway:signal:speed_limit:speed"~=70]
 {
+	z-index: 230;
 	icon-image: "icons/de/zs3-70-light-38.png";
 	icon-width: 14;
 	icon-height: 19;
@@ -1176,6 +1179,7 @@ node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 }
 node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:zs3"]["railway:signal:speed_limit:form"=light]["railway:signal:speed_limit:speed"~=80]
 {
+	z-index: 235;
 	icon-image: "icons/de/zs3-80-light-38.png";
 	icon-width: 14;
 	icon-height: 19;
@@ -1187,6 +1191,7 @@ node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 }
 node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:zs3"]["railway:signal:speed_limit:form"=light]["railway:signal:speed_limit:speed"~=90]
 {
+	z-index: 240;
 	icon-image: "icons/de/zs3-90-light-38.png";
 	icon-width: 14;
 	icon-height: 19;
@@ -1198,6 +1203,7 @@ node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 }
 node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:zs3"]["railway:signal:speed_limit:form"=light]["railway:signal:speed_limit:speed"~=100]
 {
+	z-index: 245;
 	icon-image: "icons/de/zs3-100-light-38.png";
 	icon-width: 14;
 	icon-height: 19;
@@ -1209,6 +1215,7 @@ node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 }
 node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:zs3"]["railway:signal:speed_limit:form"=light]["railway:signal:speed_limit:speed"~=110]
 {
+	z-index: 250;
 	icon-image: "icons/de/zs3-110-light-38.png";
 	icon-width: 14;
 	icon-height: 19;
@@ -1220,6 +1227,7 @@ node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 }
 node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:zs3"]["railway:signal:speed_limit:form"=light]["railway:signal:speed_limit:speed"~=120]
 {
+	z-index: 255;
 	icon-image: "icons/de/zs3-120-light-38.png";
 	icon-width: 14;
 	icon-height: 19;


### PR DESCRIPTION
While the cond() works fine for Zs3 signs, it often does not work for light signals. Those are matched using ~= operator, which means the railway:signal:speed_limit_distant:speed does usually contain more than just the matched speed value. This can't be used for a simple addition, so explicitely state the z-index value.