### PR TITLE
clean up JOSM templates and improve verification

### DIFF
--- a/josm-presets/Makefile
+++ b/josm-presets/Makefile
@@ -1,4 +1,4 @@
 .phony: check
 
 check: *.xml
-	@xmllint --noout *.xml
+	@xmllint --schema http://josm.openstreetmap.de/tagging-preset-1.0 --noout *.xml

--- a/josm-presets/at-signals-v2.xml
+++ b/josm-presets/at-signals-v2.xml
@@ -23,26 +23,26 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				text="Signal ref"
 				de.text="Signalbezeichnung"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<check key="railway:signal:main:deactivated"
 				text="Out of order"
 				de.text="Ungültigkeitskreuz"
 				default="off"
-				delete_if_empty="true" />
+				/>
 			<combo key="railway:signal:position"
 				text="Signal position"
 				de.text="Signalstandort"
 				values="left,right,bridge"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<combo key="railway:signal:direction"
 				text="Direction"
 				de.text="Anzeigerichtung"
 				values="forward,backward"
 				display_values="In Wegrichtung,Entgegen Wegrichtung"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<space />
 			<key key="railway:signal:main"
 				value="AT-V2:hauptsignal" />
@@ -54,28 +54,28 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				values="normal,dwarf"
 				display_values="Mastbauform,Zwergsignal"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<multiselect key="railway:signal:main:states"
 				text="Signal states (multi-selection)"
 				de.text="Signalzustände (Mehrfachauswahl)"
 				delimiter=";"
 				values="AT-V2:halt;AT-V2:frei;AT-V2:frei_mit_40;AT-V2:frei_mit_20"
 				display_values="Halt;Frei;Frei mit 40 km/h;Frei mit 20 km/h"
-				delete_if_empty="true" />
+				/>
 			<combo key="railway:signal:main:function"
 				text="Signal function"
 				de.text="Signalaufgabe"
 				values="entry,exit,block,intermediate"
 				display_values="Einfahrsignal,Ausfahrsignal,Blocksignal,Zwischensignal"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<multiselect key="railway:signal:main:substitute_signal"
 				text="Substitute signal (multi-selection)"
 				de.text="Ersatzsignal (Mehrfachauswahl)"
 				delimiter=";"
 				values="AT-V2:ersatzsignal;AT-V2:vorsichtssignal"
 				display_values="Ersatzsignal;Vorsichtssignal"
-				delete_if_empty="true" />
+				/>
 			<space />
 			<preset_link preset_name="Geschwindigkeitsanzeiger" />
 			<preset_link preset_name="Geschwindigkeitsvoranzeiger" />
@@ -92,26 +92,26 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				text="Signal ref"
 				de.text="Signalbezeichnung"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<check key="railway:signal:main:deactivated"
 				text="Out of order"
 				de.text="Ungültigkeitskreuz"
 				default="off"
-				delete_if_empty="true" />
+				/>
 			<combo key="railway:signal:position"
 				text="Signal position"
 				de.text="Signalstandort"
 				values="left,right,bridge"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<combo key="railway:signal:direction"
 				text="Direction"
 				de.text="Anzeigerichtung"
 				values="forward,backward"
 				display_values="In Wegrichtung,Entgegen Wegrichtung"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<space />
 			<key key="railway:signal:main"
 				value="AT-V2:hauptsignal" />
@@ -123,28 +123,28 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				values="normal,dwarf"
 				display_values="Mastbauform,Zwergsignal"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<multiselect key="railway:signal:main:states"
 				text="Signal states (multi-selection)"
 				de.text="Signalzustände (Mehrfachauswahl)"
 				delimiter=";"
 				values="AT-V2:halt;AT-V2:frei;AT-V2:frei_mit_60;AT-V2:frei_mit_40;AT-V2:frei_mit_20"
 				display_values="Halt;Frei;Frei mit 60 km/h;Frei mit 40 km/h;Frei mit 20 km/h"
-				delete_if_empty="true" />
+				/>
 			<combo key="railway:signal:main:function"
 				text="Signal function"
 				de.text="Signalaufgabe"
 				values="entry,exit,block,intermediate"
 				display_values="Einfahrsignal,Ausfahrsignal,Blocksignal,Zwischensignal"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<multiselect key="railway:signal:main:substitute_signal"
 				text="Substitute signal (multi-selection)"
 				de.text="Ersatzsignal (Mehrfachauswahl)"
 				delimiter=";"
 				values="AT-V2:ersatzsignal;AT-V2:vorsichtssignal"
 				display_values="Ersatzsignal;Vorsichtssignal"
-				delete_if_empty="true" />
+				/>
 			<space />
 			<preset_link preset_name="Lichtvorsignal" />
 			<preset_link preset_name="Geschwindigkeitsanzeiger" />
@@ -163,26 +163,26 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				text="Signal ref"
 				de.text="Signalbezeichnung"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<check key="railway:signal:distant:deactivated"
 				text="Out of order"
 				de.text="Ungültigkeitskreuz"
 				default="off"
-				delete_if_empty="true" />
+				/>
 			<combo key="railway:signal:position"
 				text="Signal position"
 				de.text="Signalstandort"
 				values="left,right,bridge"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<combo key="railway:signal:direction"
 				text="Direction"
 				de.text="Anzeigerichtung"
 				values="forward,backward"
 				display_values="In Wegrichtung,Entgegen Wegrichtung"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<space />
 			<key key="railway:signal:distant"
 				value="AT-V2:vorsignal" />
@@ -194,7 +194,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				values="normal,dwarf"
 				display_values="Mastbauform,Zwergsignal"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<key key="railway:signal:distant:states"
 				value="AT-V2:vorsicht;AT-V2:hauptsignal_frei" />
 			<space />
@@ -210,26 +210,26 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				text="Signal ref"
 				de.text="Signalbezeichnung"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<check key="railway:signal:distant:deactivated"
 				text="Out of order"
 				de.text="Ungültigkeitskreuz"
 				default="off"
-				delete_if_empty="true" />
+				/>
 			<combo key="railway:signal:position"
 				text="Signal position"
 				de.text="Signalstandort"
 				values="left,right,bridge"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<combo key="railway:signal:direction"
 				text="Direction"
 				de.text="Anzeigerichtung"
 				values="forward,backward"
 				display_values="In Wegrichtung,Entgegen Wegrichtung"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<space />
 			<key key="railway:signal:distant"
 				value="AT-V2:vorsignal" />
@@ -241,13 +241,13 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				values="normal,dwarf"
 				display_values="Mastbauform,Zwergsignal"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<multiselect key="railway:signal:distant:states"
 				text="Signal states (multi-selection)"
 				de.text="Signalzustände (Mehrfachauswahl)"
 				delimiter=";"
 				values="AT-V2:vorsicht;AT-V2:hauptsignal_frei;AT-V2:hauptsignal_frei_mit_60;AT-V2:hauptsignal_frei_mit_40"
-				delete_if_empty="true" />
+				/>
 			<space />
 			<preset_link preset_name="Geschwindigkeitsvoranzeiger" />
 		</item>
@@ -262,21 +262,21 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				text="Out of order"
 				de.text="Ungültigkeitskreuz"
 				default="off"
-				delete_if_empty="true" />
+				/>
 			<combo key="railway:signal:position"
 				text="Signal position"
 				de.text="Signalstandort"
 				values="left,right,bridge"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<combo key="railway:signal:direction"
 				text="Direction"
 				de.text="Anzeigerichtung"
 				values="forward,backward"
 				display_values="In Wegrichtung,Entgegen Wegrichtung"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<space />
 			<key key="railway:signal:main"
 				value="AT-V2:trapeztafel" />
@@ -288,7 +288,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				values="normal,dwarf"
 				display_values="Normalhöhe,Zwergsignal"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<key key="railway:signal:main:function"
 				value="entry" />
 		</item>
@@ -302,21 +302,21 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				text="Out of order"
 				de.text="Ungültigkeitskreuz"
 				default="off"
-				delete_if_empty="true" />
+				/>
 			<combo key="railway:signal:position"
 				text="Signal position"
 				de.text="Signalstandort"
 				values="left,right,bridge"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<combo key="railway:signal:direction"
 				text="Direction"
 				de.text="Anzeigerichtung"
 				values="forward,backward"
 				display_values="In Wegrichtung,Entgegen Wegrichtung"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<space />
 			<key key="railway:signal:distant"
 				value="AT-V2:kreuztafel" />
@@ -334,26 +334,26 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				text="Signal ref"
 				de.text="Signalbezeichnung"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<check key="railway:signal:minor:deactivated"
 				text="Out of order"
 				de.text="Ungültigkeitskreuz"
 				default="off"
-				delete_if_empty="true" />
+				/>
 			<combo key="railway:signal:position"
 				text="Signal position"
 				de.text="Signalstandort"
 				values="left,right,bridge,in_track"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke,Gleismitte/am Prellbock"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<combo key="railway:signal:direction"
 				text="Direction"
 				de.text="Anzeigerichtung"
 				values="forward,backward"
 				display_values="In Wegrichtung,Entgegen Wegrichtung"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<space />
 			<key key="railway:signal:minor"
 				value="AT-V2:schutzsignal" />
@@ -365,7 +365,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				values="normal,dwarf"
 				display_values="Mastbauform,Zwergsignal"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<key key="railway:signal:minor:states"
 				value="AT:fahrverbot;AT:fahrverbot_aufgehoben" />
 			<multiselect key="railway:signal:minor:substitute_signal"
@@ -374,7 +374,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				delimiter=";"
 				values="AT-V2:ersatzsignal;AT-V2:vorsichtssignal"
 				display_values="Ersatzsignal;Vorsichtssignal"
-				delete_if_empty="true" />
+				/>
 			<space />
 			<preset_link preset_name="Geschwindigkeitsanzeiger" />
 			<preset_link preset_name="Geschwindigkeitsvoranzeiger" />
@@ -391,26 +391,26 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				text="Signal ref"
 				de.text="Signalbezeichnung"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<check key="railway:signal:minor:deactivated"
 				text="Out of order"
 				de.text="Ungültigkeitskreuz"
 				default="off"
-				delete_if_empty="true" />
+				/>
 			<combo key="railway:signal:position"
 				text="Signal position"
 				de.text="Signalstandort"
 				values="left,right,in_track"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Gleismitte/am Prellbock"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<combo key="railway:signal:direction"
 				text="Direction"
 				de.text="Anzeigerichtung"
 				values="forward,backward"
 				display_values="In Wegrichtung,Entgegen Wegrichtung"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<space />
 			<key key="railway:signal:minor"
 				value="AT-V2:sperrsignal" />
@@ -424,7 +424,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				values="normal,dwarf"
 				default=""
 				display_values="Mastbauform,Zwergsignal"
-				delete_if_empty="true" />
+				/>
 		</item>
 		<item name="Sperrsignal, fix" type="node">
 			<label text="Sperrsignal, fix" />
@@ -436,26 +436,26 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				text="Signal ref"
 				de.text="Signalbezeichnung"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<check key="railway:signal:minor:deactivated"
 				text="Out of order"
 				de.text="Ungültigkeitskreuz"
 				default="off"
-				delete_if_empty="true" />
+				/>
 			<combo key="railway:signal:position"
 				text="Signal position"
 				de.text="Signalstandort"
 				values="left,right,in_track"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Gleismitte/am Prellbock"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<combo key="railway:signal:direction"
 				text="Direction"
 				de.text="Anzeigerichtung"
 				values="forward,backward,both"
 				display_values="In Wegrichtung,Entgegen Wegrichtung,Beide Richtungen"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<space />
 			<key key="railway:signal:minor"
 				value="AT-V2:weiterfahrt_verboten" />
@@ -467,7 +467,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				values="normal,dwarf"
 				default=""
 				display_values="Mastbauform,Zwergsignal"
-				delete_if_empty="true" />
+				/>
 		</item>
 		<item name="Haltscheibe" icon="de-sh2.png" type="node">
 			<label text="Haltscheibe" />
@@ -479,21 +479,21 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				text="Out of order"
 				de.text="Ungültigkeitskreuz"
 				default="off"
-				delete_if_empty="true" />
+				/>
 			<combo key="railway:signal:position"
 				text="Signal position"
 				de.text="Signalstandort"
 				values="left,right,in_track"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Gleismitte/am Prellbock"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<combo key="railway:signal:direction"
 				text="Direction"
 				de.text="Anzeigerichtung"
 				values="forward,backward"
 				display_values="In Wegrichtung,Entgegen Wegrichtung"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<space />
 			<key key="railway:signal:minor"
 				value="AT-V2:haltscheibe" />
@@ -505,7 +505,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				values="normal,dwarf"
 				default=""
 				display_values="Mastbauform,Zwergsignal"
-				delete_if_empty="true" />
+				/>
 		</item>
 		<separator />
 		<group name="Verschubsignale">
@@ -519,26 +519,26 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Signal ref"
 					de.text="Signalbezeichnung"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<check key="railway:signal:shunting:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
 					de.text="Signalstandort"
 					values="left,right"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:signal:direction"
 					text="Direction"
 					de.text="Anzeigerichtung"
 					values="forward,backward"
 					display_values="In Wegrichtung,Entgegen Wegrichtung"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<key key="railway:signal:shunting"
 					value="AT-V2:verschubsignal" />
@@ -552,7 +552,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="normal,dwarf"
 					default=""
 					display_values="Mastbauform,Zwergsignal"
-					delete_if_empty="true" />
+					/>
 			</item>
 			<item name="Verschubhalttafel" type="node">
 				<label text="Verschubhalttafel" />
@@ -564,21 +564,21 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
 					de.text="Signalstandort"
 					values="left,right"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:signal:direction"
 					text="Direction"
 					de.text="Anzeigerichtung"
 					values="forward,backward"
 					display_values="In Wegrichtung,Entgegen Wegrichtung"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<key key="railway:signal:shunting"
 					value="AT-V2:verschubhalttafel" />
@@ -590,7 +590,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="normal,dwarf"
 					display_values="Mastbauform,Zwergsignal"
 					default=""
-					delete_if_empty="true" />
+					/>
 			</item>
 			<item name="Wartesignal (Tafel)" type="node">
 				<label text="Wartesignal (Tafel)" />
@@ -602,21 +602,21 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
 					de.text="Signalstandort"
 					values="left,right"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:signal:direction"
 					text="Direction"
 					de.text="Anzeigerichtung"
 					values="forward,backward"
 					display_values="In Wegrichtung,Entgegen Wegrichtung"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<key key="railway:signal:shunting"
 					value="AT-V2:wartesignal" />
@@ -628,7 +628,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="normal,dwarf"
 					default=""
 					display_values="Mastbauform,Zwergsignal"
-					delete_if_empty="true" />
+					/>
 			</item>
 			<item name="Wartesignal (Lichtsignal)" type="node">
 				<label text="Wartesignal (Lichtsignal)" />
@@ -640,21 +640,21 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
 					de.text="Signalstandort"
 					values="left,right"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:signal:direction"
 					text="Direction"
 					de.text="Anzeigerichtung"
 					values="forward,backward"
 					display_values="In Wegrichtung,Entgegen Wegrichtung"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<key key="railway:signal:shunting"
 					value="AT-V2:wartesignal" />
@@ -668,7 +668,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="normal,dwarf"
 					default=""
 					display_values="Mastbauform,Zwergsignal"
-					delete_if_empty="true" />
+					/>
 			</item>
 			<item name="Abdrücksignal" type="node">
 				<label text="Abdrücksignal" />
@@ -680,21 +680,21 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
 					de.text="Signalstandort"
 					values="left,right"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:signal:direction"
 					text="Direction"
 					de.text="Anzeigerichtung"
 					values="forward,backward"
 					display_values="In Wegrichtung,Entgegen Wegrichtung"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<key key="railway:signal:humping"
 					value="AT-V2:abdrücksignal" />
@@ -708,7 +708,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="normal,dwarf"
 					display_values="Mastbauform,Zwergsignal"
 					default=""
-					delete_if_empty="true" />
+					/>
 			</item>
 		</group>
 		<separator />
@@ -722,21 +722,21 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				text="Out of order"
 				de.text="Ungültigkeitskreuz"
 				default="off"
-				delete_if_empty="true" />
+				/>
 			<combo key="railway:signal:position"
 				text="Signal position"
 				de.text="Signalstandort"
 				values="left,right,bridge"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<combo key="railway:signal:direction"
 				text="Direction"
 				de.text="Anzeigerichtung"
 				values="forward,backward"
 				display_values="In Wegrichtung,Entgegen Wegrichtung"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<space />
 			<key key="railway:signal:speed_limit"
 				value="AT-V2:geschwindigkeitsanzeiger" />
@@ -746,11 +746,10 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				values="light,sign"
 				display_values="Lichtsignal,Tafel"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<combo key="railway:signal:speed_limit:speed" default=""
 				text="Speed (km/h, in case of light signals separate the possible values (number or 'off') with ';')"
 				de.text="Geschwindigkeit (km/h, bei Lichtsignalen mögliche Werte (Zahl oder 'off') mit ';' trennen)"
-				delete_if_empty="true"
 				values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,?"
 				display_values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,unknown"
 				de.display_values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,unbekannt" />
@@ -760,7 +759,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				values="normal,dwarf"
 				default=""
 				display_values="Mastbauform,Zwergsignal"
-				delete_if_empty="true" />
+				/>
 		</item>
 		<item name="Geschwindigkeitsvoranzeiger" type="node">
 			<label text="Geschwindigkeitsvoranzeiger" />
@@ -772,21 +771,21 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				text="Out of order"
 				de.text="Ungültigkeitskreuz"
 				default="off"
-				delete_if_empty="true" />
+				/>
 			<combo key="railway:signal:position"
 				text="Signal position"
 				de.text="Signalstandort"
 				values="left,right,bridge"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<combo key="railway:signal:direction"
 				text="Direction"
 				de.text="Anzeigerichtung"
 				values="forward,backward"
 				display_values="In Wegrichtung,Entgegen Wegrichtung"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<space />
 			<key key="railway:signal:speed_limit_distant"
 				value="AT-V2:geschwindigkeitvorsanzeiger" />
@@ -796,11 +795,10 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				values="light,sign"
 				display_values="Lichtsignal,Tafel"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<combo key="railway:signal:speed_limit_distant:speed" default=""
 				text="Speed (km/h, in case of light signals separate the possible values(number or 'off') with ';')"
 				de.text="Geschwindigkeit (km/h, bei Lichtsignalen mögliche Werte (Zahl oder 'off') mit ';' trennen)"
-				delete_if_empty="true"
 				values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,?"
 				display_values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,unknown"
 				de.display_values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,unbekannt" />
@@ -810,7 +808,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				values="normal,dwarf"
 				default=""
 				display_values="Mastbauform,Zwergsignal"
-				delete_if_empty="true" />
+				/>
 		</item>
 		<item name="Geschwindigkeitstafel" type="node">
 			<label text="Geschwindigkeitstafel" />
@@ -822,21 +820,21 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				text="Out of order"
 				de.text="Ungültigkeitskreuz"
 				default="off"
-				delete_if_empty="true" />
+				/>
 			<combo key="railway:signal:position"
 				text="Signal position"
 				de.text="Signalstandort"
 				values="left,right,bridge"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<combo key="railway:signal:direction"
 				text="Direction"
 				de.text="Anzeigerichtung"
 				values="forward,backward"
 				display_values="In Wegrichtung,Entgegen Wegrichtung"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<space />
 			<key key="railway:signal:speed_limit"
 				value="AT-V2:geschwindigkeitstafel" />
@@ -848,11 +846,10 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				values="light,sign"
 				display_values="Lichtsignal,Tafel"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<combo key="railway:signal:speed_limit:speed" default=""
 				text="Speed (km/h, in case of light signals separate the possible values (number or 'off') with ';')"
 				de.text="Geschwindigkeit (km/h, bei Lichtsignalen mögliche Werte (Zahl oder 'off') mit ';' trennen)"
-				delete_if_empty="true"
 				values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200"
 				display_values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200" />
 			<combo key="railway:signal:speed_limit:height"
@@ -861,7 +858,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				values="normal,dwarf"
 				default=""
 				display_values="Mastbauform,Zwergsignal"
-				delete_if_empty="true" />
+				/>
 		</item>
 		<item name="Ankündigungstafel" type="node">
 			<label text="Ankündigungstafel" />
@@ -873,21 +870,21 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				text="Out of order"
 				de.text="Ungültigkeitskreuz"
 				default="off"
-				delete_if_empty="true" />
+				/>
 			<combo key="railway:signal:position"
 				text="Signal position"
 				de.text="Signalstandort"
 				values="left,right,bridge"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<combo key="railway:signal:direction"
 				text="Direction"
 				de.text="Anzeigerichtung"
 				values="forward,backward"
 				display_values="In Wegrichtung,Entgegen Wegrichtung"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<space />
 			<key key="railway:signal:speed_limit_distant"
 				value="AT-V2:ankündigungstafel" />
@@ -896,7 +893,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<combo key="railway:signal:speed_limit_distant:speed" default=""
 				text="Speed (km/h, in case of light signals separate the possible values(number or 'off') with ';')"
 				de.text="Geschwindigkeit (km/h, bei Lichtsignalen mögliche Werte (Zahl oder 'off') mit ';' trennen)"
-				delete_if_empty="true"
 				values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200"
 				display_values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200" />
 			<combo key="railway:signal:speed_limit_distant:height"
@@ -905,7 +901,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				values="normal,dwarf"
 				default=""
 				display_values="Mastbauform,Zwergsignal"
-				delete_if_empty="true" />
+				/>
 		</item>
 		<group name="Langsamfahrsignale">
 			<item name="Ankündigungssignal" type="node">
@@ -918,21 +914,21 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
 					de.text="Signalstandort"
 					values="left,right,bridge"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:signal:direction"
 					text="Direction"
 					de.text="Anzeigerichtung"
 					values="forward,backward"
 					display_values="In Wegrichtung,Entgegen Wegrichtung"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<key key="railway:signal:speed_limit_distant"
 					value="AT-V2:ankündigungssignal" />
@@ -941,7 +937,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<combo key="railway:signal:speed_limit_distant:speed" default=""
 					text="Speed (km/h, in case of light signals separate the possible values(number or 'off') with ';')"
 					de.text="Geschwindigkeit (km/h, bei Lichtsignalen mögliche Werte (Zahl oder 'off') mit ';' trennen)"
-					delete_if_empty="true"
 					values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200"
 					display_values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200" />
 				<combo key="railway:signal:speed_limit_distant:height"
@@ -950,7 +945,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="normal,dwarf"
 					default=""
 					display_values="Mastbauform,Zwergsignal"
-					delete_if_empty="true" />
+					/>
 			</item>
 			<item name="Anfangssignal" type="node">
 				<label text="Anfangssignal" />
@@ -962,21 +957,21 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
 					de.text="Signalstandort"
 					values="left,right,bridge"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:signal:direction"
 					text="Direction"
 					de.text="Anzeigerichtung"
 					values="forward,backward"
 					display_values="In Wegrichtung,Entgegen Wegrichtung"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<key key="railway:signal:speed_limit"
 					value="AT-V2:anfangssignal" />
@@ -985,7 +980,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<combo key="railway:signal:speed_limit:speed" default=""
 					text="Speed (km/h, in case of light signals separate the possible values (number or 'off') with ';')"
 					de.text="Geschwindigkeit (km/h, bei Lichtsignalen mögliche Werte (Zahl oder 'off') mit ';' trennen)"
-					delete_if_empty="true"
 					values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200"
 					display_values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200" />
 				<combo key="railway:signal:speed_limit:height"
@@ -994,7 +988,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="normal,dwarf"
 					default=""
 					display_values="Mastbauform,Zwergsignal"
-					delete_if_empty="true" />
+					/>
 			</item>
 			<item name="Endsignal" type="node">
 				<label text="Endsignal" />
@@ -1006,21 +1000,21 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
 					de.text="Signalstandort"
 					values="left,right,bridge"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:signal:direction"
 					text="Direction"
 					de.text="Anzeigerichtung"
 					values="forward,backward"
 					display_values="In Wegrichtung,Entgegen Wegrichtung"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<key key="railway:signal:speed_limit"
 					value="AT-V2:endsignal" />
@@ -1034,7 +1028,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="normal,dwarf"
 					default=""
 					display_values="Mastbauform,Zwergsignal"
-					delete_if_empty="true" />
+					/>
 			</item>
 		</group>
 		<separator />
@@ -1048,21 +1042,21 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				text="Out of order"
 				de.text="Ungültigkeitskreuz"
 				default="off"
-				delete_if_empty="true" />
+				/>
 			<combo key="railway:signal:position"
 				text="Signal position"
 				de.text="Signalstandort"
 				values="left,right,overhead"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Oberleitung"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<combo key="railway:signal:direction"
 				text="Direction"
 				de.text="Anzeigerichtung"
 				values="forward,backward"
 				display_values="In Wegrichtung,Entgegen Wegrichtung"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<space />
 			<combo key="railway:signal:electricity"
 				text="Exact type"
@@ -1070,28 +1064,28 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				values="AT-V2:ankündigung_hauptschalter_aus,AT-V2:hauptschalter_aus,AT-V2:hauptschalter_ein,AT-V2:ankündigung_stromabnehmer_tief,AT-V2:stromabnehmer_tief,AT-V2:stromabnehmer_hoch,AT-V2:halt_fuer_fahrzeuge_mit_angehobenem_stromabnehmer;AT-V2:bahnhof-streckentrennung_anfang;AT-V2:bahnhof-streckentrennung_ende"
 				display_values="Ankündigung Hauptschalter aus,Hauptschalter aus,Hauptschalter ein,Ankündigung Stromabnehmer tief,Stromabnehmer tief,Stromabnehmer hoch,Halt für Fahrzeuge mit angehobenem Stromabnehmer,Bahnhof-Streckentrennung Anfang,Bahnhof-Streckentrennung Ende"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<combo key="railway:signal:electricity:turn_direction"
 				text="Turn direction arrow – if the signals only valid for some turn directions at the next switch/junction. Leave this key empty if there is no arrow."
 				de.text="Richtungs – falls das Signal an der nächsten Weiche/Abzweigung nur für bestimmte Richtungen gilt. Leer lassen, falls es keinen Richtungspfeil gibt."
 				values="left,through,right"
 				display_values="links,geradeaus,rechts"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<combo key="railway:signal:electricity:height"
 				text="Signal height"
 				de.text="Signalbauform"
 				values="normal,dwarf"
 				default=""
 				display_values="Mastbauform,Zwergsignal"
-				delete_if_empty="true" />
+				/>
 			<combo key="railway:signal:electricity:type"
 				text="Meaning"
 				de.text="Bedeutung"
 				values="power_off_advance,power_off,power_on,pantograph_down_advance,pantograph_down,pantograph_up,end_of_catenary,pantograph_down,pantograph_up"
 				display_values="Ankündigung Hauptschalter aus,Hauptschalter aus,Hauptschalter ein,Ankündigung Stromabnehmer tief,Stromabnehmer tief,Stromabnehmer hoch,Halt für Fahrzeuge mit angehobenem Stromabnehmer,Bahnhof-Streckentrennung Anfang,Bahnhof-Streckentrennung Ende"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<key key="railway:signal:electricity:form"
 				value="sign" />
 		</item>
@@ -1105,21 +1099,21 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				text="Out of order"
 				de.text="Ungültigkeitskreuz"
 				default="off"
-				delete_if_empty="true" />
+				/>
 			<combo key="railway:signal:position"
 				text="Signal position"
 				de.text="Signalstandort"
 				values="left,right,overhead"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Oberleitung"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<combo key="railway:signal:direction"
 				text="Direction"
 				de.text="Anzeigerichtung"
 				values="forward,backward"
 				display_values="In Wegrichtung,Entgegen Wegrichtung"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<space />
 			<key key="railway:signal:electricity"
 				value="AT-V2:schaltzeiger" />
@@ -1142,21 +1136,21 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
 					de.text="Signalstandort"
 					values="left,right,bridge"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:signal:direction"
 					text="Direction"
 					de.text="Anzeigerichtung"
 					values="forward,backward"
 					display_values="In Wegrichtung,Entgegen Wegrichtung"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<key key="railway:signal:crossing"
 					value="AT-V2:ek_überwachungssignal" />
@@ -1175,21 +1169,21 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
 					de.text="Signalstandort"
 					values="left,right"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:signal:direction"
 					text="Direction"
 					de.text="Anzeigerichtung"
 					values="forward,backward"
 					display_values="In Wegrichtung,Entgegen Wegrichtung"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<key key="railway:signal:crossing_hint"
 					value="AT-V2:eküs" />
 				<key key="railway:signal:crossing_hint:form"
@@ -1198,14 +1192,14 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Caption (e.g. '3 EK')"
 					de.text="Beschriftung (z. B. '3 EK')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:signal:crossing_hint:height"
 					text="Signal height"
 					de.text="Signalbauform"
 					values="normal,dwarf"
 					default=""
 					display_values="Mastbauform,Zwergsignal"
-					delete_if_empty="true" />
+					/>
 			</item>
 			<item name="Eisenbahnkreuzungs-Zusatztafel Ende" type="node">
 				<label text="Eisenbahnkreuzungs-Zusatztafel Ende" />
@@ -1217,21 +1211,21 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
 					de.text="Signalstandort"
 					values="left,right"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:signal:direction"
 					text="Direction"
 					de.text="Anzeigerichtung"
 					values="forward,backward"
 					display_values="In Wegrichtung,Entgegen Wegrichtung"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<key key="railway:signal:crossing_info"
 					value="AT-V2:eküs" />
 				<key key="railway:signal:crossing_info:form"
@@ -1240,14 +1234,14 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Caption (e.g. 'EK 3')"
 					de.text="Beschriftung (z. B. 'EK 3')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:signal:crossing_info:height"
 					text="Signal height"
 					de.text="Signalbauform"
 					values="normal,dwarf"
 					default=""
 					display_values="Mastbauform,Zwergsignal"
-					delete_if_empty="true" />
+					/>
 			</item>
 			<item name="Rautentafel" type="node">
 				<label text="Rautentafel" />
@@ -1259,21 +1253,21 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
 					de.text="Signalstandort"
 					values="left,right,bridge"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:signal:direction"
 					text="Direction"
 					de.text="Anzeigerichtung"
 					values="forward,backward"
 					display_values="In Wegrichtung,Entgegen Wegrichtung"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<key key="railway:signal:crossing_distant"
 					value="AT-V2:rautentafel" />
@@ -1290,21 +1284,21 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
 					de.text="Signalstandort"
 					values="left,right,bridge"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:signal:direction"
 					text="Direction"
 					de.text="Anzeigerichtung"
 					values="forward,backward"
 					display_values="In Wegrichtung,Entgegen Wegrichtung"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<key key="railway:signal:crossing_distant"
 					value="AT-V2:schaltstellenpflock" />
@@ -1314,7 +1308,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Position of level crossing (e.g. '13.427')"
 					de.text="Streckenkilometer der Eisenbahnkreuzung (z. B. '13.427')"
 					default=""
-					delete_if_empty="true" />
+					/>
 			</item>
 			<item name="Pfeifpflock" type="node">
 				<label text="Pfeifpflock" />
@@ -1326,21 +1320,21 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
 					de.text="Signalstandort"
 					values="left,right,bridge"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:signal:direction"
 					text="Direction"
 					de.text="Anzeigerichtung"
 					values="forward,backward"
 					display_values="In Wegrichtung,Entgegen Wegrichtung"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<key key="railway:signal:whistle"
 					value="AT-V2:pfeifpflock" />
@@ -1357,21 +1351,21 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
 					de.text="Signalstandort"
 					values="left,right,bridge"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:signal:direction"
 					text="Direction"
 					de.text="Anzeigerichtung"
 					values="forward,backward"
 					display_values="In Wegrichtung,Entgegen Wegrichtung"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<key key="railway:signal:whistle"
 					value="AT-V2:gruppenpfeifpflock" />
@@ -1388,21 +1382,21 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
 					de.text="Signalstandort"
 					values="left,right,bridge"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:signal:direction"
 					text="Direction"
 					de.text="Anzeigerichtung"
 					values="forward,backward"
 					display_values="In Wegrichtung,Entgegen Wegrichtung"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<key key="railway:signal:whistle"
 					value="AT-V2:endpflock" />
@@ -1420,21 +1414,21 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				text="Out of order"
 				de.text="Ungültigkeitskreuz"
 				default="off"
-				delete_if_empty="true" />
+				/>
 			<combo key="railway:signal:position"
 				text="Signal position"
 				de.text="Signalstandort"
 				values="left,right"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<combo key="railway:signal:direction"
 				text="Direction"
 				de.text="Anzeigerichtung"
 				values="forward,backward"
 				display_values="In Wegrichtung,Entgegen Wegrichtung"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<key key="railway:signal:stop"
 				value="AT-V2:haltepunkt" />
 			<key key="railway:signal:stop:form"
@@ -1445,12 +1439,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				values="normal,dwarf"
 				default=""
 				display_values="Mastbauform,Zwergsignal"
-				delete_if_empty="true" />
+				/>
 			<text key="railway:signal:stop:description"
 				text="Description"
 				de.text="Zusatztext"
 				default=""
-				delete_if_empty="true" />
+				/>
 		</item>
 		<item name="Haltestellentafel" icon="de/ne6-32.png" type="node">
 			<label text="Haltestellentafel" />
@@ -1462,21 +1456,21 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				text="Out of order"
 				de.text="Ungültigkeitskreuz"
 				default="off"
-				delete_if_empty="true" />
+				/>
 			<combo key="railway:signal:position"
 				text="Signal position"
 				de.text="Signalstandort"
 				values="left,right"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<combo key="railway:signal:direction"
 				text="Direction"
 				de.text="Anzeigerichtung"
 				values="forward,backward"
 				display_values="In Wegrichtung,Entgegen Wegrichtung"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<key key="railway:signal:station_distant"
 				value="AT-V2:haltestellentafel" />
 			<key key="railway:signal:station_distant:form"
@@ -1492,21 +1486,21 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				text="Out of order"
 				de.text="Ungültigkeitskreuz"
 				default="off"
-				delete_if_empty="true" />
+				/>
 			<combo key="railway:signal:position"
 				text="Signal position"
 				de.text="Signalstandort"
 				values="left,right"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<combo key="railway:signal:direction"
 				text="Direction"
 				de.text="Anzeigerichtung"
 				values="forward,backward"
 				display_values="In Wegrichtung,Entgegen Wegrichtung"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<space />
 			<key key="railway:signal:resetting_switch"
 				value="AT-V2:weichenüberwachungssignal" />
@@ -1518,7 +1512,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				values="normal,dwarf"
 				default=""
 				display_values="Mastbauform,Zwergsignal"
-				delete_if_empty="true" />
+				/>
 		</item>
 		<group name="Grenzmarken">
 			<item name="Grenzmarke" type="node">
@@ -1533,7 +1527,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="left,right"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<key key="railway:signal:fouling_point"
 					value="AT-V2:grenzmarke" />
 			</item>
@@ -1549,7 +1543,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="left,right"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<key key="railway:signal:fouling_point"
 					value="AT-V2:markierte_grenzmarke" />
 			</item>
@@ -1565,7 +1559,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="left,right"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<key key="railway:signal:fouling_point"
 					value="AT-V2:verschub-grenzmarke" />
 			</item>
@@ -1581,7 +1575,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="left,right"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<key key="railway:signal:fouling_point"
 					value="AT-V2:grenzmarke_rollwagenbetrieb" />
 			</item>
@@ -1596,21 +1590,21 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				text="Out of order"
 				de.text="Ungültigkeitskreuz"
 				default="off"
-				delete_if_empty="true" />
+				/>
 			<combo key="railway:signal:position"
 				text="Signal position"
 				de.text="Signalstandort"
 				values="left,right,bridge"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<combo key="railway:signal:direction"
 				text="Direction"
 				de.text="Anzeigerichtung"
 				values="forward,backward,both"
 				display_values="In Wegrichtung,Entgegen Wegrichtung,Beide Richtungen"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<key key="railway:signal:brake_test"
 				value="AT-V2:bremsprobesignal" />
 			<key key="railway:signal:brake_test:form"
@@ -1628,21 +1622,21 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				text="Out of order"
 				de.text="Ungültigkeitskreuz"
 				default="off"
-				delete_if_empty="true" />
+				/>
 			<combo key="railway:signal:position"
 				text="Signal position"
 				de.text="Signalstandort"
 				values="left,right,bridge"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<combo key="railway:signal:direction"
 				text="Direction"
 				de.text="Anzeigerichtung"
 				values="forward,backward,both"
 				display_values="In Wegrichtung,Entgegen Wegrichtung,Beide Richtungen"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<key key="railway:signal:departure"
 				value="AT-V2:abfahrt" />
 			<key key="railway:signal:departure:form"
@@ -1658,21 +1652,21 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				text="Out of order"
 				de.text="Ungültigkeitskreuz"
 				default="off"
-				delete_if_empty="true" />
+				/>
 			<combo key="railway:signal:position"
 				text="Signal position"
 				de.text="Signalstandort"
 				values="left,right,bridge"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<combo key="railway:signal:direction"
 				text="Direction"
 				de.text="Anzeigerichtung"
 				values="forward,backward,both"
 				display_values="In Wegrichtung,Entgegen Wegrichtung,Beide Richtungen"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<key key="railway:signal:departure"
 				value="AT-V2:fahrerlaubnissignal" />
 			<combo key="railway:signal:departure:form"
@@ -1681,12 +1675,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				values="light,sign"
 				display_values="Lichtsignal,Tafel"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<check key="railway:signal:departure:repeated"
 				text="Repeated Signal"
 				de.text="Vorsignalwiederholer"
 				default="off"
-				delete_if_empty="true" />
+				/>
 		</item>
 		<group name="Räumsignale">
 			<item name="Räumarbeit einstellen" type="node">
@@ -1699,21 +1693,21 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
 					de.text="Signalstandort"
 					values="left,right"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:signal:direction"
 					text="Direction"
 					de.text="Anzeigerichtung"
 					values="forward,backward"
 					display_values="In Wegrichtung,Entgegen Wegrichtung"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<key key="railway:signal:snowplow"
 					value="AT-V2:räumarbeit_einstellen" />
 				<key key="railway:signal:snowplow:form"
@@ -1731,21 +1725,21 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
 					de.text="Signalstandort"
 					values="left,right"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:signal:direction"
 					text="Direction"
 					de.text="Anzeigerichtung"
 					values="forward,backward"
 					display_values="In Wegrichtung,Entgegen Wegrichtung"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<key key="railway:signal:snowplow"
 					value="AT-V2:mittelräumer_heben" />
 				<key key="railway:signal:snowplow:form"
@@ -1763,21 +1757,21 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
 					de.text="Signalstandort"
 					values="left,right"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:signal:direction"
 					text="Direction"
 					de.text="Anzeigerichtung"
 					values="forward,backward"
 					display_values="In Wegrichtung,Entgegen Wegrichtung"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<key key="railway:signal:snowplow"
 					value="AT-V2:räumarbeit_aufnehmen" />
 				<key key="railway:signal:snowplow:form"
@@ -1796,26 +1790,26 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				text="Out of order"
 				de.text="Ungültigkeitskreuz"
 				default="off"
-				delete_if_empty="true" />
+				/>
 			<combo key="railway:signal:position"
 				text="Signal position"
 				de.text="Signalstandort"
 				values="left,right"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<combo key="railway:signal:direction"
 				text="Direction"
 				de.text="Anzeigerichtung"
 				values="forward,backward"
 				display_values="In Wegrichtung,Entgegen Wegrichtung"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<check key="railway:signal:catenary_mast"
 				text="On catenary mast"
 				de.text="Am Oberleitungsmast"
 				default="off"
-				delete_if_empty="true" />
+				/>
 			<key key="railway:signal:train_protection"
 				value="AT-V2:lzb-bereichskennzeichen" />
 			<key key="railway:signal:train_protection:form"
@@ -1826,12 +1820,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				values="start,section"
 				display_values="LZB Anfang,Bereichswechsel"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<text key="railway:position:exact"
 				text="Exact position (e.g. '13.427')"
 				de.text="Standortangabe (z. B. '13.427')"
 				default=""
-				delete_if_empty="true" />
+				/>
 		</item>
 		<item name="Signalnachahmer" type="node">
 			<label text="Signalnachahmer" />
@@ -1843,26 +1837,26 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				text="Signal ref"
 				de.text="Signalbezeichnung"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<check key="railway:signal:main_repeated:deactivated"
 				text="Out of order"
 				de.text="Ungültigkeitskreuz"
 				default="off"
-				delete_if_empty="true" />
+				/>
 			<combo key="railway:signal:position"
 				text="Signal position"
 				de.text="Signalstandort"
 				values="left,right,bridge"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<combo key="railway:signal:direction"
 				text="Direction"
 				de.text="Anzeigerichtung"
 				values="forward,backward"
 				display_values="In Wegrichtung,Entgegen Wegrichtung"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<space />
 			<key key="railway:signal:main_repeated"
 				value="AT-V2:signalnachahmer" />
@@ -1876,7 +1870,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				values="AT-V2:ersatzsignal, "
 				display_values="Kann Ersatzsignal anzeigen,Kann kein Ersatzsignal anzeigen"
 				default=""
-				delete_if_empty="true" />
+				/>
 		</item>
 		<item name="Fahrwegende" type="node">
 			<label text="Fahrwegende" />
@@ -1888,21 +1882,21 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				text="Out of order"
 				de.text="Ungültigkeitskreuz"
 				default="off"
-				delete_if_empty="true" />
+				/>
 			<combo key="railway:signal:position"
 				text="Signal position"
 				de.text="Signalstandort"
 				values="left,right,in_track"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Gleismitte/am Prellbock"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<combo key="railway:signal:direction"
 				text="Direction"
 				de.text="Anzeigerichtung"
 				values="forward,backward"
 				display_values="In Wegrichtung,Entgegen Wegrichtung"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<space />
 			<key key="railway:signal:minor"
 				value="AT-V2:fahrwegende" />
@@ -1914,7 +1908,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				values="normal,dwarf"
 				default=""
 				display_values="Mastbauform,Zwergsignal"
-				delete_if_empty="true" />
+				/>
 		</item>
 		<item name="Dienstruhe" type="node">
 			<label text="Dienstruhe" />
@@ -1926,21 +1920,21 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				text="Out of order"
 				de.text="Ungültigkeitskreuz"
 				default="off"
-				delete_if_empty="true" />
+				/>
 			<combo key="railway:signal:position"
 				text="Signal position"
 				de.text="Signalstandort"
 				values="left,right,in_track"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Gleismitte/am Prellbock"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<combo key="railway:signal:direction"
 				text="Direction"
 				de.text="Anzeigerichtung"
 				values="forward,backward"
 				display_values="In Wegrichtung,Entgegen Wegrichtung"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<space />
 			<key key="railway:signal:main:substitute_signal"
 				value="AT-V2:dienstruhe" />
@@ -1952,7 +1946,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				values="normal,dwarf"
 				default=""
 				display_values="Mastbauform,Zwergsignal"
-				delete_if_empty="true" />
+				/>
 		</item>
 		<item name="ETCS-Blockkennzeichen" type="node">
 			<label text="ETCS-Blockkennzeichen" />
@@ -1964,31 +1958,31 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				text="Out of order"
 				de.text="Ungültigkeitskreuz"
 				default="off"
-				delete_if_empty="true" />
+				/>
 			<combo key="railway:signal:position"
 				text="Signal position"
 				de.text="Signalstandort"
 				values="left,right"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<combo key="railway:signal:direction"
 				text="Direction"
 				de.text="Anzeigerichtung"
 				values="forward,backward"
 				display_values="In Wegrichtung,Entgegen Wegrichtung"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<check key="railway:signal:catenary_mast"
 				text="On catenary mast"
 				de.text="Am Oberleitungsmast"
 				default="off"
-				delete_if_empty="true" />
+				/>
 			<text key="ref"
 				text="Block reference"
 				de.text="Blockbezeichner"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<key key="railway:signal:train_protection"
 				value="AT-V2:etcs-blockkennzeichen" />
 			<key key="railway:signal:train_protection:form"

--- a/josm-presets/at-signals-v2.xml
+++ b/josm-presets/at-signals-v2.xml
@@ -22,7 +22,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<text key="ref"
 				text="Signal ref"
 				de.text="Signalbezeichnung"
-				default=""
 				/>
 			<check key="railway:signal:main:deactivated"
 				text="Out of order"
@@ -34,14 +33,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				de.text="Signalstandort"
 				values="left,right,bridge"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
-				default=""
 				/>
 			<combo key="railway:signal:direction"
 				text="Direction"
 				de.text="Anzeigerichtung"
 				values="forward,backward"
 				display_values="In Wegrichtung,Entgegen Wegrichtung"
-				default=""
 				/>
 			<space />
 			<key key="railway:signal:main"
@@ -53,7 +50,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				de.text="Signalbauform"
 				values="normal,dwarf"
 				display_values="Mastbauform,Zwergsignal"
-				default=""
 				/>
 			<multiselect key="railway:signal:main:states"
 				text="Signal states (multi-selection)"
@@ -67,7 +63,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				de.text="Signalaufgabe"
 				values="entry,exit,block,intermediate"
 				display_values="Einfahrsignal,Ausfahrsignal,Blocksignal,Zwischensignal"
-				default=""
 				/>
 			<multiselect key="railway:signal:main:substitute_signal"
 				text="Substitute signal (multi-selection)"
@@ -91,7 +86,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<text key="ref"
 				text="Signal ref"
 				de.text="Signalbezeichnung"
-				default=""
 				/>
 			<check key="railway:signal:main:deactivated"
 				text="Out of order"
@@ -103,14 +97,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				de.text="Signalstandort"
 				values="left,right,bridge"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
-				default=""
 				/>
 			<combo key="railway:signal:direction"
 				text="Direction"
 				de.text="Anzeigerichtung"
 				values="forward,backward"
 				display_values="In Wegrichtung,Entgegen Wegrichtung"
-				default=""
 				/>
 			<space />
 			<key key="railway:signal:main"
@@ -122,7 +114,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				de.text="Signalbauform"
 				values="normal,dwarf"
 				display_values="Mastbauform,Zwergsignal"
-				default=""
 				/>
 			<multiselect key="railway:signal:main:states"
 				text="Signal states (multi-selection)"
@@ -136,7 +127,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				de.text="Signalaufgabe"
 				values="entry,exit,block,intermediate"
 				display_values="Einfahrsignal,Ausfahrsignal,Blocksignal,Zwischensignal"
-				default=""
 				/>
 			<multiselect key="railway:signal:main:substitute_signal"
 				text="Substitute signal (multi-selection)"
@@ -162,7 +152,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<text key="ref"
 				text="Signal ref"
 				de.text="Signalbezeichnung"
-				default=""
 				/>
 			<check key="railway:signal:distant:deactivated"
 				text="Out of order"
@@ -174,14 +163,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				de.text="Signalstandort"
 				values="left,right,bridge"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
-				default=""
 				/>
 			<combo key="railway:signal:direction"
 				text="Direction"
 				de.text="Anzeigerichtung"
 				values="forward,backward"
 				display_values="In Wegrichtung,Entgegen Wegrichtung"
-				default=""
 				/>
 			<space />
 			<key key="railway:signal:distant"
@@ -193,7 +180,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				de.text="Signalbauform"
 				values="normal,dwarf"
 				display_values="Mastbauform,Zwergsignal"
-				default=""
 				/>
 			<key key="railway:signal:distant:states"
 				value="AT-V2:vorsicht;AT-V2:hauptsignal_frei" />
@@ -209,7 +195,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<text key="ref"
 				text="Signal ref"
 				de.text="Signalbezeichnung"
-				default=""
 				/>
 			<check key="railway:signal:distant:deactivated"
 				text="Out of order"
@@ -221,14 +206,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				de.text="Signalstandort"
 				values="left,right,bridge"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
-				default=""
 				/>
 			<combo key="railway:signal:direction"
 				text="Direction"
 				de.text="Anzeigerichtung"
 				values="forward,backward"
 				display_values="In Wegrichtung,Entgegen Wegrichtung"
-				default=""
 				/>
 			<space />
 			<key key="railway:signal:distant"
@@ -240,7 +223,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				de.text="Signalbauform"
 				values="normal,dwarf"
 				display_values="Mastbauform,Zwergsignal"
-				default=""
 				/>
 			<multiselect key="railway:signal:distant:states"
 				text="Signal states (multi-selection)"
@@ -268,14 +250,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				de.text="Signalstandort"
 				values="left,right,bridge"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
-				default=""
 				/>
 			<combo key="railway:signal:direction"
 				text="Direction"
 				de.text="Anzeigerichtung"
 				values="forward,backward"
 				display_values="In Wegrichtung,Entgegen Wegrichtung"
-				default=""
 				/>
 			<space />
 			<key key="railway:signal:main"
@@ -287,7 +267,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				de.text="Signalbauform"
 				values="normal,dwarf"
 				display_values="Normalhöhe,Zwergsignal"
-				default=""
 				/>
 			<key key="railway:signal:main:function"
 				value="entry" />
@@ -308,14 +287,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				de.text="Signalstandort"
 				values="left,right,bridge"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
-				default=""
 				/>
 			<combo key="railway:signal:direction"
 				text="Direction"
 				de.text="Anzeigerichtung"
 				values="forward,backward"
 				display_values="In Wegrichtung,Entgegen Wegrichtung"
-				default=""
 				/>
 			<space />
 			<key key="railway:signal:distant"
@@ -333,7 +310,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<text key="ref"
 				text="Signal ref"
 				de.text="Signalbezeichnung"
-				default=""
 				/>
 			<check key="railway:signal:minor:deactivated"
 				text="Out of order"
@@ -345,14 +321,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				de.text="Signalstandort"
 				values="left,right,bridge,in_track"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke,Gleismitte/am Prellbock"
-				default=""
 				/>
 			<combo key="railway:signal:direction"
 				text="Direction"
 				de.text="Anzeigerichtung"
 				values="forward,backward"
 				display_values="In Wegrichtung,Entgegen Wegrichtung"
-				default=""
 				/>
 			<space />
 			<key key="railway:signal:minor"
@@ -364,7 +338,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				de.text="Signalbauform"
 				values="normal,dwarf"
 				display_values="Mastbauform,Zwergsignal"
-				default=""
 				/>
 			<key key="railway:signal:minor:states"
 				value="AT:fahrverbot;AT:fahrverbot_aufgehoben" />
@@ -390,7 +363,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<text key="ref"
 				text="Signal ref"
 				de.text="Signalbezeichnung"
-				default=""
 				/>
 			<check key="railway:signal:minor:deactivated"
 				text="Out of order"
@@ -402,14 +374,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				de.text="Signalstandort"
 				values="left,right,in_track"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Gleismitte/am Prellbock"
-				default=""
 				/>
 			<combo key="railway:signal:direction"
 				text="Direction"
 				de.text="Anzeigerichtung"
 				values="forward,backward"
 				display_values="In Wegrichtung,Entgegen Wegrichtung"
-				default=""
 				/>
 			<space />
 			<key key="railway:signal:minor"
@@ -422,7 +392,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				text="Signal height"
 				de.text="Signalbauform"
 				values="normal,dwarf"
-				default=""
 				display_values="Mastbauform,Zwergsignal"
 				/>
 		</item>
@@ -435,7 +404,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<text key="ref"
 				text="Signal ref"
 				de.text="Signalbezeichnung"
-				default=""
 				/>
 			<check key="railway:signal:minor:deactivated"
 				text="Out of order"
@@ -447,14 +415,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				de.text="Signalstandort"
 				values="left,right,in_track"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Gleismitte/am Prellbock"
-				default=""
 				/>
 			<combo key="railway:signal:direction"
 				text="Direction"
 				de.text="Anzeigerichtung"
 				values="forward,backward,both"
 				display_values="In Wegrichtung,Entgegen Wegrichtung,Beide Richtungen"
-				default=""
 				/>
 			<space />
 			<key key="railway:signal:minor"
@@ -465,7 +431,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				text="Signal height"
 				de.text="Signalbauform"
 				values="normal,dwarf"
-				default=""
 				display_values="Mastbauform,Zwergsignal"
 				/>
 		</item>
@@ -485,14 +450,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				de.text="Signalstandort"
 				values="left,right,in_track"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Gleismitte/am Prellbock"
-				default=""
 				/>
 			<combo key="railway:signal:direction"
 				text="Direction"
 				de.text="Anzeigerichtung"
 				values="forward,backward"
 				display_values="In Wegrichtung,Entgegen Wegrichtung"
-				default=""
 				/>
 			<space />
 			<key key="railway:signal:minor"
@@ -503,7 +466,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				text="Signal height"
 				de.text="Signalbauform"
 				values="normal,dwarf"
-				default=""
 				display_values="Mastbauform,Zwergsignal"
 				/>
 		</item>
@@ -518,7 +480,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<text key="ref"
 					text="Signal ref"
 					de.text="Signalbezeichnung"
-					default=""
 					/>
 				<check key="railway:signal:shunting:deactivated"
 					text="Out of order"
@@ -530,14 +491,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Signalstandort"
 					values="left,right"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung"
-					default=""
 					/>
 				<combo key="railway:signal:direction"
 					text="Direction"
 					de.text="Anzeigerichtung"
 					values="forward,backward"
 					display_values="In Wegrichtung,Entgegen Wegrichtung"
-					default=""
 					/>
 				<space />
 				<key key="railway:signal:shunting"
@@ -550,7 +509,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Signal height"
 					de.text="Signalbauform"
 					values="normal,dwarf"
-					default=""
 					display_values="Mastbauform,Zwergsignal"
 					/>
 			</item>
@@ -570,14 +528,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Signalstandort"
 					values="left,right"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung"
-					default=""
 					/>
 				<combo key="railway:signal:direction"
 					text="Direction"
 					de.text="Anzeigerichtung"
 					values="forward,backward"
 					display_values="In Wegrichtung,Entgegen Wegrichtung"
-					default=""
 					/>
 				<space />
 				<key key="railway:signal:shunting"
@@ -589,7 +545,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Signalbauform"
 					values="normal,dwarf"
 					display_values="Mastbauform,Zwergsignal"
-					default=""
 					/>
 			</item>
 			<item name="Wartesignal (Tafel)" type="node">
@@ -608,14 +563,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Signalstandort"
 					values="left,right"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung"
-					default=""
 					/>
 				<combo key="railway:signal:direction"
 					text="Direction"
 					de.text="Anzeigerichtung"
 					values="forward,backward"
 					display_values="In Wegrichtung,Entgegen Wegrichtung"
-					default=""
 					/>
 				<space />
 				<key key="railway:signal:shunting"
@@ -626,7 +579,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Signal height"
 					de.text="Signalbauform"
 					values="normal,dwarf"
-					default=""
 					display_values="Mastbauform,Zwergsignal"
 					/>
 			</item>
@@ -646,14 +598,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Signalstandort"
 					values="left,right"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung"
-					default=""
 					/>
 				<combo key="railway:signal:direction"
 					text="Direction"
 					de.text="Anzeigerichtung"
 					values="forward,backward"
 					display_values="In Wegrichtung,Entgegen Wegrichtung"
-					default=""
 					/>
 				<space />
 				<key key="railway:signal:shunting"
@@ -666,7 +616,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Signal height"
 					de.text="Signalbauform"
 					values="normal,dwarf"
-					default=""
 					display_values="Mastbauform,Zwergsignal"
 					/>
 			</item>
@@ -686,14 +635,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Signalstandort"
 					values="left,right"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung"
-					default=""
 					/>
 				<combo key="railway:signal:direction"
 					text="Direction"
 					de.text="Anzeigerichtung"
 					values="forward,backward"
 					display_values="In Wegrichtung,Entgegen Wegrichtung"
-					default=""
 					/>
 				<space />
 				<key key="railway:signal:humping"
@@ -707,7 +654,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Signalbauform"
 					values="normal,dwarf"
 					display_values="Mastbauform,Zwergsignal"
-					default=""
 					/>
 			</item>
 		</group>
@@ -728,14 +674,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				de.text="Signalstandort"
 				values="left,right,bridge"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
-				default=""
 				/>
 			<combo key="railway:signal:direction"
 				text="Direction"
 				de.text="Anzeigerichtung"
 				values="forward,backward"
 				display_values="In Wegrichtung,Entgegen Wegrichtung"
-				default=""
 				/>
 			<space />
 			<key key="railway:signal:speed_limit"
@@ -745,9 +689,8 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				de.text="Anzeigeart"
 				values="light,sign"
 				display_values="Lichtsignal,Tafel"
-				default=""
 				/>
-			<combo key="railway:signal:speed_limit:speed" default=""
+			<combo key="railway:signal:speed_limit:speed"
 				text="Speed (km/h, in case of light signals separate the possible values (number or 'off') with ';')"
 				de.text="Geschwindigkeit (km/h, bei Lichtsignalen mögliche Werte (Zahl oder 'off') mit ';' trennen)"
 				values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,?"
@@ -757,7 +700,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				text="Signal height"
 				de.text="Signalbauform"
 				values="normal,dwarf"
-				default=""
 				display_values="Mastbauform,Zwergsignal"
 				/>
 		</item>
@@ -777,14 +719,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				de.text="Signalstandort"
 				values="left,right,bridge"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
-				default=""
 				/>
 			<combo key="railway:signal:direction"
 				text="Direction"
 				de.text="Anzeigerichtung"
 				values="forward,backward"
 				display_values="In Wegrichtung,Entgegen Wegrichtung"
-				default=""
 				/>
 			<space />
 			<key key="railway:signal:speed_limit_distant"
@@ -794,9 +734,8 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				de.text="Anzeigeart"
 				values="light,sign"
 				display_values="Lichtsignal,Tafel"
-				default=""
 				/>
-			<combo key="railway:signal:speed_limit_distant:speed" default=""
+			<combo key="railway:signal:speed_limit_distant:speed"
 				text="Speed (km/h, in case of light signals separate the possible values(number or 'off') with ';')"
 				de.text="Geschwindigkeit (km/h, bei Lichtsignalen mögliche Werte (Zahl oder 'off') mit ';' trennen)"
 				values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,?"
@@ -806,7 +745,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				text="Signal height"
 				de.text="Signalbauform"
 				values="normal,dwarf"
-				default=""
 				display_values="Mastbauform,Zwergsignal"
 				/>
 		</item>
@@ -826,14 +764,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				de.text="Signalstandort"
 				values="left,right,bridge"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
-				default=""
 				/>
 			<combo key="railway:signal:direction"
 				text="Direction"
 				de.text="Anzeigerichtung"
 				values="forward,backward"
 				display_values="In Wegrichtung,Entgegen Wegrichtung"
-				default=""
 				/>
 			<space />
 			<key key="railway:signal:speed_limit"
@@ -845,9 +781,8 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				de.text="Anzeigeart"
 				values="light,sign"
 				display_values="Lichtsignal,Tafel"
-				default=""
 				/>
-			<combo key="railway:signal:speed_limit:speed" default=""
+			<combo key="railway:signal:speed_limit:speed"
 				text="Speed (km/h, in case of light signals separate the possible values (number or 'off') with ';')"
 				de.text="Geschwindigkeit (km/h, bei Lichtsignalen mögliche Werte (Zahl oder 'off') mit ';' trennen)"
 				values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200"
@@ -856,7 +791,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				text="Signal height"
 				de.text="Signalbauform"
 				values="normal,dwarf"
-				default=""
 				display_values="Mastbauform,Zwergsignal"
 				/>
 		</item>
@@ -876,21 +810,19 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				de.text="Signalstandort"
 				values="left,right,bridge"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
-				default=""
 				/>
 			<combo key="railway:signal:direction"
 				text="Direction"
 				de.text="Anzeigerichtung"
 				values="forward,backward"
 				display_values="In Wegrichtung,Entgegen Wegrichtung"
-				default=""
 				/>
 			<space />
 			<key key="railway:signal:speed_limit_distant"
 				value="AT-V2:ankündigungstafel" />
 			<key key="railway:signal:speed_limit_distant:form"
 				value="sign" />
-			<combo key="railway:signal:speed_limit_distant:speed" default=""
+			<combo key="railway:signal:speed_limit_distant:speed"
 				text="Speed (km/h, in case of light signals separate the possible values(number or 'off') with ';')"
 				de.text="Geschwindigkeit (km/h, bei Lichtsignalen mögliche Werte (Zahl oder 'off') mit ';' trennen)"
 				values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200"
@@ -899,7 +831,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				text="Signal height"
 				de.text="Signalbauform"
 				values="normal,dwarf"
-				default=""
 				display_values="Mastbauform,Zwergsignal"
 				/>
 		</item>
@@ -920,21 +851,19 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Signalstandort"
 					values="left,right,bridge"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
-					default=""
 					/>
 				<combo key="railway:signal:direction"
 					text="Direction"
 					de.text="Anzeigerichtung"
 					values="forward,backward"
 					display_values="In Wegrichtung,Entgegen Wegrichtung"
-					default=""
 					/>
 				<space />
 				<key key="railway:signal:speed_limit_distant"
 					value="AT-V2:ankündigungssignal" />
 				<key key="railway:signal:speed_limit_distant:form"
 					value="sign" />
-				<combo key="railway:signal:speed_limit_distant:speed" default=""
+				<combo key="railway:signal:speed_limit_distant:speed"
 					text="Speed (km/h, in case of light signals separate the possible values(number or 'off') with ';')"
 					de.text="Geschwindigkeit (km/h, bei Lichtsignalen mögliche Werte (Zahl oder 'off') mit ';' trennen)"
 					values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200"
@@ -943,7 +872,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Signal height"
 					de.text="Signalbauform"
 					values="normal,dwarf"
-					default=""
 					display_values="Mastbauform,Zwergsignal"
 					/>
 			</item>
@@ -963,21 +891,19 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Signalstandort"
 					values="left,right,bridge"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
-					default=""
 					/>
 				<combo key="railway:signal:direction"
 					text="Direction"
 					de.text="Anzeigerichtung"
 					values="forward,backward"
 					display_values="In Wegrichtung,Entgegen Wegrichtung"
-					default=""
 					/>
 				<space />
 				<key key="railway:signal:speed_limit"
 					value="AT-V2:anfangssignal" />
 				<key key="railway:signal:speed_limit:form"
 					value="sign" />
-				<combo key="railway:signal:speed_limit:speed" default=""
+				<combo key="railway:signal:speed_limit:speed"
 					text="Speed (km/h, in case of light signals separate the possible values (number or 'off') with ';')"
 					de.text="Geschwindigkeit (km/h, bei Lichtsignalen mögliche Werte (Zahl oder 'off') mit ';' trennen)"
 					values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200"
@@ -986,7 +912,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Signal height"
 					de.text="Signalbauform"
 					values="normal,dwarf"
-					default=""
 					display_values="Mastbauform,Zwergsignal"
 					/>
 			</item>
@@ -1006,14 +931,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Signalstandort"
 					values="left,right,bridge"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
-					default=""
 					/>
 				<combo key="railway:signal:direction"
 					text="Direction"
 					de.text="Anzeigerichtung"
 					values="forward,backward"
 					display_values="In Wegrichtung,Entgegen Wegrichtung"
-					default=""
 					/>
 				<space />
 				<key key="railway:signal:speed_limit"
@@ -1026,7 +949,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Signal height"
 					de.text="Signalbauform"
 					values="normal,dwarf"
-					default=""
 					display_values="Mastbauform,Zwergsignal"
 					/>
 			</item>
@@ -1048,14 +970,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				de.text="Signalstandort"
 				values="left,right,overhead"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Oberleitung"
-				default=""
 				/>
 			<combo key="railway:signal:direction"
 				text="Direction"
 				de.text="Anzeigerichtung"
 				values="forward,backward"
 				display_values="In Wegrichtung,Entgegen Wegrichtung"
-				default=""
 				/>
 			<space />
 			<combo key="railway:signal:electricity"
@@ -1063,20 +983,17 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				de.text="Signaltyp"
 				values="AT-V2:ankündigung_hauptschalter_aus,AT-V2:hauptschalter_aus,AT-V2:hauptschalter_ein,AT-V2:ankündigung_stromabnehmer_tief,AT-V2:stromabnehmer_tief,AT-V2:stromabnehmer_hoch,AT-V2:halt_fuer_fahrzeuge_mit_angehobenem_stromabnehmer;AT-V2:bahnhof-streckentrennung_anfang;AT-V2:bahnhof-streckentrennung_ende"
 				display_values="Ankündigung Hauptschalter aus,Hauptschalter aus,Hauptschalter ein,Ankündigung Stromabnehmer tief,Stromabnehmer tief,Stromabnehmer hoch,Halt für Fahrzeuge mit angehobenem Stromabnehmer,Bahnhof-Streckentrennung Anfang,Bahnhof-Streckentrennung Ende"
-				default=""
 				/>
 			<combo key="railway:signal:electricity:turn_direction"
 				text="Turn direction arrow – if the signals only valid for some turn directions at the next switch/junction. Leave this key empty if there is no arrow."
 				de.text="Richtungs – falls das Signal an der nächsten Weiche/Abzweigung nur für bestimmte Richtungen gilt. Leer lassen, falls es keinen Richtungspfeil gibt."
 				values="left,through,right"
 				display_values="links,geradeaus,rechts"
-				default=""
 				/>
 			<combo key="railway:signal:electricity:height"
 				text="Signal height"
 				de.text="Signalbauform"
 				values="normal,dwarf"
-				default=""
 				display_values="Mastbauform,Zwergsignal"
 				/>
 			<combo key="railway:signal:electricity:type"
@@ -1084,7 +1001,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				de.text="Bedeutung"
 				values="power_off_advance,power_off,power_on,pantograph_down_advance,pantograph_down,pantograph_up,end_of_catenary,pantograph_down,pantograph_up"
 				display_values="Ankündigung Hauptschalter aus,Hauptschalter aus,Hauptschalter ein,Ankündigung Stromabnehmer tief,Stromabnehmer tief,Stromabnehmer hoch,Halt für Fahrzeuge mit angehobenem Stromabnehmer,Bahnhof-Streckentrennung Anfang,Bahnhof-Streckentrennung Ende"
-				default=""
 				/>
 			<key key="railway:signal:electricity:form"
 				value="sign" />
@@ -1105,14 +1021,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				de.text="Signalstandort"
 				values="left,right,overhead"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Oberleitung"
-				default=""
 				/>
 			<combo key="railway:signal:direction"
 				text="Direction"
 				de.text="Anzeigerichtung"
 				values="forward,backward"
 				display_values="In Wegrichtung,Entgegen Wegrichtung"
-				default=""
 				/>
 			<space />
 			<key key="railway:signal:electricity"
@@ -1142,14 +1056,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Signalstandort"
 					values="left,right,bridge"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
-					default=""
 					/>
 				<combo key="railway:signal:direction"
 					text="Direction"
 					de.text="Anzeigerichtung"
 					values="forward,backward"
 					display_values="In Wegrichtung,Entgegen Wegrichtung"
-					default=""
 					/>
 				<space />
 				<key key="railway:signal:crossing"
@@ -1175,14 +1087,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Signalstandort"
 					values="left,right"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung"
-					default=""
 					/>
 				<combo key="railway:signal:direction"
 					text="Direction"
 					de.text="Anzeigerichtung"
 					values="forward,backward"
 					display_values="In Wegrichtung,Entgegen Wegrichtung"
-					default=""
 					/>
 				<key key="railway:signal:crossing_hint"
 					value="AT-V2:eküs" />
@@ -1191,13 +1101,11 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<text key="railway:signal:crossing_hint:caption"
 					text="Caption (e.g. '3 EK')"
 					de.text="Beschriftung (z. B. '3 EK')"
-					default=""
 					/>
 				<combo key="railway:signal:crossing_hint:height"
 					text="Signal height"
 					de.text="Signalbauform"
 					values="normal,dwarf"
-					default=""
 					display_values="Mastbauform,Zwergsignal"
 					/>
 			</item>
@@ -1217,14 +1125,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Signalstandort"
 					values="left,right"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung"
-					default=""
 					/>
 				<combo key="railway:signal:direction"
 					text="Direction"
 					de.text="Anzeigerichtung"
 					values="forward,backward"
 					display_values="In Wegrichtung,Entgegen Wegrichtung"
-					default=""
 					/>
 				<key key="railway:signal:crossing_info"
 					value="AT-V2:eküs" />
@@ -1233,13 +1139,11 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<text key="railway:signal:crossing_info:caption"
 					text="Caption (e.g. 'EK 3')"
 					de.text="Beschriftung (z. B. 'EK 3')"
-					default=""
 					/>
 				<combo key="railway:signal:crossing_info:height"
 					text="Signal height"
 					de.text="Signalbauform"
 					values="normal,dwarf"
-					default=""
 					display_values="Mastbauform,Zwergsignal"
 					/>
 			</item>
@@ -1259,14 +1163,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Signalstandort"
 					values="left,right,bridge"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
-					default=""
 					/>
 				<combo key="railway:signal:direction"
 					text="Direction"
 					de.text="Anzeigerichtung"
 					values="forward,backward"
 					display_values="In Wegrichtung,Entgegen Wegrichtung"
-					default=""
 					/>
 				<space />
 				<key key="railway:signal:crossing_distant"
@@ -1290,14 +1192,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Signalstandort"
 					values="left,right,bridge"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
-					default=""
 					/>
 				<combo key="railway:signal:direction"
 					text="Direction"
 					de.text="Anzeigerichtung"
 					values="forward,backward"
 					display_values="In Wegrichtung,Entgegen Wegrichtung"
-					default=""
 					/>
 				<space />
 				<key key="railway:signal:crossing_distant"
@@ -1307,7 +1207,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<text key="railway:signal:crossing_distant:caption"
 					text="Position of level crossing (e.g. '13.427')"
 					de.text="Streckenkilometer der Eisenbahnkreuzung (z. B. '13.427')"
-					default=""
 					/>
 			</item>
 			<item name="Pfeifpflock" type="node">
@@ -1326,14 +1225,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Signalstandort"
 					values="left,right,bridge"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
-					default=""
 					/>
 				<combo key="railway:signal:direction"
 					text="Direction"
 					de.text="Anzeigerichtung"
 					values="forward,backward"
 					display_values="In Wegrichtung,Entgegen Wegrichtung"
-					default=""
 					/>
 				<space />
 				<key key="railway:signal:whistle"
@@ -1357,14 +1254,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Signalstandort"
 					values="left,right,bridge"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
-					default=""
 					/>
 				<combo key="railway:signal:direction"
 					text="Direction"
 					de.text="Anzeigerichtung"
 					values="forward,backward"
 					display_values="In Wegrichtung,Entgegen Wegrichtung"
-					default=""
 					/>
 				<space />
 				<key key="railway:signal:whistle"
@@ -1388,14 +1283,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Signalstandort"
 					values="left,right,bridge"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
-					default=""
 					/>
 				<combo key="railway:signal:direction"
 					text="Direction"
 					de.text="Anzeigerichtung"
 					values="forward,backward"
 					display_values="In Wegrichtung,Entgegen Wegrichtung"
-					default=""
 					/>
 				<space />
 				<key key="railway:signal:whistle"
@@ -1420,14 +1313,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				de.text="Signalstandort"
 				values="left,right"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung"
-				default=""
 				/>
 			<combo key="railway:signal:direction"
 				text="Direction"
 				de.text="Anzeigerichtung"
 				values="forward,backward"
 				display_values="In Wegrichtung,Entgegen Wegrichtung"
-				default=""
 				/>
 			<key key="railway:signal:stop"
 				value="AT-V2:haltepunkt" />
@@ -1437,13 +1328,11 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				text="Signal height"
 				de.text="Signalbauform"
 				values="normal,dwarf"
-				default=""
 				display_values="Mastbauform,Zwergsignal"
 				/>
 			<text key="railway:signal:stop:description"
 				text="Description"
 				de.text="Zusatztext"
-				default=""
 				/>
 		</item>
 		<item name="Haltestellentafel" icon="de/ne6-32.png" type="node">
@@ -1462,14 +1351,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				de.text="Signalstandort"
 				values="left,right"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung"
-				default=""
 				/>
 			<combo key="railway:signal:direction"
 				text="Direction"
 				de.text="Anzeigerichtung"
 				values="forward,backward"
 				display_values="In Wegrichtung,Entgegen Wegrichtung"
-				default=""
 				/>
 			<key key="railway:signal:station_distant"
 				value="AT-V2:haltestellentafel" />
@@ -1492,14 +1379,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				de.text="Signalstandort"
 				values="left,right"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung"
-				default=""
 				/>
 			<combo key="railway:signal:direction"
 				text="Direction"
 				de.text="Anzeigerichtung"
 				values="forward,backward"
 				display_values="In Wegrichtung,Entgegen Wegrichtung"
-				default=""
 				/>
 			<space />
 			<key key="railway:signal:resetting_switch"
@@ -1510,7 +1395,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				text="Signal height"
 				de.text="Signalbauform"
 				values="normal,dwarf"
-				default=""
 				display_values="Mastbauform,Zwergsignal"
 				/>
 		</item>
@@ -1526,7 +1410,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Signalstandort"
 					values="left,right"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung"
-					default=""
 					/>
 				<key key="railway:signal:fouling_point"
 					value="AT-V2:grenzmarke" />
@@ -1542,7 +1425,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Signalstandort"
 					values="left,right"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung"
-					default=""
 					/>
 				<key key="railway:signal:fouling_point"
 					value="AT-V2:markierte_grenzmarke" />
@@ -1558,7 +1440,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Signalstandort"
 					values="left,right"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung"
-					default=""
 					/>
 				<key key="railway:signal:fouling_point"
 					value="AT-V2:verschub-grenzmarke" />
@@ -1574,7 +1455,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Signalstandort"
 					values="left,right"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung"
-					default=""
 					/>
 				<key key="railway:signal:fouling_point"
 					value="AT-V2:grenzmarke_rollwagenbetrieb" />
@@ -1596,14 +1476,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				de.text="Signalstandort"
 				values="left,right,bridge"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
-				default=""
 				/>
 			<combo key="railway:signal:direction"
 				text="Direction"
 				de.text="Anzeigerichtung"
 				values="forward,backward,both"
 				display_values="In Wegrichtung,Entgegen Wegrichtung,Beide Richtungen"
-				default=""
 				/>
 			<key key="railway:signal:brake_test"
 				value="AT-V2:bremsprobesignal" />
@@ -1628,14 +1506,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				de.text="Signalstandort"
 				values="left,right,bridge"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
-				default=""
 				/>
 			<combo key="railway:signal:direction"
 				text="Direction"
 				de.text="Anzeigerichtung"
 				values="forward,backward,both"
 				display_values="In Wegrichtung,Entgegen Wegrichtung,Beide Richtungen"
-				default=""
 				/>
 			<key key="railway:signal:departure"
 				value="AT-V2:abfahrt" />
@@ -1658,14 +1534,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				de.text="Signalstandort"
 				values="left,right,bridge"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
-				default=""
 				/>
 			<combo key="railway:signal:direction"
 				text="Direction"
 				de.text="Anzeigerichtung"
 				values="forward,backward,both"
 				display_values="In Wegrichtung,Entgegen Wegrichtung,Beide Richtungen"
-				default=""
 				/>
 			<key key="railway:signal:departure"
 				value="AT-V2:fahrerlaubnissignal" />
@@ -1674,7 +1548,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				de.text="Anzeigeart"
 				values="light,sign"
 				display_values="Lichtsignal,Tafel"
-				default=""
 				/>
 			<check key="railway:signal:departure:repeated"
 				text="Repeated Signal"
@@ -1699,14 +1572,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Signalstandort"
 					values="left,right"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung"
-					default=""
 					/>
 				<combo key="railway:signal:direction"
 					text="Direction"
 					de.text="Anzeigerichtung"
 					values="forward,backward"
 					display_values="In Wegrichtung,Entgegen Wegrichtung"
-					default=""
 					/>
 				<key key="railway:signal:snowplow"
 					value="AT-V2:räumarbeit_einstellen" />
@@ -1731,14 +1602,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Signalstandort"
 					values="left,right"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung"
-					default=""
 					/>
 				<combo key="railway:signal:direction"
 					text="Direction"
 					de.text="Anzeigerichtung"
 					values="forward,backward"
 					display_values="In Wegrichtung,Entgegen Wegrichtung"
-					default=""
 					/>
 				<key key="railway:signal:snowplow"
 					value="AT-V2:mittelräumer_heben" />
@@ -1763,14 +1632,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Signalstandort"
 					values="left,right"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung"
-					default=""
 					/>
 				<combo key="railway:signal:direction"
 					text="Direction"
 					de.text="Anzeigerichtung"
 					values="forward,backward"
 					display_values="In Wegrichtung,Entgegen Wegrichtung"
-					default=""
 					/>
 				<key key="railway:signal:snowplow"
 					value="AT-V2:räumarbeit_aufnehmen" />
@@ -1796,14 +1663,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				de.text="Signalstandort"
 				values="left,right"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung"
-				default=""
 				/>
 			<combo key="railway:signal:direction"
 				text="Direction"
 				de.text="Anzeigerichtung"
 				values="forward,backward"
 				display_values="In Wegrichtung,Entgegen Wegrichtung"
-				default=""
 				/>
 			<check key="railway:signal:catenary_mast"
 				text="On catenary mast"
@@ -1819,12 +1684,10 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				de.text="Anzeigerichtung"
 				values="start,section"
 				display_values="LZB Anfang,Bereichswechsel"
-				default=""
 				/>
 			<text key="railway:position:exact"
 				text="Exact position (e.g. '13.427')"
 				de.text="Standortangabe (z. B. '13.427')"
-				default=""
 				/>
 		</item>
 		<item name="Signalnachahmer" type="node">
@@ -1836,7 +1699,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<text key="ref"
 				text="Signal ref"
 				de.text="Signalbezeichnung"
-				default=""
 				/>
 			<check key="railway:signal:main_repeated:deactivated"
 				text="Out of order"
@@ -1848,14 +1710,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				de.text="Signalstandort"
 				values="left,right,bridge"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
-				default=""
 				/>
 			<combo key="railway:signal:direction"
 				text="Direction"
 				de.text="Anzeigerichtung"
 				values="forward,backward"
 				display_values="In Wegrichtung,Entgegen Wegrichtung"
-				default=""
 				/>
 			<space />
 			<key key="railway:signal:main_repeated"
@@ -1869,7 +1729,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				de.text="Anzeigerichtung"
 				values="AT-V2:ersatzsignal, "
 				display_values="Kann Ersatzsignal anzeigen,Kann kein Ersatzsignal anzeigen"
-				default=""
 				/>
 		</item>
 		<item name="Fahrwegende" type="node">
@@ -1888,14 +1747,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				de.text="Signalstandort"
 				values="left,right,in_track"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Gleismitte/am Prellbock"
-				default=""
 				/>
 			<combo key="railway:signal:direction"
 				text="Direction"
 				de.text="Anzeigerichtung"
 				values="forward,backward"
 				display_values="In Wegrichtung,Entgegen Wegrichtung"
-				default=""
 				/>
 			<space />
 			<key key="railway:signal:minor"
@@ -1906,7 +1763,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				text="Signal height"
 				de.text="Signalbauform"
 				values="normal,dwarf"
-				default=""
 				display_values="Mastbauform,Zwergsignal"
 				/>
 		</item>
@@ -1926,14 +1782,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				de.text="Signalstandort"
 				values="left,right,in_track"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Gleismitte/am Prellbock"
-				default=""
 				/>
 			<combo key="railway:signal:direction"
 				text="Direction"
 				de.text="Anzeigerichtung"
 				values="forward,backward"
 				display_values="In Wegrichtung,Entgegen Wegrichtung"
-				default=""
 				/>
 			<space />
 			<key key="railway:signal:main:substitute_signal"
@@ -1944,7 +1798,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				text="Signal height"
 				de.text="Signalbauform"
 				values="normal,dwarf"
-				default=""
 				display_values="Mastbauform,Zwergsignal"
 				/>
 		</item>
@@ -1964,14 +1817,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				de.text="Signalstandort"
 				values="left,right"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung"
-				default=""
 				/>
 			<combo key="railway:signal:direction"
 				text="Direction"
 				de.text="Anzeigerichtung"
 				values="forward,backward"
 				display_values="In Wegrichtung,Entgegen Wegrichtung"
-				default=""
 				/>
 			<check key="railway:signal:catenary_mast"
 				text="On catenary mast"
@@ -1981,7 +1832,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<text key="ref"
 				text="Block reference"
 				de.text="Blockbezeichner"
-				default=""
 				/>
 			<key key="railway:signal:train_protection"
 				value="AT-V2:etcs-blockkennzeichen" />

--- a/josm-presets/at.xml
+++ b/josm-presets/at.xml
@@ -22,20 +22,17 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<text key="ref"
 					text="Line ref (VzG number, e.g. '2379')"
 					de.text="Streckennummer (VzG-Nummer, z. B. '2379')"
-					default=""
 					/>
 				<text key="railway:track_ref"
 					text="Track ref (inside station)"
 					de.text="Gleisnummer (im Bahnhof)"
-					default=""
 					/>
 				<text key="name"
 					text="Railway name"
 					de.text="Streckenname"
-					default=""
 					/>
 				<space />	
-				<combo key="usage" text="Usage" de.text="Nutzung" default="">
+				<combo key="usage" text="Usage" de.text="Nutzung">
 					<list_entry value="main" de.display_value="Hauptbahn" display_value="main line" de.short_description="Strecke mit übergeordneter Bedeutung; meist zweigleisig, meist elektrifiziert, in der Regel zumindest abschnittsweise mit mehr als 100 km/h befahrbar" short_description="An important line; often double tracks, electrified; usually more than 100 km/h" />
 					<list_entry value="branch" de.display_value="Nebenbahn" display_value="branch line" de.short_description="Strecke mit untergeordneter Bedeutung; oft nicht elektrifiziert, oft eingleisig. Keinesfalls mit mehr als 100 km/h befahrbar." short_description="less important line; often single-tracked; not electrified; less than 100 km/h" />
 					<list_entry value="industrial" de.display_value="Industriebahn" display_value="industrial line" de.short_description="Eine Strecke, die ausschließlich dem Güterverkehr dient und in der Regel Eigentum eines Industrieunternehmens ist. Meist nur innerhalb von Hafengebieten, Industrieanlagen, Tagebauen." short_description="A line only used for freight trains inside industrial areas or mines." />
@@ -48,7 +45,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Verkehrsart"
 					values="mixed,passenger,freight"
 					display_values="Gemischt,Personenverkehr,Güterverkehr"
-					default=""
 					/>
 				<check key="highspeed"
 					text="High-speed line (~ >200 km/h)"
@@ -81,27 +77,25 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="ETCS"
 					values="yes,no,0,1,2,3"
 					display_values="Ja,Nein,Level 0,Level 1,Level 2,Level 3"
-					default=""
 					/>
 				<combo key="railway:radio"
 					text="Radio"
 					de.text="Zugfunk"
 					values="analogue,gsm-r"
 					display_values="Analog,GSM-R"
-					default=""
 					/>
-				<combo key="railway:preferred_direction" text="Direction of use (depends on direction of OSM way)" de.text="Regelfahrtrichtung (abhängig von Richtung des OSM-Ways)" default="">
+				<combo key="railway:preferred_direction" text="Direction of use (depends on direction of OSM way)" de.text="Regelfahrtrichtung (abhängig von Richtung des OSM-Ways)">
 					<list_entry value="forward" display_value="In Wegrichtung" short_description="Das Gleis wird üblicherweise in die Richtung befahren, in die der OSM-Way führt. Nur für mehrgleisige Strecken." />
 					<list_entry value="backward" display_value="Entgegen Wegrichtung" short_description="Das Gleis wird üblicherweise entgegen der Richtung befahren, in die der OSM-Way führt. Nur für mehrgleisige Strecken." />
 					<list_entry value="both" display_value="Beide Richtungen" short_description="Es gibt keine Richtung, in die die Züge üblicherweise fahren bzw. nicht fahren. Nur für eingleisige Strecken." />
 				</combo>
-				<combo key="railway:bidirectional" text="Bidirectional traffic (depends on direction of OSM way)" de.text="Gleiswechselbetrieb (abhängig von Richtung des OSM-Ways)" default="">
+				<combo key="railway:bidirectional" text="Bidirectional traffic (depends on direction of OSM way)" de.text="Gleiswechselbetrieb (abhängig von Richtung des OSM-Ways)">
 					<list_entry value="regular" display_value="Gleiswechselbetrieb" short_description="Das Gleis ist für beide Fahrtrichtungen mit Signalen ausgestattet und kann daher regulär entgegen der üblichen Fahrtrichtung befahren werden." />
 					<list_entry value="signals" display_value="Signalisierter Falschfahrbetrieb" short_description="Das Gleis ist signaltechnisch nur für eine Fahrtrichtung ausgelegt, sodass weiterhin Falschfahrten notwendig sind, diese sind aber durch Signale geregelt." />
 					<list_entry value="possible" display_value="Falschfahrt möglich" short_description="Signaltechnisch besteht keine Möglichkeit einer Befahrung des Gegengleises. Es ist ein schriftlicher Befehl notwendig." />
 				</combo>
 				<space />
-				<combo key="maxspeed" default=""
+				<combo key="maxspeed"
 					text="Maxspeed (km/h)"
 					de.text="Höchstgeschwindigkeit (km/h)"
 					values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,none"
@@ -113,21 +107,18 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Elektrifizierung"
 					values="yes,no,contact_line,rail"
 					display_values="Ja,Nein,Ja (mit Oberleitung),Ja (mit Stromschiene)"
-					default=""
 					/>
 				<combo key="voltage"
 					text="Voltage"
 					de.text="Spannung"
 					values="15000,500,550,600,750,850,1000,1200,1500,2400,3000,6500,6600,11000,25000"
 					display_values="15 kV (Standard in Österreich),500 V,550 V,600 V,750 V,850 V,1000 V,1200 V,1500 V,2400 V,3000 V,6500 V,6600 V,11 kV,25 kV"
-					default=""
 					/>
 				<combo key="frequency"
 					text="Frequency"
 					de.text="Frequenz"
 					values="16.7,0,16.67,50,60,25"
 					display_values="16.7 Hz (Standard in Österreich),Gleichspannung,16 2/3 Hz,50 Hz,60 Hz,25 Hz"
-					default=""
 					/>
 				<key key="gauge"
 					value="1435" />
@@ -141,23 +132,19 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Zahnstange"
 					values="yes,no,riggenbach,strub,abt,locher,riggenbach-klose,marsh,von_roll"
 					display_values="Ja,Nein,System Riggenbach,System Strub,System Abt,System Locher,System Riggenbach-Klose,System Marsh,System Von Roll"
-					default=""
 					/>
 				<text key="incline"
 					text="Incline (e.g.. '3%')"
 					de.text="Steigung (z. B. '3%')"
-					default=""
 					/>
 				<space />
 				<text key="start_date"
 					text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
-					default=""
 					/>
 				<text key="operator"
 					text="Operator (e.g. 'ÖBB-Infrastruktur AG')"
 					de.text="Betreiber (z. B. 'ÖBB-Infrastruktur AG')"
-					default=""
 					/>
 				<space />
 				<check key="embankment"
@@ -181,7 +168,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<text key="railway:track_ref"
 					text="Track ref (inside station)"
 					de.text="Gleisnummer (im Bahnhof)"
-					default=""
 					/>
 				<space />
 				<combo key="railway:traffic_mode"
@@ -189,7 +175,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Verkehrsart"
 					values="mixed,passenger,freight"
 					display_values="Gemischt,Personenverkehr,Güterverkehr"
-					default=""
 					/>
 				<check key="highspeed"
 					text="High-speed line (~ >200 km/h)"
@@ -217,16 +202,14 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="ETCS"
 					values="yes,no,0,1,2,3"
 					display_values="Ja,Nein,Level 0,Level 1,Level 2,Level 3"
-					default=""
 					/>
 				<combo key="railway:radio"
 					text="Radio"
 					de.text="Zugfunk"
 					values="analogue,gsm-r"
 					display_values="Analog,GSM-R"
-					default=""
 					/>
-				<combo key="maxspeed" default=""
+				<combo key="maxspeed"
 					text="Maxspeed (km/h)"
 					de.text="Höchstgeschwindigkeit (km/h)"
 					values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,none"
@@ -238,21 +221,18 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Elektrifizierung"
 					values="yes,no,contact_line,rail"
 					display_values="Ja,Nein,Oberleitung,Stromschiene"
-					default=""
 					/>
 				<combo key="voltage"
 					text="Voltage"
 					de.text="Spannung"
 					values="15000,500,550,600,750,850,1000,1200,1500,2400,3000,6500,6600,11000,25000"
 					display_values="15 kV (Standard in Österreich),500 V,550 V,600 V,750 V,850 V,1000 V,1200 V,1500 V,2400 V,3000 V,6500 V,6600 V,11 kV,25 kV"
-					default=""
 					/>
 				<combo key="frequency"
 					text="Frequency"
 					de.text="Frequenz"
 					values="16.7,0,16.67,50,60,25"
 					display_values="16.7 Hz (Standard in Österreich),Gleichspannung,16 2/3 Hz,50 Hz,60 Hz,25 Hz"
-					default=""
 					/>
 				<key key="gauge"
 					value="1435" />
@@ -266,23 +246,19 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Zahnstange"
 					values="yes,no,riggenbach,strub,abt,locher,riggenbach-klose,marsh,von_roll"
 					display_values="Ja,Nein,System Riggenbach,System Strub,System Abt,System Locher,System Riggenbach-Klose,System Marsh,System Von Roll"
-					default=""
 					/>
 				<text key="incline"
 					text="Incline (e.g.. '3%')"
 					de.text="Steigung (z. B. '3%')"
-					default=""
 					/>
 				<space />
 				<text key="start_date"
 					text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
-					default=""
 					/>
 				<text key="operator"
 					text="Operator (e.g. 'ÖBB-Infrastruktur AG')"
 					de.text="Betreiber (z. B. 'ÖBB-Infrastruktur AG')"
-					default=""
 					/>
 				<space />
 				<check key="embankment"
@@ -306,7 +282,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<text key="railway:track_ref"
 					text="Track ref (inside station)"
 					de.text="Gleisnummer (im Bahnhof)"
-					default=""
 					/>
 				<space />
 				<combo key="railway:traffic_mode"
@@ -314,7 +289,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Verkehrsart"
 					values="mixed,passenger,freight"
 					display_values="Gemischt,Personenverkehr,Güterverkehr"
-					default=""
 					/>
 				<space />
 				<check key="lit"
@@ -332,16 +306,14 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="ETCS"
 					values="yes,no,0,1,2,3"
 					display_values="Ja,Nein,Level 0,Level 1,Level 2,Level 3"
-					default=""
 					/>
 				<combo key="railway:radio"
 					text="Radio"
 					de.text="Zugfunk"
 					values="analogue,gsm-r"
 					display_values="Analog,GSM-R"
-					default=""
 					/>
-				<combo key="maxspeed" default=""
+				<combo key="maxspeed"
 					text="Maxspeed (km/h)"
 					de.text="Höchstgeschwindigkeit (km/h)"
 					values="10,20,30,40,50,60,70,80,90,100,none"
@@ -353,21 +325,18 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Elektrifizierung"
 					values="yes,no,contact_line,rail"
 					display_values="Ja,Nein,Oberleitung,Stromschiene"
-					default=""
 					/>
 				<combo key="voltage"
 					text="Voltage"
 					de.text="Spannung"
 					values="15000,500,550,600,750,850,1000,1200,1500,2400,3000,6500,6600,11000,25000"
 					display_values="15 kV (Standard in Österreich),500 V,550 V,600 V,750 V,850 V,1000 V,1200 V,1500 V,2400 V,3000 V,6500 V,6600 V,11 kV,25 kV"
-					default=""
 					/>
 				<combo key="frequency"
 					text="Frequency"
 					de.text="Frequenz"
 					values="16.7,0,16.67,50,60,25"
 					display_values="16.7 Hz (Standard in Österreich),Gleichspannung,16 2/3 Hz,50 Hz,60 Hz,25 Hz"
-					default=""
 					/>
 				<key key="gauge"
 					value="1435" />
@@ -381,23 +350,19 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Zahnstange"
 					values="yes,no,riggenbach,strub,abt,locher,riggenbach-klose,marsh,von_roll"
 					display_values="Ja,Nein,System Riggenbach,System Strub,System Abt,System Locher,System Riggenbach-Klose,System Marsh,System Von Roll"
-					default=""
 					/>
 				<text key="incline"
 					text="Incline (e.g.. '3%')"
 					de.text="Steigung (z. B. '3%')"
-					default=""
 					/>
 				<space />
 				<text key="start_date"
 					text="Year of opening"
 					de.text="Zeitpunkt der Inbetriebnahme"
-					default=""
 					/>
 				<text key="operator"
 					text="Operator (e.g. 'ÖBB-Infrastruktur AG')"
 					de.text="Betreiber (z. B. 'ÖBB-Infrastruktur AG')"
-					default=""
 					/>
 				<space />
 				<check key="embankment"
@@ -442,16 +407,14 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="ETCS"
 					values="yes,no,0,1,2,3"
 					display_values="Ja,Nein,Level 0,Level 1,Level 2,Level 3"
-					default=""
 					/>
 				<combo key="railway:radio"
 					text="Radio"
 					de.text="Zugfunk"
 					values="analogue,gsm-r"
 					display_values="Analog,GSM-R"
-					default=""
 					/>
-				<combo key="maxspeed" default=""
+				<combo key="maxspeed"
 					text="Maxspeed (km/h)"
 					de.text="Höchstgeschwindigkeit (km/h)"
 					values="10,20,30,40,50,60,70,80,90,100,none"
@@ -463,21 +426,18 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Elektrifizierung"
 					values="yes,no,contact_line,rail"
 					display_values="Ja,Nein,Oberleitung,Stromschiene"
-					default=""
 					/>
 				<combo key="voltage"
 					text="Voltage"
 					de.text="Spannung"
 					values="15000,500,550,600,750,850,1000,1200,1500,2400,3000,6500,6600,11000,25000"
 					display_values="15 kV (Standard in Deutschland),500 V,550 V,600 V,750 V,850 V,1000 V,1200 V,1500 V,2400 V,3000 V,6500 V,6600 V,11 kV,25 kV"
-					default=""
 					/>
 				<combo key="frequency"
 					text="Frequency"
 					de.text="Frequenz"
 					values="16.7,16.67,50,60,25,0"
 					display_values="16.7 Hz (Standard in Deutschland),16 2/3 Hz (in Teilen Deutschlands),50 Hz,60 Hz,25 Hz,Gleichspannung"
-					default=""
 					/>
 				<key key="gauge"
 					value="1435" />
@@ -491,23 +451,19 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Zahnstange"
 					values="yes,no,riggenbach,strub,abt,locher,riggenbach-klose,marsh,von_roll"
 					display_values="Ja,Nein,System Riggenbach,System Strub,System Abt,System Locher,System Riggenbach-Klose,System Marsh,System Von Roll"
-					default=""
 					/>
 				<text key="incline"
 					text="Incline (e.g.. '3%')"
 					de.text="Steigung (z. B. '3%')"
-					default=""
 					/>
 				<space />
 				<text key="start_date"
 					text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
-					default=""
 					/>
 				<text key="operator"
 					text="Operator (e.g. 'ÖBB-Infrastruktur AG')"
 					de.text="Betreiber (z. B. 'ÖBB-Infrastruktur AG')"
-					default=""
 					/>
 				<space />
 				<check key="embankment"
@@ -534,7 +490,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Verkehrsart"
 					values="mixed,passenger,freight"
 					display_values="Gemischt,Personenverkehr,Güterverkehr"
-					default=""
 					/>
 				<check key="highspeed"
 					text="High-speed line (~ >200 km/h)"
@@ -562,17 +517,15 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="ETCS"
 					values="yes,no,0,1,2,3"
 					display_values="Ja,Nein,Level 0,Level 1,Level 2,Level 3"
-					default=""
 					/>
 				<combo key="railway:radio"
 					text="Radio"
 					de.text="Zugfunk"
 					values="analogue,gsm-r"
 					display_values="Analog,GSM-R"
-					default=""
 					/>
 				<space />
-				<combo key="maxspeed" default=""
+				<combo key="maxspeed"
 					text="Maxspeed (km/h)"
 					de.text="Höchstgeschwindigkeit (km/h)"
 					values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,none"
@@ -584,21 +537,18 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Elektrifizierung"
 					values="yes,no,contact_line,rail"
 					display_values="Ja,Nein,Oberleitung,Stromschiene"
-					default=""
 					/>
 				<combo key="voltage"
 					text="Voltage"
 					de.text="Spannung"
 					values="15000,500,550,600,750,850,1000,1200,1500,2400,3000,6500,6600,11000,25000"
 					display_values="15 kV (Standard in Österreich),500 V,550 V,600 V,750 V,850 V,1000 V,1200 V,1500 V,2400 V,3000 V,6500 V,6600 V,11 kV,25 kV"
-					default=""
 					/>
 				<combo key="frequency"
 					text="Frequency"
 					de.text="Frequenz"
 					values="16.7,0,16.67,50,60,25"
 					display_values="16.7 Hz (Standard in Österreich),Gleichspannung,16 2/3 Hz,50 Hz,60 Hz,25 Hz"
-					default=""
 					/>
 				<key key="gauge"
 					value="1435" />
@@ -612,23 +562,19 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Zahnstange"
 					values="yes,no,riggenbach,strub,abt,locher,riggenbach-klose,marsh,von_roll"
 					display_values="Ja,Nein,System Riggenbach,System Strub,System Abt,System Locher,System Riggenbach-Klose,System Marsh,System Von Roll"
-					default=""
 					/>
 				<text key="incline"
 					text="Incline (e.g.. '3%')"
 					de.text="Steigung (z. B. '3%')"
-					default=""
 					/>
 				<space />
 				<text key="start_date"
 					text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
-					default=""
 					/>
 				<text key="operator"
 					text="Operator (e.g. 'ÖBB-Infrastruktur AG')"
 					de.text="Betreiber (z. B. 'ÖBB-Infrastruktur AG')"
-					default=""
 					/>
 				<space />
 				<check key="embankment"
@@ -651,20 +597,17 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<text key="ref"
 					text="Line ref (VzG number, e.g. '2379')"
 					de.text="Streckennummer (VzG-Nummer, z. B. '2379')"
-					default=""
 					/>
 				<text key="railway:track_ref"
 					text="Track ref (inside station)"
 					de.text="Gleisnummer (im Bahnhof)"
-					default=""
 					/>
 				<text key="name"
 					text="Railway name"
 					de.text="Streckenname"
-					default=""
 					/>
 				<space />
-				<combo key="usage" text="Usage (leave empty if main track or line)" de.text="Nutzung (leer lassen bei Strecken- und Hauptgleisen)" default="">
+				<combo key="usage" text="Usage (leave empty if main track or line)" de.text="Nutzung (leer lassen bei Strecken- und Hauptgleisen)">
 					<list_entry value="branch" display_value="Reguläre Strecke" short_description="Eine Schmalspurbahn, auf der regulärer Personen- und/oder Güterverkehr stattfindet." />
 					<list_entry value="industrial" display_value="Industriebahn" short_description="Eine Strecke, die ausschließlich dem Güterverkehr dient und in der Regel Eigentum eines Industrieunternehmens ist. Meist nur innerhalb von Hafengebieten, Industrieanlagen, Tagebauen." />
 					<list_entry value="military" display_value="Militärbahn" short_description="Eine Strecke, die ausschließlich dem Militärverkehr dient. Meistens Strecken zwischen normalen Bahnstrecken und Munitionsdepots oder Truppenübungsplätzen." />
@@ -676,9 +619,8 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Verkehrsart"
 					values="mixed,passenger,freight"
 					display_values="Gemischt,Personenverkehr,Güterverkehr"
-					default=""
 					/>
-				<combo key="service" text="Track service" de.text="Gleisfunktion" default="">
+				<combo key="service" text="Track service" de.text="Gleisfunktion">
 				  <list_entry value="siding" display_value="Nebengleis" short_description="Gleise in Bahnhöfen, die parallel zum durchgehenden Hauptgleis verlaufen und zum Überholen und Halten von Zügen dienen" /><!-- FIXME: Abgrenzung zwischen (nicht durchgehenden) Hauptgleisen und (planmäßig nicht von Zügen befahrenen) Nebengleisen herausstellen -->
 					<list_entry value="yard" display_value="Abstellgleis" short_description="Gleise in Rangier-, Güter- oder Betriebsbahnhöfen, die zum Rangieren, Zusammenstellen von Zügen und Abstellen von Wagen dienen" />
 					<list_entry value="crossover" display_value="Überleitgleis" short_description="Kurze Gleise, die das Wechseln zwischen zwei Gleisen ermöglichen" />
@@ -706,26 +648,24 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="ETCS"
 					values="yes,no,0,1,2,3"
 					display_values="Ja,Nein,Level 0,Level 1,Level 2,Level 3"
-					default=""
 					/>
 				<combo key="railway:radio"
 					text="Radio"
 					de.text="Zugfunk"
 					values="analogue,gsm-r"
 					display_values="Analog,GSM-R"
-					default=""
 					/>
-				<combo key="railway:preferred_direction" text="Direction of use (depends on direction of OSM way)" de.text="Regelfahrtrichtung (abhängig von Richtung des OSM-Ways)" default="">
+				<combo key="railway:preferred_direction" text="Direction of use (depends on direction of OSM way)" de.text="Regelfahrtrichtung (abhängig von Richtung des OSM-Ways)">
 					<list_entry value="forward" display_value="In Wegrichtung" short_description="Das Gleis wird üblicherweise in die Richtung befahren, in die der OSM-Way führt. Nur für mehrgleisige Strecken." />
 					<list_entry value="backward" display_value="Entgegen Wegrichtung" short_description="Das Gleis wird üblicherweise entgegen der Richtung befahren, in die der OSM-Way führt. Nur für mehrgleisige Strecken." />
 					<list_entry value="both" display_value="Beide Richtungen" short_description="Es gibt keine Richtung, in die die Züge üblicherweise fahren bzw. nicht fahren. Nur für eingleisige Strecken." />
 				</combo>
-				<combo key="railway:bidirectional" text="Bidirectional traffic (depends on direction of OSM way)" de.text="Gleiswechselbetrieb (abhängig von Richtung des OSM-Ways)" default="">
+				<combo key="railway:bidirectional" text="Bidirectional traffic (depends on direction of OSM way)" de.text="Gleiswechselbetrieb (abhängig von Richtung des OSM-Ways)">
 					<list_entry value="regular" display_value="Gleiswechselbetrieb" short_description="Das Gleis ist für beide Fahrtrichtungen mit Signalen ausgestattet und kann daher regulär entgegen der üblichen Fahrtrichtung befahren werden." />
 					<list_entry value="signals" display_value="Signalisierter Falschfahrbetrieb" short_description="Das Gleis ist signaltechnisch nur für eine Fahrtrichtung ausgelegt, sodass weiterhin Falschfahrten notwendig sind, diese sind aber durch Signale geregelt." />
 					<list_entry value="possible" display_value="Falschfahrt möglich" short_description="Signaltechnisch besteht keine Möglichkeit einer Befahrung des Gegengleises. Es ist ein schriftlicher Befehl notwendig." />
 				</combo>
-				<combo key="maxspeed" default=""
+				<combo key="maxspeed"
 					text="Maxspeed (km/h)"
 					de.text="Höchstgeschwindigkeit (km/h)"
 					values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,none"
@@ -737,28 +677,24 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Elektrifizierung"
 					values="yes,no,contact_line,rail"
 					display_values="Ja,Nein,Oberleitung,Stromschiene"
-					default=""
 					/>
 				<combo key="voltage"
 					text="Voltage"
 					de.text="Spannung"
 					values="15000,500,550,600,750,850,1000,1200,1500,2400,3000,6500,6600,11000,25000"
 					display_values="15 kV (Standard in Österreich),500 V,550 V,600 V,750 V,850 V,1000 V,1200 V,1500 V,2400 V,3000 V,6500 V,6600 V,11 kV,25 kV"
-					default=""
 					/>
 				<combo key="frequency"
 					text="Frequency"
 					de.text="Frequenz"
 					values="16.7,0,16.67,50,60,25"
 					display_values="16.7 Hz (Standard in Österreich),Gleichspannung,16 2/3 Hz,50 Hz,60 Hz,25 Hz"
-					default=""
 					/>
 				<combo key="gauge"
 					text="Gauge"
 					de.text="Spurweite"
 					values="1040,1000,900,880,800,760,750,580,500"
 					display_values="1040 mm,1000 mm (Meterspur),900 mm,880 mm,800 mm,760mm (Bosnische Spur),750 mm,580 mm,500 mm"
-					default=""
 					/>
 				<check key="railway:ballastless"
 					text="Ballastless"
@@ -770,23 +706,19 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Zahnstange"
 					values="yes,no,riggenbach,strub,abt,locher,riggenbach-klose,marsh,von_roll"
 					display_values="Ja,Nein,System Riggenbach,System Strub,System Abt,System Locher,System Riggenbach-Klose,System Marsh,System Von Roll"
-					default=""
 					/>
 				<text key="incline"
 					text="Incline (e.g.. '3%')"
 					de.text="Steigung (z. B. '3%')"
-					default=""
 					/>
 				<space />
 				<text key="start_date"
 					text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
-					default=""
 					/>
 				<text key="operator"
 					text="Operator (e.g. 'ÖBB-Infrastruktur AG')"
 					de.text="Betreiber (z. B. 'ÖBB-Infrastruktur AG')"
-					default=""
 					/>
 				<space />
 				<check key="embankment"
@@ -808,17 +740,14 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<text key="ref"
 					text="Line ref (VzG number, e.g. '2379')"
 					de.text="Streckennummer (VzG-Nummer, z. B. '2379')"
-					default=""
 					/>
 				<text key="railway:track_ref"
 					text="Track ref (inside station)"
 					de.text="Gleisnummer (im Bahnhof)"
-					default=""
 					/>
 				<text key="name"
 					text="Railway name"
 					de.text="Streckenname"
-					default=""
 					/>
 				<space />
 				<combo key="railway:traffic_mode"
@@ -826,9 +755,8 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Verkehrsart"
 					values="mixed,passenger,freight"
 					display_values="Gemischt,Personenverkehr,Güterverkehr"
-					default=""
 					/>
-				<combo key="service" text="Track service" de.text="Gleisfunktion" default="">
+				<combo key="service" text="Track service" de.text="Gleisfunktion">
 					<list_entry value="siding" display_value="Nebengleis" short_description="Gleise in Bahnhöfen, die parallel zum durchgehenden Hauptgleis verlaufen und zum Überholen und Halten von Zügen dienen" />
 					<list_entry value="yard" display_value="Abstellgleis" short_description="Gleise in Rangier-, Güter- oder Betriebsbahnhöfen, die zum Rangieren, Zusammenstellen von Zügen und Abstellen von Wagen dienen" />
 					<list_entry value="crossover" display_value="Überleitgleis" short_description="Kurze Gleise, die das Wechseln zwischen zwei Gleisen ermöglichen" />
@@ -851,19 +779,18 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Zugfunk"
 					values="analogue,gsm-r"
 					display_values="Analog,GSM-R"
-					default=""
 					/>
-				<combo key="railway:preferred_direction" text="Direction of use (depends on direction of OSM way)" de.text="Regelfahrtrichtung (abhängig von Richtung des OSM-Ways)" default="">
+				<combo key="railway:preferred_direction" text="Direction of use (depends on direction of OSM way)" de.text="Regelfahrtrichtung (abhängig von Richtung des OSM-Ways)">
 					<list_entry value="forward" display_value="In Wegrichtung" short_description="Das Gleis wird üblicherweise in die Richtung befahren, in die der OSM-Way führt. Nur für mehrgleisige Strecken." />
 					<list_entry value="backward" display_value="Entgegen Wegrichtung" short_description="Das Gleis wird üblicherweise entgegen der Richtung befahren, in die der OSM-Way führt. Nur für mehrgleisige Strecken." />
 					<list_entry value="both" display_value="Beide Richtungen" short_description="Es gibt keine Richtung, in die die Züge üblicherweise fahren bzw. nicht fahren. Nur für eingleisige Strecken." />
 				</combo>
-				<combo key="railway:bidirectional" text="Bidirectional traffic (depends on direction of OSM way)" de.text="Gleiswechselbetrieb (abhängig von Richtung des OSM-Ways)" default="">
+				<combo key="railway:bidirectional" text="Bidirectional traffic (depends on direction of OSM way)" de.text="Gleiswechselbetrieb (abhängig von Richtung des OSM-Ways)">
 					<list_entry value="regular" display_value="Gleiswechselbetrieb" short_description="Das Gleis ist für beide Fahrtrichtungen mit Signalen ausgestattet und kann daher regulär entgegen der üblichen Fahrtrichtung befahren werden." />
 					<list_entry value="signals" display_value="Signalisierter Falschfahrbetrieb" short_description="Das Gleis ist signaltechnisch nur für eine Fahrtrichtung ausgelegt, sodass weiterhin Falschfahrten notwendig sind, diese sind aber durch Signale geregelt." />
 					<list_entry value="possible" display_value="Falschfahrt möglich" short_description="Signaltechnisch besteht keine Möglichkeit einer Befahrung des Gegengleises. Es ist ein schriftlicher Befehl notwendig." />
 				</combo>
-				<combo key="maxspeed" default=""
+				<combo key="maxspeed"
 					text="Maxspeed (km/h)"
 					de.text="Höchstgeschwindigkeit (km/h)"
 					values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,none"
@@ -875,28 +802,24 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Elektrifizierung"
 					values="yes,no,contact_line,rail"
 					display_values="Ja,Nein,Oberleitung,Stromschiene"
-					default=""
 					/>
 				<combo key="voltage"
 					text="Voltage"
 					de.text="Spannung"
 					values="15000,500,550,600,750,850,1000,1200,1500,2400,3000,6500,6600,11000,25000"
 					display_values="15 kV (Standard in Österreich),500 V,550 V,600 V,750 V,850 V,1000 V,1200 V,1500 V,2400 V,3000 V,6500 V,6600 V,11 kV,25 kV"
-					default=""
 					/>
 				<combo key="frequency"
 					text="Frequency"
 					de.text="Frequenz"
 					values="16.7,0,16.67,50,60,25"
 					display_values="16.7 Hz (Standard in Österreich),Gleichspannung,16 2/3 Hz,50 Hz,60 Hz,25 Hz"
-					default=""
 					/>
 				<combo key="gauge"
 					text="Gauge"
 					de.text="Spurweite"
 					values="1435,1040,1000,900,880,800,760,750,580,500,381,184,127"
 					display_values="1435 mm (Normalspur),1040 mm,1000 mm (Meterspur),900 mm,880 mm,800 mm,760mm (Bosnische Spur),750 mm,580 mm,500 mm,381 mm,184 mm,127 mm"
-					default=""
 					/>
 				<check key="railway:ballastless"
 					text="Ballastless"
@@ -908,23 +831,19 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Zahnstange"
 					values="yes,no,riggenbach,strub,abt,locher,riggenbach-klose,marsh,von_roll"
 					display_values="Ja,Nein,System Riggenbach,System Strub,System Abt,System Locher,System Riggenbach-Klose,System Marsh,System Von Roll"
-					default=""
 					/>
 				<text key="incline"
 					text="Incline (e.g.. '3%')"
 					de.text="Steigung (z. B. '3%')"
-					default=""
 					/>
 				<space />
 				<text key="start_date"
 					text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
-					default=""
 					/>
 				<text key="operator"
 					text="Operator (e.g. 'ÖBB-Infrastruktur AG')"
 					de.text="Betreiber (z. B. 'ÖBB-Infrastruktur AG')"
-					default=""
 					/>
 				<space />
 				<check key="embankment"
@@ -946,15 +865,13 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<text key="railway:track_ref"
 					text="Track ref (inside station)"
 					de.text="Gleisnummer (im Bahnhof)"
-					default=""
 					/>
 				<text key="name"
 					text="Railway name"
 					de.text="Streckenname"
-					default=""
 					/>
 				<space />
-				<combo key="usage" text="Usage (leave empty if main track or line)" de.text="Nutzung (leer lassen bei Strecken- und Hauptgleisen)" default="">
+				<combo key="usage" text="Usage (leave empty if main track or line)" de.text="Nutzung (leer lassen bei Strecken- und Hauptgleisen)">
 					<list_entry value="branch" display_value="Reguläre Strecke" short_description="Eine Schmalspurbahn, auf der regulärer Personen- und/oder Güterverkehr stattfindet." />
 					<list_entry value="industrial" display_value="Industriebahn" short_description="Eine Strecke, die ausschließlich dem Güterverkehr dient und in der Regel Eigentum eines Industrieunternehmens ist. Meist nur innerhalb von Hafengebieten, Industrieanlagen, Tagebauen." />
 					<list_entry value="tourism" display_value="Tourismusbahn" short_description="Eine Strecke, die ausschließlich touristischen Zwecken dient, z. B. Museumsstrecken oder Draisinenbahnen." />
@@ -964,9 +881,8 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Verkehrsart"
 					values="mixed,passenger,freight"
 					display_values="Gemischt,Personenverkehr,Güterverkehr"
-					default=""
 					/>
-				<combo key="service" text="Track service" de.text="Gleisfunktion" default="">
+				<combo key="service" text="Track service" de.text="Gleisfunktion">
 					<list_entry value="siding" display_value="Nebengleis" short_description="Gleise in Bahnhöfen, die parallel zum durchgehenden Hauptgleis verlaufen und zum Überholen und Halten von Zügen dienen" />
 					<list_entry value="yard" display_value="Abstellgleis" short_description="Gleise in Rangier-, Güter- oder Betriebsbahnhöfen, die zum Rangieren, Zusammenstellen von Zügen und Abstellen von Wagen dienen" />
 					<list_entry value="crossover" display_value="Überleitgleis" short_description="Kurze Gleise, die das Wechseln zwischen zwei Gleisen ermöglichen" />
@@ -984,9 +900,8 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Zugfunk"
 					values="analogue,gsm-r"
 					display_values="Analog,GSM-R"
-					default=""
 					/>
-				<combo key="maxspeed" default=""
+				<combo key="maxspeed"
 					text="Maxspeed (km/h)"
 					de.text="Höchstgeschwindigkeit (km/h)"
 					values="10,20,30,40,50,60,70,80,90,100,none"
@@ -998,28 +913,24 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Elektrifizierung"
 					values="yes,no,contact_line,rail"
 					display_values="Ja,Nein,Oberleitung,Stromschiene"
-					default=""
 					/>
 				<combo key="voltage"
 					text="Voltage"
 					de.text="Spannung"
 					values="500,550,600,750,850,1000,1200,1500,2400,3000,6500,6600"
 					display_values="500 V,550 V,600 V,750 V,850 V,1000 V,1200 V,1500 V,2400 V,3000 V,6500 V,6600 V"
-					default=""
 					/>
 				<combo key="frequency"
 					text="Frequency"
 					de.text="Frequenz"
 					values="16.7,0,16.67,50,60,25"
 					display_values="16.7 Hz (Standard in Österreich),Gleichspannung,16 2/3 Hz,50 Hz,60 Hz,25 Hz"
-					default=""
 					/>
 				<combo key="gauge"
 					text="Gauge"
 					de.text="Spurweite"
 					values="381,184,127"
 					display_values="381 mm,184 mm,127 mm"
-					default=""
 					/>
 				<check key="railway:ballastless"
 					text="Ballastless"
@@ -1031,23 +942,19 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Zahnstange"
 					values="yes,no,riggenbach,strub,abt,locher,riggenbach-klose,marsh,von_roll"
 					display_values="Ja,Nein,System Riggenbach,System Strub,System Abt,System Locher,System Riggenbach-Klose,System Marsh,System Von Roll"
-					default=""
 					/>
 				<text key="incline"
 					text="Incline (e.g.. '3%')"
 					de.text="Steigung (z. B. '3%')"
-					default=""
 					/>
 				<space />
 				<text key="start_date"
 					text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
-					default=""
 					/>
 				<text key="operator"
 					text="Operator (e.g. 'ÖBB-Infrastruktur AG')"
 					de.text="Betreiber (z. B. 'ÖBB-Infrastruktur AG')"
-					default=""
 					/>
 				<space />
 				<check key="embankment"
@@ -1070,17 +977,14 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<text key="ref"
 					text="Line ref"
 					de.text="Streckennummer"
-					default=""
 					/>
 				<text key="railway:track_ref"
 					text="Track ref (inside station)"
 					de.text="Gleisnummer (im Bahnhof)"
-					default=""
 					/>
 				<text key="name"
 					text="Railway name"
 					de.text="Streckenname"
-					default=""
 					/>
 				<space />
 				<combo key="railway:traffic_mode"
@@ -1090,7 +994,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					display_values="Gemischt,Güterverkehr,Personenverkehr"
 					default="passenger"
 					/>
-				<combo key="service" text="Track service" de.text="Gleisfunktion" default="">
+				<combo key="service" text="Track service" de.text="Gleisfunktion">
 					<list_entry value="siding" display_value="Nebengleis" short_description="Gleise in Bahnhöfen, die parallel zum durchgehenden Hauptgleis verlaufen und zum Überholen und Halten von Zügen dienen" />
 					<list_entry value="yard" display_value="Abstellgleis" short_description="Gleise in Rangier-, Güter- oder Betriebsbahnhöfen, die zum Rangieren, Zusammenstellen von Zügen und Abstellen von Wagen dienen" />
 					<list_entry value="crossover" display_value="Überleitgleis" short_description="Kurze Gleise, die das Wechseln zwischen zwei Gleisen ermöglichen" />
@@ -1117,19 +1021,18 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="ETCS"
 					values="yes,no,0,1,2,3"
 					display_values="Ja,Nein,Level 0,Level 1,Level 2,Level 3"
-					default=""
 					/>
-				<combo key="railway:preferred_direction" text="Direction of use (depends on direction of OSM way)" de.text="Regelfahrtrichtung (abhängig von Richtung des OSM-Ways)" default="">
+				<combo key="railway:preferred_direction" text="Direction of use (depends on direction of OSM way)" de.text="Regelfahrtrichtung (abhängig von Richtung des OSM-Ways)">
 					<list_entry value="forward" display_value="In Wegrichtung" short_description="Das Gleis wird üblicherweise in die Richtung befahren, in die der OSM-Way führt. Nur für mehrgleisige Strecken." />
 					<list_entry value="backward" display_value="Entgegen Wegrichtung" short_description="Das Gleis wird üblicherweise entgegen der Richtung befahren, in die der OSM-Way führt. Nur für mehrgleisige Strecken." />
 					<list_entry value="both" display_value="Beide Richtungen" short_description="Es gibt keine Richtung, in die die Züge üblicherweise fahren bzw. nicht fahren. Nur für eingleisige Strecken." />
 				</combo>
-				<combo key="railway:bidirectional" text="Bidirectional traffic (depends on direction of OSM way)" de.text="Gleiswechselbetrieb (abhängig von Richtung des OSM-Ways)" default="">
+				<combo key="railway:bidirectional" text="Bidirectional traffic (depends on direction of OSM way)" de.text="Gleiswechselbetrieb (abhängig von Richtung des OSM-Ways)">
 					<list_entry value="regular" display_value="Gleiswechselbetrieb" short_description="Das Gleis ist für beide Fahrtrichtungen mit Signalen ausgestattet und kann daher regulär entgegen der üblichen Fahrtrichtung befahren werden." />
 					<list_entry value="signals" display_value="Signalisierter Falschfahrbetrieb" short_description="Das Gleis ist signaltechnisch nur für eine Fahrtrichtung ausgelegt, sodass weiterhin Falschfahrten notwendig sind, diese sind aber durch Signale geregelt." />
 					<list_entry value="possible" display_value="Falschfahrt möglich" short_description="Signaltechnisch besteht keine Möglichkeit einer Befahrung des Gegengleises. Es ist ein schriftlicher Befehl notwendig." />
 				</combo>
-				<combo key="maxspeed" default=""
+				<combo key="maxspeed"
 					text="Maxspeed (km/h)"
 					de.text="Höchstgeschwindigkeit (km/h)"
 					values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,none"
@@ -1141,28 +1044,24 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Elektrifizierung"
 					values="yes,no,contact_line,rail"
 					display_values="Ja,Nein,Oberleitung,Stromschiene"
-					default=""
 					/>
 				<combo key="voltage"
 					text="Voltage"
 					de.text="Spannung"
 					values="500,550,600,750,850,1000,1200,1500,2400,3000,6500,6600"
 					display_values="500 V,550 V,600 V,750 V,850 V,1000 V,1200 V,1500 V,2400 V,3000 V,6500 V,6600 V"
-					default=""
 					/>
 				<combo key="frequency"
 					text="Frequency"
 					de.text="Frequenz"
 					values="0,16.7,16.67,50,60,25"
 					display_values="Gleichspannung,16.7 Hz,16 2/3 Hz,50 Hz,60 Hz,25 Hz"
-					default=""
 					/>
 				<combo key="gauge"
 					text="Gauge"
 					de.text="Spurweite"
 					values="1435,1040,1000,900,760,750"
 					display_values="1435 mm (Normalspur),1040 mm,1000 mm (Meterspur),900 mm,760mm (Bosnische Spur),750 mm"
-					default=""
 					/>
 				<check key="railway:ballastless"
 					text="Ballastless (slab track)"
@@ -1172,18 +1071,15 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<text key="incline"
 					text="Incline (e.g.. '3%')"
 					de.text="Steigung (z. B. '3%')"
-					default=""
 					/>
 				<space />
 				<text key="start_date"
 					text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
-					default=""
 					/>
 				<text key="operator"
 					text="Operator (e.g. 'Wiener Linien GmbH &amp; Co KG')"
 					de.text="Betreiber (z. B. 'Wiener Linien GmbH &amp; Co KG')"
-					default=""
 					/>
 				<space />
 				<check key="embankment"
@@ -1205,20 +1101,17 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<text key="ref"
 					text="Line ref"
 					de.text="Streckennummer"
-					default=""
 					/>
 				<text key="railway:track_ref"
 					text="Track ref (inside station)"
 					de.text="Gleisnummer (im Bahnhof)"
-					default=""
 					/>
 				<text key="name"
 					text="Railway name"
 					de.text="Streckenname"
-					default=""
 					/>
 				<space />
-				<combo key="service" text="Track service" de.text="Gleisfunktion" default="">
+				<combo key="service" text="Track service" de.text="Gleisfunktion">
 					<list_entry value="siding" display_value="Nebengleis" short_description="Gleise in Bahnhöfen, die parallel zum durchgehenden Hauptgleis verlaufen und zum Überholen und Halten von Zügen dienen" />
 					<list_entry value="yard" display_value="Abstellgleis" short_description="Gleise in Rangier-, Güter- oder Betriebsbahnhöfen, die zum Rangieren, Zusammenstellen von Zügen und Abstellen von Wagen dienen" />
 					<list_entry value="crossover" display_value="Überleitgleis" short_description="Kurze Gleise, die das Wechseln zwischen zwei Gleisen ermöglichen" />
@@ -1244,19 +1137,18 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="ETCS"
 					values="yes,no,0,1,2,3"
 					display_values="Ja,Nein,Level 0,Level 1,Level 2,Level 3"
-					default=""
 					/>
-				<combo key="railway:preferred_direction" text="Direction of use (depends on direction of OSM way)" de.text="Regelfahrtrichtung (abhängig von Richtung des OSM-Ways)" default="">
+				<combo key="railway:preferred_direction" text="Direction of use (depends on direction of OSM way)" de.text="Regelfahrtrichtung (abhängig von Richtung des OSM-Ways)">
 					<list_entry value="forward" display_value="In Wegrichtung" short_description="Das Gleis wird üblicherweise in die Richtung befahren, in die der OSM-Way führt. Nur für mehrgleisige Strecken." />
 					<list_entry value="backward" display_value="Entgegen Wegrichtung" short_description="Das Gleis wird üblicherweise entgegen der Richtung befahren, in die der OSM-Way führt. Nur für mehrgleisige Strecken." />
 					<list_entry value="both" display_value="Beide Richtungen" short_description="Es gibt keine Richtung, in die die Züge üblicherweise fahren bzw. nicht fahren. Nur für eingleisige Strecken." />
 				</combo>
-				<combo key="railway:bidirectional" text="Bidirectional traffic (depends on direction of OSM way)" de.text="Gleiswechselbetrieb (abhängig von Richtung des OSM-Ways)" default="">
+				<combo key="railway:bidirectional" text="Bidirectional traffic (depends on direction of OSM way)" de.text="Gleiswechselbetrieb (abhängig von Richtung des OSM-Ways)">
 					<list_entry value="regular" display_value="Gleiswechselbetrieb" short_description="Das Gleis ist für beide Fahrtrichtungen mit Signalen ausgestattet und kann daher regulär entgegen der üblichen Fahrtrichtung befahren werden." />
 					<list_entry value="signals" display_value="Signalisierter Falschfahrbetrieb" short_description="Das Gleis ist signaltechnisch nur für eine Fahrtrichtung ausgelegt, sodass weiterhin Falschfahrten notwendig sind, diese sind aber durch Signale geregelt." />
 					<list_entry value="possible" display_value="Falschfahrt möglich" short_description="Signaltechnisch besteht keine Möglichkeit einer Befahrung des Gegengleises. Es ist ein schriftlicher Befehl notwendig." />
 				</combo>
-				<combo key="maxspeed" default=""
+				<combo key="maxspeed"
 					text="Maxspeed (km/h)"
 					de.text="Höchstgeschwindigkeit (km/h)"
 					values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,none"
@@ -1268,28 +1160,24 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Elektrifizierung"
 					values="yes,no,contact_line,rail"
 					display_values="Ja,Nein,Oberleitung,Stromschiene"
-					default=""
 					/>
 				<combo key="voltage"
 					text="Voltage"
 					de.text="Spannung"
 					values="500,550,600,750,850,1000,1200,1500,2400,3000,6500,6600,11000"
 					display_values="500 V,550 V,600 V,750 V,850 V,1000 V,1200 V,1500 V,2400 V,3000 V,6500 V,6600 V,11 kV"
-					default=""
 					/>
 				<combo key="frequency"
 					text="Frequency"
 					de.text="Frequenz"
 					values="0,16.7,16.67,50,60,25"
 					display_values="Gleichspannung,16.7 Hz,16 2/3 Hz,50 Hz,60 Hz,25 Hz"
-					default=""
 					/>
 				<combo key="gauge"
 					text="Gauge"
 					de.text="Spurweite"
 					values="1435,1040,1000,900,760,750"
 					display_values="1435 mm (Normalspur),1040 mm,1000 mm (Meterspur),900 mm,760mm (Bosnische Spur),750 mm"
-					default=""
 					/>
 				<check key="railway:ballastless"
 					text="Ballastless"
@@ -1299,18 +1187,15 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<text key="incline"
 					text="Incline (e.g.. '3%')"
 					de.text="Steigung (z. B. '3%')"
-					default=""
 					/>
 				<space />
 				<text key="start_date"
 					text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
-					default=""
 					/>
 				<text key="operator"
 					text="Operator (e.g. 'Wiener Linien GmbH &amp; Co KG')"
 					de.text="Betreiber (z. B. 'Wiener Linien GmbH &amp; Co KG')"
-					default=""
 					/>
 			</item>
 			<item name="Stadt-/Schnellbahngleis" icon="light-rail.png" type="way">
@@ -1321,22 +1206,19 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<text key="ref"
 					text="Line ref"
 					de.text="Streckennummer"
-					default=""
 					/>
 				<text key="railway:track_ref"
 					text="Track ref (inside station)"
 					de.text="Gleisnummer (im Bahnhof)"
-					default=""
 					/>
 				<text key="name"
 					text="Railway name"
 					de.text="Streckenname"
-					default=""
 					/>
 				<space />
 				<key key="railway:traffic_mode"
 					value="passenger" />
-				<combo key="service" text="Track service" de.text="Gleisfunktion" default="">
+				<combo key="service" text="Track service" de.text="Gleisfunktion">
 					<list_entry value="siding" display_value="Nebengleis" short_description="Gleise in Bahnhöfen, die parallel zum durchgehenden Hauptgleis verlaufen und zum Überholen und Halten von Zügen dienen" />
 					<list_entry value="yard" display_value="Abstellgleis" short_description="Gleise in Rangier-, Güter- oder Betriebsbahnhöfen, die zum Rangieren, Zusammenstellen von Zügen und Abstellen von Wagen dienen" />
 					<list_entry value="crossover" display_value="Überleitgleis" short_description="Kurze Gleise, die das Wechseln zwischen zwei Gleisen ermöglichen" />
@@ -1363,19 +1245,18 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="ETCS"
 					values="yes,no,0,1,2,3"
 					display_values="Ja,Nein,Level 0,Level 1,Level 2,Level 3"
-					default=""
 					/>
-				<combo key="railway:preferred_direction" text="Direction of use (depends on direction of OSM way)" de.text="Regelfahrtrichtung (abhängig von Richtung des OSM-Ways)" default="">
+				<combo key="railway:preferred_direction" text="Direction of use (depends on direction of OSM way)" de.text="Regelfahrtrichtung (abhängig von Richtung des OSM-Ways)">
 					<list_entry value="forward" display_value="In Wegrichtung" short_description="Das Gleis wird üblicherweise in die Richtung befahren, in die der OSM-Way führt. Nur für mehrgleisige Strecken." />
 					<list_entry value="backward" display_value="Entgegen Wegrichtung" short_description="Das Gleis wird üblicherweise entgegen der Richtung befahren, in die der OSM-Way führt. Nur für mehrgleisige Strecken." />
 					<list_entry value="both" display_value="Beide Richtungen" short_description="Es gibt keine Richtung, in die die Züge üblicherweise fahren bzw. nicht fahren. Nur für eingleisige Strecken." />
 				</combo>
-				<combo key="railway:bidirectional" text="Bidirectional traffic (depends on direction of OSM way)" de.text="Gleiswechselbetrieb (abhängig von Richtung des OSM-Ways)" default="">
+				<combo key="railway:bidirectional" text="Bidirectional traffic (depends on direction of OSM way)" de.text="Gleiswechselbetrieb (abhängig von Richtung des OSM-Ways)">
 					<list_entry value="regular" display_value="Gleiswechselbetrieb" short_description="Das Gleis ist für beide Fahrtrichtungen mit Signalen ausgestattet und kann daher regulär entgegen der üblichen Fahrtrichtung befahren werden." />
 					<list_entry value="signals" display_value="Signalisierter Falschfahrbetrieb" short_description="Das Gleis ist signaltechnisch nur für eine Fahrtrichtung ausgelegt, sodass weiterhin Falschfahrten notwendig sind, diese sind aber durch Signale geregelt." />
 					<list_entry value="possible" display_value="Falschfahrt möglich" short_description="Signaltechnisch besteht keine Möglichkeit einer Befahrung des Gegengleises. Es ist ein schriftlicher Befehl notwendig." />
 				</combo>
-				<combo key="maxspeed" default=""
+				<combo key="maxspeed"
 					text="Maxspeed (km/h)"
 					de.text="Höchstgeschwindigkeit (km/h)"
 					values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,none"
@@ -1387,28 +1268,24 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Elektrifizierung"
 					values="yes,no,contact_line,rail"
 					display_values="Ja,Nein,Oberleitung,Stromschiene"
-					default=""
 					/>
 				<combo key="voltage"
 					text="Voltage"
 					de.text="Spannung"
 					values="15000,500,550,600,750,850,1000,1200,1500,2400,3000,6500,6600,11000,25000"
 					display_values="15 kV,500 V,550 V,600 V,750 V,850 V,1000 V,1200 V,1500 V,2400 V,3000 V,6500 V,6600 V,11 kV,25 kV"
-					default=""
 					/>
 				<combo key="frequency"
 					text="Frequency"
 					de.text="Frequenz"
 					values="0,16.7,16.67,50,60,25"
 					display_values="Gleichspannung,16.7 Hz,16 2/3 Hz,50 Hz,60 Hz,25 Hz"
-					default=""
 					/>
 				<combo key="gauge"
 					text="Gauge"
 					de.text="Spurweite"
 					values="1435,1040,1000,900,760,750"
 					display_values="1435 mm (Normalspur),1040 mm,1000 mm (Meterspur),900 mm,760mm (Bosnische Spur),750 mm"
-					default=""
 					/>
 				<check key="railway:ballastless"
 					text="Ballastless"
@@ -1418,18 +1295,15 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<text key="incline"
 					text="Incline (e.g.. '3%')"
 					de.text="Steigung (z. B. '3%')"
-					default=""
 					/>
 				<space />
 				<text key="start_date"
 					text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
-					default=""
 					/>
 				<text key="operator"
 					text="Operator (e.g. 'Wiener Linien GmbH &amp; Co KG')"
 					de.text="Betreiber (z. B. 'Wiener Linien GmbH &amp; Co KG')"
-					default=""
 					/>
 				<space />
 				<check key="embankment"
@@ -1452,20 +1326,17 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<text key="ref"
 					text="Line ref (VzG number, e.g. '2379')"
 					de.text="Streckennummer (VzG-Nummer, z. B. '2379')"
-					default=""
 					/>
 				<text key="railway:track_ref"
 					text="Track ref (inside station)"
 					de.text="Gleisnummer (im Bahnhof)"
-					default=""
 					/>
 				<text key="name"
 					text="Railway name"
 					de.text="Streckenname"
-					default=""
 					/>
 				<space />
-				<combo key="usage" text="Usage" de.text="Nutzung" default="">
+				<combo key="usage" text="Usage" de.text="Nutzung">
 					<list_entry value="main" display_value="Hauptbahn" short_description="Strecke mit übergeordneter Bedeutung; meist zweigleisig, meist elektrifiziert, zumindest abschnittsweise mit mehr als 100 km/h befahrbar" />
 					<list_entry value="branch" display_value="Nebenbahn" short_description="Strecke mit untergeordneter Bedeutung; oft nicht elektrifiziert, oft eingleisig. Keinesfalls mit mehr als 100 km/h befahrbar." />
 					<list_entry value="industrial" display_value="Industriebahn" short_description="Eine Strecke, die ausschließlich dem Güterverkehr dient und in der Regel Eigentum eines Industrieunternehmens ist. Meist nur innerhalb von Hafengebieten, Industrieanlagen, Tagebauen." />
@@ -1478,7 +1349,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Verkehrsart"
 					values="mixed,passenger,freight"
 					display_values="Gemischt,Personenverkehr,Güterverkehr"
-					default=""
 					/>
 				<check key="highspeed"
 					text="Highspeed traffic (~ >200 km/h)"
@@ -1506,27 +1376,25 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="ETCS"
 					values="yes,no,0,1,2,3"
 					display_values="Ja,Nein,Level 0,Level 1,Level 2,Level 3"
-					default=""
 					/>
 				<combo key="railway:radio"
 					text="Radio"
 					de.text="Zugfunk"
 					values="analogue,gsm-r"
 					display_values="Analog,GSM-R"
-					default=""
 					/>
-				<combo key="railway:preferred_direction" text="Direction of use (depends on direction of OSM way)" de.text="Regelfahrtrichtung (abhängig von Richtung des OSM-Ways)" default="">
+				<combo key="railway:preferred_direction" text="Direction of use (depends on direction of OSM way)" de.text="Regelfahrtrichtung (abhängig von Richtung des OSM-Ways)">
 					<list_entry value="forward" display_value="In Wegrichtung" short_description="Das Gleis wird üblicherweise in die Richtung befahren, in die der OSM-Way führt. Nur für mehrgleisige Strecken." />
 					<list_entry value="backward" display_value="Entgegen Wegrichtung" short_description="Das Gleis wird üblicherweise entgegen der Richtung befahren, in die der OSM-Way führt. Nur für mehrgleisige Strecken." />
 					<list_entry value="both" display_value="Beide Richtungen" short_description="Es gibt keine Richtung, in die die Züge üblicherweise fahren bzw. nicht fahren. Nur für eingleisige Strecken." />
 				</combo>
-				<combo key="railway:bidirectional" text="Bidirectional traffic (depends on direction of OSM way)" de.text="Gleiswechselbetrieb (abhängig von Richtung des OSM-Ways)" default="">
+				<combo key="railway:bidirectional" text="Bidirectional traffic (depends on direction of OSM way)" de.text="Gleiswechselbetrieb (abhängig von Richtung des OSM-Ways)">
 					<list_entry value="regular" display_value="Gleiswechselbetrieb" short_description="Das Gleis ist für beide Fahrtrichtungen mit Signalen ausgestattet und kann daher regulär entgegen der üblichen Fahrtrichtung befahren werden." />
 					<list_entry value="signals" display_value="Signalisierter Falschfahrbetrieb" short_description="Das Gleis ist signaltechnisch nur für eine Fahrtrichtung ausgelegt, sodass weiterhin Falschfahrten notwendig sind, diese sind aber durch Signale geregelt." />
 					<list_entry value="possible" display_value="Falschfahrt möglich" short_description="Signaltechnisch besteht keine Möglichkeit einer Befahrung des Gegengleises. Es ist ein schriftlicher Befehl notwendig." />
 				</combo>
 				<space />
-				<combo key="maxspeed" default=""
+				<combo key="maxspeed"
 					text="Maxspeed (km/h)"
 					de.text="Höchstgeschwindigkeit (km/h)"
 					values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,none"
@@ -1538,28 +1406,24 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Elektrifizierung"
 					values="yes,no,contact_line,rail"
 					display_values="Ja,Nein,Oberleitung,Stromschiene"
-					default=""
 					/>
 				<combo key="voltage"
 					text="Voltage"
 					de.text="Spannung"
 					values="15000,500,550,600,750,850,1000,1200,1500,2400,3000,6500,6600,11000,25000"
 					display_values="15 kV (Standard in Österreich),500 V,550 V,600 V,750 V,850 V,1000 V,1200 V,1500 V,2400 V,3000 V,6500 V,6600 V,11 kV,25 kV"
-					default=""
 					/>
 				<combo key="frequency"
 					text="Frequency"
 					de.text="Frequenz"
 					values="16.7,0,16.67,50,60,25"
 					display_values="16.7 Hz (Standard in Österreich),Gleichspannung,16 2/3 Hz,50 Hz,60 Hz,25 Hz"
-					default=""
 					/>
 				<combo key="gauge"
 					text="Gauge"
 					de.text="Spurweite"
 					values="1435,1040,1000,900,880,800,760,750,580,500,381,184,127"
 					display_values="1435 mm (Normalspur),1040 mm,1000 mm (Meterspur),900 mm,880 mm,800 mm,760mm (Bosnische Spur),750 mm,580 mm,500 mm,381 mm,184 mm,127 mm"
-					default=""
 					/>
 				<check key="railway:ballastless"
 					text="Ballastless"
@@ -1571,23 +1435,19 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Zahnstange"
 					values="yes,no,riggenbach,strub,abt,locher,riggenbach-klose,marsh,von_roll"
 					display_values="Ja,Nein,System Riggenbach,System Strub,System Abt,System Locher,System Riggenbach-Klose,System Marsh,System Von Roll"
-					default=""
 					/>
 				<text key="incline"
 					text="Incline (e.g.. '3%')"
 					de.text="Steigung (z. B. '3%')"
-					default=""
 					/>
 				<space />
 				<text key="start_date"
 					text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
-					default=""
 					/>
 				<text key="operator"
 					text="Operator (e.g. 'ÖBB-Infrastruktur AG')"
 					de.text="Betreiber (z. B. 'ÖBB-Infrastruktur AG')"
-					default=""
 					/>
 				<space />
 				<check key="embankment"
@@ -1609,20 +1469,17 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<text key="ref"
 					text="Line ref (VzG number, e.g. '2379')"
 					de.text="Streckennummer (VzG-Nummer, z. B. '2379')"
-					default=""
 					/>
 				<text key="railway:track_ref"
 					text="Track ref (inside station)"
 					de.text="Gleisnummer (im Bahnhof)"
-					default=""
 					/>
 				<text key="name"
 					text="Railway name"
 					de.text="Streckenname"
-					default=""
 					/>
 				<space />
-				<combo key="usage" text="Usage" de.text="Nutzung" default="">
+				<combo key="usage" text="Usage" de.text="Nutzung">
 					<list_entry value="main" display_value="Hauptbahn" short_description="Strecke mit übergeordneter Bedeutung; meist zweigleisig, meist elektrifiziert, zumindest abschnittsweise mit mehr als 100 km/h befahrbar" />
 					<list_entry value="branch" display_value="Nebenbahn" short_description="Strecke mit untergeordneter Bedeutung; oft nicht elektrifiziert, oft eingleisig. Keinesfalls mit mehr als 100 km/h befahrbar." />
 					<list_entry value="industrial" display_value="Industriebahn" short_description="Eine Strecke, die ausschließlich dem Güterverkehr dient und in der Regel Eigentum eines Industrieunternehmens ist. Meist nur innerhalb von Hafengebieten, Industrieanlagen, Tagebauen." />
@@ -1635,7 +1492,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Verkehrsart"
 					values="mixed,passenger,freight"
 					display_values="Gemischt,Personenverkehr,Güterverkehr"
-					default=""
 					/>
 				<check key="highspeed"
 					text="Highspeed traffic (~ >200 km/h)"
@@ -1663,27 +1519,25 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="ETCS"
 					values="yes,no,0,1,2,3"
 					display_values="Ja,Nein,Level 0,Level 1,Level 2,Level 3"
-					default=""
 					/>
 				<combo key="railway:radio"
 					text="Radio"
 					de.text="Zugfunk"
 					values="analogue,gsm-r"
 					display_values="Analog,GSM-R"
-					default=""
 					/>
-				<combo key="railway:preferred_direction" text="Direction of use (depends on direction of OSM way)" de.text="Regelfahrtrichtung (abhängig von Richtung des OSM-Ways)" default="">
+				<combo key="railway:preferred_direction" text="Direction of use (depends on direction of OSM way)" de.text="Regelfahrtrichtung (abhängig von Richtung des OSM-Ways)">
 					<list_entry value="forward" display_value="In Wegrichtung" short_description="Das Gleis wird üblicherweise in die Richtung befahren, in die der OSM-Way führt. Nur für mehrgleisige Strecken." />
 					<list_entry value="backward" display_value="Entgegen Wegrichtung" short_description="Das Gleis wird üblicherweise entgegen der Richtung befahren, in die der OSM-Way führt. Nur für mehrgleisige Strecken." />
 					<list_entry value="both" display_value="Beide Richtungen" short_description="Es gibt keine Richtung, in die die Züge üblicherweise fahren bzw. nicht fahren. Nur für eingleisige Strecken." />
 				</combo>
-				<combo key="railway:bidirectional" text="Bidirectional traffic (depends on direction of OSM way)" de.text="Gleiswechselbetrieb (abhängig von Richtung des OSM-Ways)" default="">
+				<combo key="railway:bidirectional" text="Bidirectional traffic (depends on direction of OSM way)" de.text="Gleiswechselbetrieb (abhängig von Richtung des OSM-Ways)">
 					<list_entry value="regular" display_value="Gleiswechselbetrieb" short_description="Das Gleis ist für beide Fahrtrichtungen mit Signalen ausgestattet und kann daher regulär entgegen der üblichen Fahrtrichtung befahren werden." />
 					<list_entry value="signals" display_value="Signalisierter Falschfahrbetrieb" short_description="Das Gleis ist signaltechnisch nur für eine Fahrtrichtung ausgelegt, sodass weiterhin Falschfahrten notwendig sind, diese sind aber durch Signale geregelt." />
 					<list_entry value="possible" display_value="Falschfahrt möglich" short_description="Signaltechnisch besteht keine Möglichkeit einer Befahrung des Gegengleises. Es ist ein schriftlicher Befehl notwendig." />
 				</combo>
 				<space />
-				<combo key="maxspeed" default=""
+				<combo key="maxspeed"
 					text="Maxspeed (km/h)"
 					de.text="Höchstgeschwindigkeit (km/h)"
 					values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,none"
@@ -1695,28 +1549,24 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Elektrifizierung"
 					values="yes,no,contact_line,rail"
 					display_values="Ja,Nein,Oberleitung,Stromschiene"
-					default=""
 					/>
 				<combo key="voltage"
 					text="Voltage"
 					de.text="Spannung"
 					values="15000,500,550,600,750,850,1000,1200,1500,2400,3000,6500,6600,11000,25000"
 					display_values="15 kV (Standard in Österreich),500 V,550 V,600 V,750 V,850 V,1000 V,1200 V,1500 V,2400 V,3000 V,6500 V,6600 V,11 kV,25 kV"
-					default=""
 					/>
 				<combo key="frequency"
 					text="Frequency"
 					de.text="Frequenz"
 					values="16.7,0,16.67,50,60,25"
 					display_values="16.7 Hz (Standard in Österreich),Gleichspannung,16 2/3 Hz,50 Hz,60 Hz,25 Hz"
-					default=""
 					/>
 				<combo key="gauge"
 					text="Gauge"
 					de.text="Spurweite"
 					values="1435,1040,1000,900,880,800,760,750,580,500,381,184,127"
 					display_values="1435 mm (Normalspur),1040 mm,1000 mm (Meterspur),900 mm,880 mm,800 mm,760mm (Bosnische Spur),750 mm,580 mm,500 mm,381 mm,184 mm,127 mm"
-					default=""
 					/>
 				<check key="railway:ballastless"
 					text="Ballastless"
@@ -1728,23 +1578,19 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Zahnstange"
 					values="yes,no,riggenbach,strub,abt,locher,riggenbach-klose,marsh,von_roll"
 					display_values="Ja,Nein,System Riggenbach,System Strub,System Abt,System Locher,System Riggenbach-Klose,System Marsh,System Von Roll"
-					default=""
 					/>
 				<text key="incline"
 					text="Incline (e.g.. '3%')"
 					de.text="Steigung (z. B. '3%')"
-					default=""
 					/>
 				<space />
 				<text key="start_date"
 					text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
-					default=""
 					/>
 				<text key="operator"
 					text="Operator (e.g. 'ÖBB-Infrastruktur AG')"
 					de.text="Betreiber (z. B. 'ÖBB-Infrastruktur AG')"
-					default=""
 					/>
 				<space />
 				<check key="embankment"
@@ -1766,20 +1612,17 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<text key="ref"
 					text="Line ref (VzG number, e.g. '2379')"
 					de.text="Streckennummer (VzG-Nummer, z. B. '2379')"
-					default=""
 					/>
 				<text key="railway:track_ref"
 					text="Track ref (inside station)"
 					de.text="Gleisnummer (im Bahnhof)"
-					default=""
 					/>
 				<text key="name"
 					text="Railway name"
 					de.text="Streckenname"
-					default=""
 					/>
 				<space />
-				<combo key="usage" text="Usage" de.text="Nutzung" default="">
+				<combo key="usage" text="Usage" de.text="Nutzung">
 					<list_entry value="main" display_value="Hauptbahn" short_description="Strecke mit übergeordneter Bedeutung; meist zweigleisig, meist elektrifiziert, zumindest abschnittsweise mit mehr als 100 km/h befahrbar" />
 					<list_entry value="branch" display_value="Nebenbahn" short_description="Strecke mit untergeordneter Bedeutung; oft nicht elektrifiziert, oft eingleisig. Keinesfalls mit mehr als 100 km/h befahrbar." />
 					<list_entry value="industrial" display_value="Industriebahn" short_description="Eine Strecke, die ausschließlich dem Güterverkehr dient und in der Regel Eigentum eines Industrieunternehmens ist. Meist nur innerhalb von Hafengebieten, Industrieanlagen, Tagebauen." />
@@ -1792,7 +1635,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Verkehrsart"
 					values="mixed,passenger,freight"
 					display_values="Gemischt,Personenverkehr,Güterverkehr"
-					default=""
 					/>
 				<check key="highspeed"
 					text="Highspeed traffic (~ >200 km/h)"
@@ -1815,26 +1657,24 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="ETCS"
 					values="yes,no,0,1,2,3"
 					display_values="Ja,Nein,Level 0,Level 1,Level 2,Level 3"
-					default=""
 					/>
 				<combo key="railway:radio"
 					text="Radio"
 					de.text="Zugfunk"
 					values="analogue,gsm-r"
 					display_values="Analog,GSM-R"
-					default=""
 					/>
-				<combo key="railway:preferred_direction" text="Direction of use (depends on direction of OSM way)" de.text="Regelfahrtrichtung (abhängig von Richtung des OSM-Ways)" default="">
+				<combo key="railway:preferred_direction" text="Direction of use (depends on direction of OSM way)" de.text="Regelfahrtrichtung (abhängig von Richtung des OSM-Ways)">
 					<list_entry value="forward" display_value="In Wegrichtung" short_description="Das Gleis wird üblicherweise in die Richtung befahren, in die der OSM-Way führt. Nur für mehrgleisige Strecken." />
 					<list_entry value="backward" display_value="Entgegen Wegrichtung" short_description="Das Gleis wird üblicherweise entgegen der Richtung befahren, in die der OSM-Way führt. Nur für mehrgleisige Strecken." />
 					<list_entry value="both" display_value="Beide Richtungen" short_description="Es gibt keine Richtung, in die die Züge üblicherweise fahren bzw. nicht fahren. Nur für eingleisige Strecken." />
 				</combo>
-				<combo key="railway:bidirectional" text="Bidirectional traffic (depends on direction of OSM way)" de.text="Gleiswechselbetrieb (abhängig von Richtung des OSM-Ways)" default="">
+				<combo key="railway:bidirectional" text="Bidirectional traffic (depends on direction of OSM way)" de.text="Gleiswechselbetrieb (abhängig von Richtung des OSM-Ways)">
 					<list_entry value="regular" display_value="Gleiswechselbetrieb" short_description="Das Gleis ist für beide Fahrtrichtungen mit Signalen ausgestattet und kann daher regulär entgegen der üblichen Fahrtrichtung befahren werden." />
 					<list_entry value="signals" display_value="Signalisierter Falschfahrbetrieb" short_description="Das Gleis ist signaltechnisch nur für eine Fahrtrichtung ausgelegt, sodass weiterhin Falschfahrten notwendig sind, diese sind aber durch Signale geregelt." />
 					<list_entry value="possible" display_value="Falschfahrt möglich" short_description="Signaltechnisch besteht keine Möglichkeit einer Befahrung des Gegengleises. Es ist ein schriftlicher Befehl notwendig." />
 				</combo>
-				<combo key="maxspeed" default=""
+				<combo key="maxspeed"
 					text="Maxspeed (km/h)"
 					de.text="Höchstgeschwindigkeit (km/h)"
 					values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,none"
@@ -1846,28 +1686,24 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Elektrifizierung"
 					values="yes,no,contact_line,rail"
 					display_values="Ja,Nein,Oberleitung,Stromschiene"
-					default=""
 					/>
 				<combo key="voltage"
 					text="Voltage"
 					de.text="Spannung"
 					values="15000,500,550,600,750,850,1000,1200,1500,1800,2200,2400,3000,6500,6600,11000,25000"
 					display_values="15 kV (Standard in Österreich),500 V,550 V,600 V,750 V,850 V,1000 V,1200 V,1500 V,1800 V,2200 V,2400 V,3000 V,6500 V,6600 V,11 kV,25 kV"
-					default=""
 					/>
 				<combo key="frequency"
 					text="Frequency"
 					de.text="Frequenz"
 					values="16.7,0,16.67,50,60,25"
 					display_values="16.7 Hz (Standard in Österreich),Gleichspannung,16 2/3 Hz,50 Hz,60 Hz,25 Hz"
-					default=""
 					/>
 				<combo key="gauge"
 					text="Gauge"
 					de.text="Spurweite"
 					values="1435,1106,1040,1000,900,880,820,800,760,750,600,580,500,381,184,127"
 					display_values="1435 mm (Normalspur),1106,1040 mm,1000 mm (Meterspur),900 mm,880 mm,820 mm,800 mm,760mm (Bosnische Spur),750 mm,600 mm,580 mm,500 mm,381 mm,184 mm,127 mm"
-					default=""
 					/>
 				<check key="railway:ballastless"
 					text="Ballastless"
@@ -1879,28 +1715,23 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Zahnstange"
 					values="yes,no,riggenbach,strub,abt,locher,riggenbach-klose,marsh,von_roll"
 					display_values="Ja,Nein,System Riggenbach,System Strub,System Abt,System Locher,System Riggenbach-Klose,System Marsh,System Von Roll"
-					default=""
 					/>
 				<text key="incline"
 					text="Incline (e.g.. '3%')"
 					de.text="Steigung (z. B. '3%')"
-					default=""
 					/>
 				<space />
 				<text key="start_date"
 					text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
-					default=""
 					/>
 				<text key="end_date"
 					text="Closed at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Stilllegung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
-					default=""
 					/>
 				<text key="operator"
 					text="Operator (e.g. 'ÖBB-Infrastruktur AG')"
 					de.text="Betreiber (z. B. 'ÖBB-Infrastruktur AG')"
-					default=""
 					/>
 				<space />
 				<check key="embankment"
@@ -1922,20 +1753,17 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<text key="ref"
 					text="Line ref (VzG number, e.g. '2379')"
 					de.text="Streckennummer (VzG-Nummer, z. B. '2379')"
-					default=""
 					/>
 				<text key="railway:track_ref"
 					text="Track ref (inside station)"
 					de.text="Gleisnummer (im Bahnhof)"
-					default=""
 					/>
 				<text key="name"
 					text="Railway name"
 					de.text="Streckenname"
-					default=""
 					/>
 				<space />
-				<combo key="usage" text="Usage" de.text="Nutzung" default="">
+				<combo key="usage" text="Usage" de.text="Nutzung">
 					<list_entry value="main" display_value="Hauptbahn" short_description="Strecke mit übergeordneter Bedeutung; meist zweigleisig, meist elektrifiziert, zumindest abschnittsweise mit mehr als 100 km/h befahrbar" />
 					<list_entry value="branch" display_value="Nebenbahn" short_description="Strecke mit untergeordneter Bedeutung; oft nicht elektrifiziert, oft eingleisig. Keinesfalls mit mehr als 100 km/h befahrbar." />
 					<list_entry value="industrial" display_value="Industriebahn" short_description="Eine Strecke, die ausschließlich dem Güterverkehr dient und in der Regel Eigentum eines Industrieunternehmens ist. Meist nur innerhalb von Hafengebieten, Industrieanlagen, Tagebauen." />
@@ -1948,7 +1776,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Verkehrsart"
 					values="mixed,passenger,freight"
 					display_values="Gemischt,Personenverkehr,Güterverkehr"
-					default=""
 					/>
 				<check key="highspeed"
 					text="Highspeed traffic (~ >200 km/h)"
@@ -1971,26 +1798,24 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="ETCS"
 					values="yes,no,0,1,2,3"
 					display_values="Ja,Nein,Level 0,Level 1,Level 2,Level 3"
-					default=""
 					/>
 				<combo key="railway:radio"
 					text="Radio"
 					de.text="Zugfunk"
 					values="analogue,gsm-r"
 					display_values="Analog,GSM-R"
-					default=""
 					/>
-				<combo key="railway:preferred_direction" text="Direction of use (depends on direction of OSM way)" de.text="Regelfahrtrichtung (abhängig von Richtung des OSM-Ways)" default="">
+				<combo key="railway:preferred_direction" text="Direction of use (depends on direction of OSM way)" de.text="Regelfahrtrichtung (abhängig von Richtung des OSM-Ways)">
 					<list_entry value="forward" display_value="In Wegrichtung" short_description="Das Gleis wird üblicherweise in die Richtung befahren, in die der OSM-Way führt. Nur für mehrgleisige Strecken." />
 					<list_entry value="backward" display_value="Entgegen Wegrichtung" short_description="Das Gleis wird üblicherweise entgegen der Richtung befahren, in die der OSM-Way führt. Nur für mehrgleisige Strecken." />
 					<list_entry value="both" display_value="Beide Richtungen" short_description="Es gibt keine Richtung, in die die Züge üblicherweise fahren bzw. nicht fahren. Nur für eingleisige Strecken." />
 				</combo>
-				<combo key="railway:bidirectional" text="Bidirectional traffic (depends on direction of OSM way)" de.text="Gleiswechselbetrieb (abhängig von Richtung des OSM-Ways)" default="">
+				<combo key="railway:bidirectional" text="Bidirectional traffic (depends on direction of OSM way)" de.text="Gleiswechselbetrieb (abhängig von Richtung des OSM-Ways)">
 					<list_entry value="regular" display_value="Gleiswechselbetrieb" short_description="Das Gleis ist für beide Fahrtrichtungen mit Signalen ausgestattet und kann daher regulär entgegen der üblichen Fahrtrichtung befahren werden." />
 					<list_entry value="signals" display_value="Signalisierter Falschfahrbetrieb" short_description="Das Gleis ist signaltechnisch nur für eine Fahrtrichtung ausgelegt, sodass weiterhin Falschfahrten notwendig sind, diese sind aber durch Signale geregelt." />
 					<list_entry value="possible" display_value="Falschfahrt möglich" short_description="Signaltechnisch besteht keine Möglichkeit einer Befahrung des Gegengleises. Es ist ein schriftlicher Befehl notwendig." />
 				</combo>
-				<combo key="maxspeed" default=""
+				<combo key="maxspeed"
 					text="Maxspeed (km/h)"
 					de.text="Höchstgeschwindigkeit (km/h)"
 					values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,none"
@@ -2002,28 +1827,24 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Elektrifizierung"
 					values="yes,no,contact_line,rail"
 					display_values="Ja,Nein,Oberleitung,Stromschiene"
-					default=""
 					/>
 				<combo key="voltage"
 					text="Voltage"
 					de.text="Spannung"
 					values="15000,500,550,600,750,850,1000,1200,1500,1800,2200,2400,3000,6500,6600,11000,25000"
 					display_values="15 kV (Standard in Österreich),500 V,550 V,600 V,750 V,850 V,1000 V,1200 V,1500 V,1800 V,2200 V,2400 V,3000 V,6500 V,6600 V,11 kV,25 kV"
-					default=""
 					/>
 				<combo key="frequency"
 					text="Frequency"
 					de.text="Frequenz"
 					values="16.7,0,16.67,50,60,25"
 					display_values="16.7 Hz (Standard in Österreich),Gleichspannung,16 2/3 Hz,50 Hz,60 Hz,25 Hz"
-					default=""
 					/>
 				<combo key="gauge"
 					text="Gauge"
 					de.text="Spurweite"
 					values="1435,1106,1040,1000,900,880,820,800,760,750,600,580,500,381,184,127"
 					display_values="1435 mm (Normalspur),1106,1040 mm,1000 mm (Meterspur),900 mm,880 mm,820 mm,800 mm,760mm (Bosnische Spur),750 mm,600 mm,580 mm,500 mm,381 mm,184 mm,127 mm"
-					default=""
 					/>
 				<check key="railway:ballastless"
 					text="Ballastless"
@@ -2035,28 +1856,23 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Zahnstange"
 					values="yes,no,riggenbach,strub,abt,locher,riggenbach-klose,marsh,von_roll"
 					display_values="Ja,Nein,System Riggenbach,System Strub,System Abt,System Locher,System Riggenbach-Klose,System Marsh,System Von Roll"
-					default=""
 					/>
 				<text key="incline"
 					text="Incline (e.g.. '3%')"
 					de.text="Steigung (z. B. '3%')"
-					default=""
 					/>
 				<space />
 				<text key="start_date"
 					text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
-					default=""
 					/>
 				<text key="end_date"
 					text="Closed at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Stilllegung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
-					default=""
 					/>
 				<text key="operator"
 					text="Operator (e.g. 'ÖBB-Infrastruktur AG')"
 					de.text="Betreiber (z. B. 'ÖBB-Infrastruktur AG')"
-					default=""
 					/>
 				<space />
 				<check key="embankment"
@@ -2078,20 +1894,17 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<text key="ref"
 					text="Line ref (VzG number, e.g. '2379')"
 					de.text="Streckennummer (VzG-Nummer, z. B. '2379')"
-					default=""
 					/>
 				<text key="railway:track_ref"
 					text="Track ref (inside station)"
 					de.text="Gleisnummer (im Bahnhof)"
-					default=""
 					/>
 				<text key="name"
 					text="Railway name"
 					de.text="Streckenname"
-					default=""
 					/>
 				<space />
-				<combo key="usage" text="Usage" de.text="Nutzung" default="">
+				<combo key="usage" text="Usage" de.text="Nutzung">
 					<list_entry value="main" display_value="Hauptbahn" short_description="Strecke mit übergeordneter Bedeutung; meist zweigleisig, meist elektrifiziert, zumindest abschnittsweise mit mehr als 100 km/h befahrbar" />
 					<list_entry value="branch" display_value="Nebenbahn" short_description="Strecke mit untergeordneter Bedeutung; oft nicht elektrifiziert, oft eingleisig. Keinesfalls mit mehr als 100 km/h befahrbar." />
 					<list_entry value="industrial" display_value="Industriebahn" short_description="Eine Strecke, die ausschließlich dem Güterverkehr dient und in der Regel Eigentum eines Industrieunternehmens ist. Meist nur innerhalb von Hafengebieten, Industrieanlagen, Tagebauen." />
@@ -2105,7 +1918,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="mixed,passenger,freight"
 					de.display_values="Gemischt,Personenverkehr,Güterverkehr"
 					display_values="mixed,passenger only,freight only"
-					default=""
 					/>
 				<check key="highspeed"
 					text="Highspeed traffic (~ >200 km/h)"
@@ -2129,26 +1941,24 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="yes,no,0,1,2,3"
 					display_values="Yes,No,Level 0,Level 1,Level 2,Level 3"
 					de.display_values="Ja,Nein,Level 0,Level 1,Level 2,Level 3"
-					default=""
 					/>
 				<combo key="railway:radio"
 					text="Radio"
 					de.text="Zugfunk"
 					values="analogue,gsm-r"
 					display_values="Analog,GSM-R"
-					default=""
 					/>
-				<combo key="railway:preferred_direction" text="Direction of use (depends on direction of OSM way)" de.text="Regelfahrtrichtung (abhängig von Richtung des OSM-Ways)" default="">
+				<combo key="railway:preferred_direction" text="Direction of use (depends on direction of OSM way)" de.text="Regelfahrtrichtung (abhängig von Richtung des OSM-Ways)">
 					<list_entry value="forward" display_value="In Wegrichtung" short_description="Das Gleis wird üblicherweise in die Richtung befahren, in die der OSM-Way führt. Nur für mehrgleisige Strecken." />
 					<list_entry value="backward" display_value="Entgegen Wegrichtung" short_description="Das Gleis wird üblicherweise entgegen der Richtung befahren, in die der OSM-Way führt. Nur für mehrgleisige Strecken." />
 					<list_entry value="both" display_value="Beide Richtungen" short_description="Es gibt keine Richtung, in die die Züge üblicherweise fahren bzw. nicht fahren. Nur für eingleisige Strecken." />
 				</combo>
-				<combo key="railway:bidirectional" text="Bidirectional traffic (depends on direction of OSM way)" de.text="Gleiswechselbetrieb (abhängig von Richtung des OSM-Ways)" default="">
+				<combo key="railway:bidirectional" text="Bidirectional traffic (depends on direction of OSM way)" de.text="Gleiswechselbetrieb (abhängig von Richtung des OSM-Ways)">
 					<list_entry value="regular" display_value="Gleiswechselbetrieb" short_description="Das Gleis ist für beide Fahrtrichtungen mit Signalen ausgestattet und kann daher regulär entgegen der üblichen Fahrtrichtung befahren werden." />
 					<list_entry value="signals" display_value="Signalisierter Falschfahrbetrieb" short_description="Das Gleis ist signaltechnisch nur für eine Fahrtrichtung ausgelegt, sodass weiterhin Falschfahrten notwendig sind, diese sind aber durch Signale geregelt." />
 					<list_entry value="possible" display_value="Falschfahrt möglich" short_description="Signaltechnisch besteht keine Möglichkeit einer Befahrung des Gegengleises. Es ist ein schriftlicher Befehl notwendig." />
 				</combo>
-				<combo key="maxspeed" default=""
+				<combo key="maxspeed"
 					text="Maxspeed (km/h)"
 					de.text="Höchstgeschwindigkeit (km/h)"
 					values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,none"
@@ -2160,28 +1970,24 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Elektrifizierung"
 					values="yes,no,contact_line,rail"
 					display_values="Ja,Nein,Oberleitung,Stromschiene"
-					default=""
 					/>
 				<combo key="voltage"
 					text="Voltage"
 					de.text="Spannung"
 					values="15000,500,550,600,750,850,1000,1200,1500,1800,2200,2400,3000,6500,6600,11000,25000"
 					display_values="15 kV (Standard in Österreich),500 V,550 V,600 V,750 V,850 V,1000 V,1200 V,1500 V,1800 V,2200 V,2400 V,3000 V,6500 V,6600 V,11 kV,25 kV"
-					default=""
 					/>
 				<combo key="frequency"
 					text="Frequency"
 					de.text="Frequenz"
 					values="16.7,0,16.67,50,60,25"
 					display_values="16.7 Hz (Standard in Österreich),Gleichspannung,16 2/3 Hz,50 Hz,60 Hz,25 Hz"
-					default=""
 					/>
 				<combo key="gauge"
 					text="Gauge"
 					de.text="Spurweite"
 					values="1435,1106,1040,1000,900,880,820,800,760,750,600,580,500,381,184,127"
 					display_values="1435 mm (Normalspur),1106,1040 mm,1000 mm (Meterspur),900 mm,880 mm,820 mm,800 mm,760mm (Bosnische Spur),750 mm,600 mm,580 mm,500 mm,381 mm,184 mm,127 mm"
-					default=""
 					/>
 				<check key="railway:ballastless"
 					text="Ballastless"
@@ -2193,28 +1999,23 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Zahnstange"
 					values="yes,no,riggenbach,strub,abt,locher,riggenbach-klose,marsh,von_roll"
 					display_values="Ja,Nein,System Riggenbach,System Strub,System Abt,System Locher,System Riggenbach-Klose,System Marsh,System Von Roll"
-					default=""
 					/>
 				<text key="incline"
 					text="Incline (e.g.. '3%')"
 					de.text="Steigung (z. B. '3%')"
-					default=""
 					/>
 				<space />
 				<text key="start_date"
 					text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
-					default=""
 					/>
 				<text key="end_date"
 					text="Closed at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Stilllegung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
-					default=""
 					/>
 				<text key="operator"
 					text="Operator (e.g. 'ÖBB-Infrastruktur AG')"
 					de.text="Betreiber (z. B. 'ÖBB-Infrastruktur AG')"
-					default=""
 					/>
 				<space />
 				<check key="embankment"
@@ -2237,17 +2038,14 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<text key="bridge:name"
 					text="Bridge name"
 					de.text="Name der Brücke"
-					default=""
 					/>
 				<text key="image"
 					text="Image URL"
 					de.text="URL eines Bildes"
-					default=""
 					/>
 				<text key="wikipedia"
 					text="Wikipedia article in the format (Language):(Article)"
 					de.text="Wikipediaartikel in der Form (Sprachkürzel):(Artikelname)"
-					default=""
 					/>
 			</item>
 			<item name="Tunnel" icon="tunnel.png" type="way">
@@ -2258,17 +2056,14 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<text key="tunnel:name"
 					text="Tunnel name"
 					de.text="Name des Tunnels"
-					default=""
 					/>
 				<text key="image"
 					text="Image URL"
 					de.text="URL eines Bildes"
-					default=""
 					/>
 				<text key="wikipedia"
 					text="Wikipedia article in the format (Language):(Article)"
 					de.text="Wikipediaartikel in der Form (Sprachkürzel):(Artikelname)"
-					default=""
 					/>
 			</item>
 			<separator />
@@ -2283,7 +2078,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="forward,backward"
 					de.display_values="In Wegrichtung,Entgegen Wegrichtung"
 					display_values="forward,backward"
-					default=""
 					/>
 				<key key="railway:signal:minor"
 					value="AT-V2:weiterfahrt_verboten" />
@@ -2298,7 +2092,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<text key="ref"
 					text="Switch ref"
 					de.text="Weichennummer"
-					default=""
 					/>
 				<check key="railway:local_operated"
 					text="Local operated"
@@ -2326,7 +2119,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="default,three_way,single_slip,double_slip,wye,abt"
 					de.values="default switch,three way switch,single slip switch,double slip switch,wye switch,abt switch"
 					display_values="Einfache Weiche,Dreiwegweiche,einfache Kreuzungsweiche,Doppelkreuzungsweiche,Y-Weiche,Abtsche Weiche"
-					default=""
 					/>
 				<combo key="railway:turnout_side"
 					text="Turnout side (only default and resetting switches)"
@@ -2334,29 +2126,24 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="left,right"
 					display_values="Left,Right"
 					de.display_values="Links,Rechts"
-					default=""
 					/>
 				<text key="railway:radius"
 					text="Switch radius (m)"
 					de.text="Weichenradius (m)"
-					default=""
 					/>
 				<text key="railway:maxspeed:straight"
 					text="Maxspeed in straight direction (km/h)"
 					de.text="Geschwindigkeit auf dem geraden Zweig (km/h)"
-					default=""
 					/>
 				<text key="railway:maxspeed:diverging"
 					text="Maxspeed in diverging direction (km/h)"
 					de.text="Geschwindigkeit auf dem Abzweig (km/h)"
-					default=""
 					/>
 				<combo key="railway:switch:configuration"
 					text="Configuration"
 					de.text="Bauform (bei Doppelkreuzungsweichen)"
 					values="inside,outside"
 					display_values="Innenliegende Zungen (Engländer),Außenliegende Zungen (Baeseler)"
-					default=""
 					/>
 				<check key="railway:switch:movable_frog"
 					text="Movable frog"
@@ -2372,7 +2159,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<text key="ref"
 					text="Ref"
 					de.text="Bezeichnung/Nummer"
-					default=""
 					/>
 			</item>
 			<item name="Gleissperre" icon="derail.png" type="node">
@@ -2385,7 +2171,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<text key="ref"
 					text="Ref"
 					de.text="Bezeichnung/Nummer"
-					default=""
 					/>
 				<check key="railway:local_operated"
 					text="Local operated"
@@ -2417,7 +2202,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="insulated_rail_joint,axle_counter"
 					display_values="insulated_rail_joint,axle_counter"
 					de.display_values="Isolierstoß,Achszähler"
-					default=""
 					/>
 			</item>
 		</group>
@@ -2429,39 +2213,32 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<text key="name"
 				text="Name"
 				de.text="Name"
-				default=""
 				/>
 			<text key="railway:ref"
 				text="Short name"
 				de.text="Abkürzung"
-				default=""
 				/>
 			<combo key="railway:signal_box"
 				text="Signal box type"
 				de.text="Stellwerkstechnik"
 				values="mechanical,electric,track_diagram,electronic"
 				display_values="Mechanisches Stellwerk,Elektrisches/Elektromechanisches Stellwerk,Gleisbildstellwerk,Elektronisches Stellwerk (ESTW)"
-				default=""
 				/>
 			<text key="start_date"
 				text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 				de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
-				default=""
 				/>
 			<text key="railway:position"
 				text="Distance indication (rounded, e.g. '12.3'; km)"
 				de.text="Hektometerwert (z. B. '12.3')"
-				default=""
 				/>
 			<text key="railway:position:exact"
 				text="Exact distance indication (exact, e.g. '12.345'; km)"
 				de.text="Metergenauer Wert (genau, z. B: '12.345'; km)"
-				default=""
 				/>
 			<text key="image"
 				text="Image URL"
 				de.text="URL eines Bildes"
-				default=""
 				/>
 			<check key="railway:local_operated"
 				text="Local operated"
@@ -2492,63 +2269,51 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="station, "
 					de.display_values="ja,nein"
 					display_values="yes,no"
-					default=""
 					/>
 				<text key="name" text="Name"
 					de.text="Name"
-					default=""
 					/>
 				<text key="railway:ref"
 					text="Short name (DB 640)"
 					de.text="Abkürzung (nach DB 640, z. B. 'Bbg')"
-					default=""
 					/>
 				<text key="uic_ref"
 					text="UIC-ID"
 					de.text="UIC-Bahnhofsnummer"
-					default=""
 					/>
 				<text key="uic_name"
 					text="UIC name"
 					de.text="UIC-Bahnhofsname"
-					default=""
 					/>
 				<combo key="railway:station_category"
 					text="Station category"
 					de.text="Bahnhofskategorie"
 					values="1,2,3,4,5,6,7"
 					display_values="1,2,3,4,5,6,7"
-					default=""
 					/>
 				<text key="operator"
 					text="Operator (e.g. 'ÖBB-Infrastruktur AG')"
 					de.text="Betreiber (z. B. 'ÖBB-Infrastruktur AG')"
-					default=""
 					/>
 				<text key="network"
 					text="Network"
 					de.text="Verkehrsverbund"
-					default=""
 					/>
 				<text key="start_date"
 					text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
-					default=""
 					/>
 				<text key="image"
 					text="Image URL"
 					de.text="URL eines Bildes"
-					default=""
 					/>
 				<text key="wikipedia"
 					text="Wikipedia article in the format (Language):(Article)"
 					de.text="Wikipediaartikel in der Form (Sprachkürzel):(Artikelname)"
-					default=""
 					/>
 				<text key="ele"
 					text="Height above sea level (m)"
 					de.text="Höhe über Meeresspiegel (m)"
-					default=""
 					/>
 			</item>
 			<item name="Haltestelle" icon="halt.png" type="node">
@@ -2563,63 +2328,51 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="station, "
 					de.display_values="ja,nein"
 					display_values="yes,no"
-					default=""
 					/>
 				<text key="name" text="Name"
 					de.text="Name"
-					default=""
 					/>
 				<text key="railway:ref"
 					text="Short name (DB 640)"
 					de.text="Abkürzung (DB 640, z. B. 'Bbg H1')"
-					default=""
 					/>
 				<text key="uic_ref"
 					text="UIC-ID"
 					de.text="UIC-Bahnhofsnummer"
-					default=""
 					/>
 				<text key="uic_name"
 					text="UIC name"
 					de.text="UIC-Bahnhofsname"
-					default=""
 					/>
 				<combo key="railway:station_category"
 					text="Station category"
 					de.text="Bahnhofskategorie"
 					values="1,2,3,4,5,6,7"
 					display_values="1,2,3,4,5,6,7"
-					default=""
 					/>
 				<text key="operator"
 					text="Operator (e.g. 'ÖBB-Infrastruktur AG')"
 					de.text="Betreiber (z. B. 'ÖBB-Infrastruktur AG')"
-					default=""
 					/>
 				<text key="network"
 					text="Network"
 					de.text="Verkehrsverbund"
-					default=""
 					/>
 				<text key="start_date"
 					text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
-					default=""
 					/>
 				<text key="image"
 					text="Image URL"
 					de.text="URL eines Bildes"
-					default=""
 					/>
 				<text key="wikipedia"
 					text="Wikipedia article in the format (Language):(Article)"
 					de.text="Wikipediaartikel in der Form (Sprachkürzel):(Artikelname)"
-					default=""
 					/>
 				<text key="ele"
 					text="Height above sea level (m)"
 					de.text="Höhe über Meeresspiegel (m)"
-					default=""
 					/>
 			</item>
 			<item name="Straßenbahnhaltestelle" icon="tramstop.png" type="node">
@@ -2634,46 +2387,37 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="station, "
 					de.display_values="ja,nein"
 					display_values="yes,no"
-					default=""
 					/>
 				<text key="name" text="Name"
 					de.text="Name"
-					default=""
 					/>
 				<text key="railway:ref"
 					text="Short name"
 					de.text="Abkürzung"
-					default=""
 					/>
 				<text key="uic_ref"
 					text="UIC-ID"
 					de.text="UIC-Bahnhofsnummer"
-					default=""
 					/>
 				<text key="uic_name"
 					text="UIC name"
 					de.text="UIC-Bahnhofsname"
-					default=""
 					/>
 				<text key="operator"
 					text="Operator (e.g. 'Wiener Linien GmbH &amp; Co KG')"
 					de.text="Betreiber (z. B. 'Wiener Linien GmbH &amp; Co KG')"
-					default=""
 					/>
 				<text key="network"
 					text="Network"
 					de.text="Verkehrsverbund"
-					default=""
 					/>
 				<text key="start_date"
 					text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
-					default=""
 					/>
 				<text key="ele"
 					text="Height above sea level (m)"
 					de.text="Höhe über Meeresspiegel (m)"
-					default=""
 					/>
 			</item>
 			<item name="Güterbahnhof/Rangierbahnhof" icon="yard.png" type="node">
@@ -2684,37 +2428,30 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					value="yard" />
 				<text key="name" text="Name"
 					de.text="Name"
-					default=""
 					/>
 				<text key="railway:ref"
 					text="Short name (DB 640)"
 					de.text="Abkürzung (nach DB 640, z. B. 'Bbg')"
-					default=""
 					/>
 				<text key="operator"
 					text="Operator (e.g. 'ÖBB-Infrastruktur AG')"
 					de.text="Betreiber (z. B. 'ÖBB-Infrastruktur AG')"
-					default=""
 					/>
 				<text key="start_date"
 					text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
-					default=""
 					/>
 				<text key="image"
 					text="Image URL"
 					de.text="URL eines Bildes"
-					default=""
 					/>
 				<text key="wikipedia"
 					text="Wikipedia article in the format (Language):(Article)"
 					de.text="Wikipediaartikel in der Form (Sprachkürzel):(Artikelname)"
-					default=""
 					/>
 				<text key="ele"
 					text="Height above sea level (m)"
 					de.text="Höhe über Meeresspiegel (m)"
-					default=""
 					/>
 			</item>
 			<item name="Betriebsbahnhof" icon="service-station.png" type="node">
@@ -2725,37 +2462,30 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					value="service_station" />
 				<text key="name" text="Name"
 					de.text="Name"
-					default=""
 					/>
 				<text key="railway:ref"
 					text="Short name (DB 640)"
 					de.text="Abkürzung (nach DB 640, z. B. 'Bbg')"
-					default=""
 					/>
 				<text key="operator"
 					text="Operator (e.g. 'ÖBB-Infrastruktur AG')"
 					de.text="Betreiber (z. B. 'ÖBB-Infrastruktur AG')"
-					default=""
 					/>
 				<text key="start_date"
 					text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
-					default=""
 					/>
 				<text key="image"
 					text="Image URL"
 					de.text="URL eines Bildes"
-					default=""
 					/>
 				<text key="wikipedia"
 					text="Wikipedia article in the format (Language):(Article)"
 					de.text="Wikipediaartikel in der Form (Sprachkürzel):(Artikelname)"
-					default=""
 					/>
 				<text key="ele"
 					text="Height above sea level (m)"
 					de.text="Höhe über Meeresspiegel (m)"
-					default=""
 					/>
 			</item>
 			<item name="Abzweig" icon="junction.png" type="node">
@@ -2767,37 +2497,30 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<text key="name"
 					text="Name"
 					de.text="Name"
-					default=""
 					/>
 				<text key="railway:ref"
 					text="Short name (DB 640, such as 'Bbg')"
 					de.text="Abkürzung (nach DB 640, z. B. 'Bbg')"
-					default=""
 					/>
 				<text key="operator"
 					text="Operator (e.g. 'ÖBB-Infrastruktur AG')"
 					de.text="Betreiber (z. B. 'ÖBB-Infrastruktur AG')"
-					default=""
 					/>
 				<text key="start_date"
 					text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
-					default=""
 					/>
 				<text key="image"
 					text="Image URL"
 					de.text="URL eines Bildes"
-					default=""
 					/>
 				<text key="wikipedia"
 					text="Wikipedia article in the format (Language):(Article)"
 					de.text="Wikipediaartikel in der Form (Sprachkürzel):(Artikelname)"
-					default=""
 					/>
 				<text key="ele"
 					text="Height above sea level (m)"
 					de.text="Höhe über Meeresspiegel (m)"
-					default=""
 					/>
 			</item>
 			<item name="Anst / Awanst" icon="junction.png" type="node">
@@ -2809,37 +2532,30 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<text key="name"
 					text="Name"
 					de.text="Name"
-					default=""
 					/>
 				<text key="railway:ref"
 					text="Short name (DB 640, such as 'Bbg')"
 					de.text="Abkürzung (nach DB 640, z. B. 'Bbg')"
-					default=""
 					/>
 				<text key="operator"
 					text="Operator (e.g. 'ÖBB-Infrastruktur AG')"
 					de.text="Betreiber (z. B. 'ÖBB-Infrastruktur AG')"
-					default=""
 					/>
 				<text key="start_date"
 					text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
-					default=""
 					/>
 				<text key="image"
 					text="Image URL"
 					de.text="URL eines Bildes"
-					default=""
 					/>
 				<text key="wikipedia"
 					text="Wikipedia article in the format (Language):(Article)"
 					de.text="Wikipediaartikel in der Form (Sprachkürzel):(Artikelname)"
-					default=""
 					/>
 				<text key="ele"
 					text="Height above sea level (m)"
 					de.text="Höhe über Meeresspiegel (m)"
-					default=""
 					/>
 			</item>
 			<item name="Überleitstelle" icon="crossover.png" type="node">
@@ -2851,37 +2567,30 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<text key="name"
 					text="Name"
 					de.text="Name"
-					default=""
 					/>
 				<text key="railway:ref"
 					text="Short name (DB 640)"
 					de.text="Abkürzung (nach DB 640, z. B. 'Bbg')"
-					default=""
 					/>
 				<text key="operator"
 					text="Operator (e.g. 'ÖBB-Infrastruktur AG')"
 					de.text="Betreiber (z. B. 'ÖBB-Infrastruktur AG')"
-					default=""
 					/>
 				<text key="start_date"
 					text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
-					default=""
 					/>
 				<text key="image"
 					text="Image URL"
 					de.text="URL eines Bildes"
-					default=""
 					/>
 				<text key="wikipedia"
 					text="Wikipedia article in the format (Language):(Article)"
 					de.text="Wikipediaartikel in der Form (Sprachkürzel):(Artikelname)"
-					default=""
 					/>
 				<text key="ele"
 					text="Height above sea level (m)"
 					de.text="Höhe über Meeresspiegel (m)"
-					default=""
 					/>
 			</item>
 			<item name="Bahnhofsteil, Blockstelle" icon="site.png" type="node">
@@ -2893,37 +2602,30 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<text key="name"
 					text="Name"
 					de.text="Name"
-					default=""
 					/>
 				<text key="railway:ref"
 					text="Short name (DB 640)"
 					de.text="Abkürzung (nach DB 640, z. B. 'Bbg')"
-					default=""
 					/>
 				<text key="operator"
 					text="Operator (e.g. 'ÖBB-Infrastruktur AG')"
 					de.text="Betreiber (z. B. 'ÖBB-Infrastruktur AG')"
-					default=""
 					/>
 				<text key="start_date"
 					text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
-					default=""
 					/>
 				<text key="image"
 					text="Image URL"
 					de.text="URL eines Bildes"
-					default=""
 					/>
 				<text key="wikipedia"
 					text="Wikipedia article in the format (Language):(Article)"
 					de.text="Wikipediaartikel in der Form (Sprachkürzel):(Artikelname)"
-					default=""
 					/>
 				<text key="ele"
 					text="Height above sea level (m)"
 					de.text="Höhe über Meeresspiegel (m)"
-					default=""
 					/>
 			</item>
 			<separator />
@@ -2937,34 +2639,28 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="stop_position, "
 					de.display_values="ja,nein"
 					display_values="yes,no"
-					default=""
 					/>
 				<key key="railway"
 					value="stop" />
 				<text key="name"
 					text="Name"
 					de.text="Name"
-					default=""
 					/>
 				<text key="railway:ref"
 					text="Short name (DB 640)"
 					de.text="Abkürzung (nach DB 640, z. B. 'Bbg')"
-					default=""
 					/>
 				<text key="uic_ref"
 					text="UIC-ID"
 					de.text="UIC-Bahnhofsnummer"
-					default=""
 					/>
 				<text key="uic_name"
 					text="UIC name"
 					de.text="UIC-Bahnhofsname"
-					default=""
 					/>
 				<text key="local_ref"
 					text="track number (e.g. 5 or 5a)"
 					de.text="Gleisnummer (z.B. 5 oder 5a)"
-					default=""
 					/>
 				<check key="train"
 					text="Railway traffic?"
@@ -2989,27 +2685,22 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<text key="operator"
 					text="Operator (e.g. 'ÖBB-Personenverkehr AG')"
 					de.text="Betreiber (z. B. 'ÖBB-Personenverkehr AG')"
-					default=""
 					/>
 				<text key="network"
 					text="Network"
 					de.text="Verkehrsverbund"
-					default=""
 					/>
 				<text key="ele"
 					text="Height above sea level (m)"
 					de.text="Höhe über Meeresspiegel (m)"
-					default=""
 					/>
 				<text key="railway:position"
 					text="Distance indication (rounded, e.g. '12.3'; km)"
 					de.text="Entfernungsangabe (gerundet, z. B. '12.3'; km)"
-					default=""
 					/>
 				<text key="railway:position:exact"
 					text="Exact distance indication (exact, e.g. '12.345'; km)"
 					de.text="Exakte Entfernungsangabe (genau, z.B: '12.345'; km)"
-					default=""
 					/>
 			</item>
 			<item name="Bahngelände" icon="landuse.png" type="closedway">
@@ -3028,7 +2719,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="public_transport, "
 					de.display_values="ja,nein"
 					display_values="yes,no"
-					default=""
 					/>
 				<combo key="public_transport"
 					text="Public transport?"
@@ -3036,32 +2726,26 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="stop_area, "
 					de.display_values="ja,nein"
 					display_values="yes,no"
-					default=""
 					/>
 				<text key="name"
 					text="Name"
 					de.text="Name"
-					default=""
 					/>
 				<text key="uic_ref"
 					text="UIC-ID"
 					de.text="UIC-Bahnhofsnummer"
-					default=""
 					/>
 				<text key="uic_name"
 					text="UIC name"
 					de.text="UIC-Bahnhofsname"
-					default=""
 					/>
 				<text key="railway:ref"
 					text="Short name (DB 640)"
 					de.text="Abkürzung (nach DB 640, z. B. 'Bbg')"
-					default=""
 					/>
 				<text key="operator"
 					text="Operator (e.g. 'ÖBB-Infrastruktur AG')"
 					de.text="Betreiber (z. B. 'ÖBB-Infrastruktur AG')"
-					default=""
 					/>
 				<check key="train"
 					text="Railway traffic?"
@@ -3129,32 +2813,26 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<text key="name"
 				text="Name of track (e.g. '222 01 Tauernbahn Schwarzach St. Veit – Spittal-Millstättersee')"
 				de.text="Streckenname (z. B. '222 01 Tauernbahn Schwarzach St. Veit – Spittal-Millstättersee')"
-				default=""
 				/>
 			<text key="ref"
 				text="Line ref (VzG number, e.g. '222 01')"
 				de.text="Streckennummer (VzG-Nummer, z. B. '222 01')"
-				default=""
 				/>
 			<text key="from"
 				text="Initial station"
 				de.text="Streckenanfang"
-				default=""
 				/>
 			<text key="to"
 				text="Terminus station"
 				de.text="Streckenende"
-				default=""
 				/>
 			<text key="operator"
 				text="Operator (e.g. 'ÖBB-Infrastruktur AG')"
 				de.text="Betreiber (z. B. 'ÖBB-Infrastruktur AG')"
-				default=""
 				/>
 			<text key="wikipedia"
 				text="Wikipedia article in the format (Language):(Article)"
 				de.text="Wikipediaartikel in der Form (Sprachkürzel):(Artikelname)"
-				default=""
 				/>
 			<roles>
 				<role key=""
@@ -3174,27 +2852,22 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<text key="name"
 				text="Name of route (e.g. '220 Tauernbahn')"
 				de.text="Name der Kursbuchstrecke (z. B. '220 Tauernbahn')"
-				default=""
 				/>
 			<text key="ref"
 				text="Line ref (KBS number, e.g. '220')"
 				de.text="Streckennummer (KBS-Nummer, z. B. '220')"
-				default=""
 				/>
 			<text key="from"
 				text="Initial station"
 				de.text="Streckenanfang"
-				default=""
 				/>
 			<text key="to"
 				text="Terminus station"
 				de.text="Streckenende"
-				default=""
 				/>
 			<text key="wikipedia"
 				text="Wikipedia article in the format (Language):(Article)"
 				de.text="Wikipediaartikel in der Form (Sprachkürzel):(Artikelname)"
-				default=""
 				/>
 			<roles>
 				<role key=""
@@ -3215,9 +2888,8 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				values="train,light_rail,tram,subway"
 				de.display_values="Zug,Stadt-/Schnellbahn,Straßenbahn,U-Bahn"
 				display_values="train,light rail,tram,subway"
-				default=""
 				/>
-			<combo key="service" text="Zuggattung" default="">
+			<combo key="service" text="Zuggattung">
 				<list_entry value="high_speed" de.display_value="Hochgeschwindigkeitszug" display_value="high speed train" short_description="ICE, Thalys, TGV, Railjet" />
 				<list_entry value="long_distance" de.display_value="Reisezug" display_value="long distance train" short_description="Eurocity, Intercity, D-Zug" />
 				<list_entry value="regional" de.display_value="Regionalzug" display_value="regional train" short_description="Regionalbahn, Regionalexpress" />
@@ -3230,32 +2902,26 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<text key="name"
 				text="Name of line (e.g. 'S 7 Wien Floridsdorf – Wolfsthal')"
 				de.text="Name der Linie (z. B. 'S 7 Wien Floridsdorf – Wolfsthal')"
-				default=""
 				/>
 			<text key="operator"
 				text="Operator"
 				de.text="Betreiber"
-				default=""
 				/>
 			<text key="ref"
 				text="Line or train ref (e.g. 'S 7')"
 				de.text="Linien- bzw. Zugnummer (z. B. 'S 7')"
-				default=""
 				/>
 			<text key="from"
 				text="Initial station"
 				de.text="Streckenanfang"
-				default=""
 				/>
 			<text key="to"
 				text="Terminus station"
 				de.text="Streckenende"
-				default=""
 				/>
 			<text key="wikipedia"
 				text="Wikipedia article in the format (Language):(Article)"
 				de.text="Wikipediaartikel in der Form (Sprachkürzel):(Artikelname)"
-				default=""
 				/>
 			<roles>
 				<role key=""
@@ -3312,9 +2978,8 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				values="train,light_rail,tram,subway"
 				de.display_values="Zug,Stadt-/Schnellbahn,Straßenbahn,U-Bahn"
 				display_values="train,light rail,tram,subway"
-				default=""
 				/>
-			<combo key="service" text="Zuggattung" default="">
+			<combo key="service" text="Zuggattung">
 				<list_entry value="high_speed" de.display_value="Hochgeschwindigkeitszug" display_value="high speed train" short_description="ICE, Thalys, TGV, Railjet" />
 				<list_entry value="long_distance" de.display_value="Reisezug" display_value="long distance train" short_description="Eurocity, Intercity, D-Zug" />
 				<list_entry value="regional" de.display_value="Regionalzug" display_value="regional train" short_description="Regionalbahn, Regionalexpress" />
@@ -3327,32 +2992,26 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<text key="name"
 				text="Name of line (e.g. 'S 7 Wien Floridsdorf – Wolfsthal')"
 				de.text="Name der Linie (z. B. 'S 7 Wien Floridsdorf – Wolfsthal')"
-				default=""
 				/>
 			<text key="operator"
 				text="Operator"
 				de.text="Betreiber"
-				default=""
 				/>
 			<text key="ref"
 				text="Line or train ref (e.g. 'S 7')"
 				de.text="Linien- bzw. Zugnummer (z. B. 'S 7')"
-				default=""
 				/>
 			<text key="from"
 				text="Initial station"
 				de.text="Streckenanfang"
-				default=""
 				/>
 			<text key="to"
 				text="Terminus station"
 				de.text="Streckenende"
-				default=""
 				/>
 			<text key="wikipedia"
 				text="Wikipedia article in the format (Language):(Article)"
 				de.text="Wikipediaartikel in der Form (Sprachkürzel):(Artikelname)"
-				default=""
 				/>
 			<roles>
 				<role key=""
@@ -3407,17 +3066,14 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<text key="railway:ref"
 				text="Name (no position)"
 				de.text="Name (keine Kilometerangabe oder kreuzende Straße)"
-				default=""
 				/>
 			<text key="railway:position"
 				text="Position (rounded, e.g. '12.3'; km)"
 				de.text="Hektometerwert (z. B. '12.3')"
-				default=""
 				/>
 			<text key="railway:position:exact"
 				text="Position (exact, e.g. '12.345'; km)"
 				de.text="Metergenauer Wert (z. B. '12.345'; km)"
-				default=""
 				/>
 			<space />
 			<combo key="crossing:barrier"
@@ -3425,7 +3081,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				values="half,double_half,full,gates,yes,no"
 				de.display_values="Halbschranke,Vollabschluss ('doppelte Halbschranke'),Vollschranke,Tore (England),Beschrankt,Unbeschrankt"
 				display_values="half boom gate,double half boom gate,full boom gate,gates (turnable),yes,no"
-				default=""
 				/>
 			<check key="crossing:light"
 				text="Lights"
@@ -3453,19 +3108,16 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				values="no,camera,attendant,automatic,phone"
 				display_values="no,camera,attendant,automatic,phone"
 				de.display_values="keine Überwachung,Kamera,Schrankenwärter/Fahrdienstleiter/Posten,Gefahrenraum-Freimeldeanlage,Telefon (Anrufschranken)"
-				default=""
 				/>
 			<combo key="crossing:activation"
 				text="Activation" de.text="Einschaltung"
 				values="automatic,remote,local"
 				display_values="automatic (contacts),remote (signal box), local (attendant/train staff)"
 				de.display_values="Einschaltkontakte, fahrdienstleitergesteuert, vor Ort (Schrankenwärter/Zugpersonal)"
-				default=""
 				/>
 			<text key="railway:level_crossing:closure:average"
 				text="average clousure duration (minutes)"
 				de.text="durchschnittliche Schließdauer (in Minuten)"
-				default=""
 				/>
 			<check key="crossing:on_demand"
 				text="On demand"
@@ -3481,17 +3133,14 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<text key="railway:ref"
 				text="Name (no position)"
 				de.text="Name (keine Kilometerangabe oder kreuzende Straße)"
-				default=""
 				/>
 			<text key="railway:position"
 				text="Position (rounded, e.g. '12.3'; km)"
 				de.text="Hektometerwert (z. B. '12.3')"
-				default=""
 				/>
 			<text key="railway:position:exact"
 				text="Position (exact, e.g. '12.345'; km)"
 				de.text="Metergenauer Wert (z. B. '12.345'; km)"
-				default=""
 				/>
 			<space />
 			<combo key="crossing:barrier"
@@ -3499,7 +3148,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				values="half,double_half,full,gates,yes,no"
 				de.display_values="Halbschranke,Vollabschluss ('doppelte Halbschranke'),Vollschranke,Tore (England),Beschrankt,Unbeschrankt"
 				display_values="half boom gate,double half boom gate,full boom gate,gates (turnable),yes,no"
-				default=""
 				/>
 			<check key="crossing:light"
 				text="Lights"
@@ -3527,19 +3175,16 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				values="no,camera,attendant,automatic,phone"
 				display_values="no,camera,attendant,automatic,phone"
 				de.display_values="keine Überwachung,Kamera,Schrankenwärter/Fahrdienstleiter/Posten,Gefahrenraum-Freimeldeanlage,Telefon (Anrufschranken)"
-				default=""
 				/>
 			<combo key="crossing:activation"
 				text="Activation" de.text="Einschaltung"
 				values="automatic,remote,local"
 				display_values="automatic (contacts),remote (signal box), local (attendant/train staff)"
 				de.display_values="Einschaltkontakte, fahrdienstleitergesteuert, vor Ort (Schrankenwärter/Zugpersonal)"
-				default=""
 				/>
 			<text key="railway:level_crossing:closure:average"
 				text="average clousure duration (minutes)"
 				de.text="durchschnittliche Schließdauer (in Minuten)"
-				default=""
 				/>
 			<check key="crossing:on_demand"
 				text="On demand"
@@ -3563,12 +3208,10 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<text key="railway:position"
 				text="Distance indication (rounded, e.g. '12.3'; km)"
 				de.text="Hektometerwert (z. B. '12.3')"
-				default=""
 				/>
 			<text key="railway:position:exact"
 				text="Exact distance indication (exact, e.g. '12.345'; km)"
 				de.text="Metergenauer Wert (z. B. '12.345')"
-				default=""
 				/>
 			<check key="railway:milestone:catenary_mast"
 				text="On catenary mast"
@@ -3585,7 +3228,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				de.text="Richtung der Notbremsunterdrückung (falls vorhanden)"
 				values="forward,backward,both"
 				display_values="In Wegrichtung,Entgegen Wegrichtung,Beide Richtungen"
-				default=""
 				/>
 		</item>
 		<item name="Bahnsteig" icon="platform.png" type="way,closedway">
@@ -3595,12 +3237,10 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<text key="name"
 				text="Caption"
 				de.text="Beschriftung"
-				default=""
 				/>
 			<text key="ref"
 				text="Platform number(s)"
 				de.text="Bahnsteignummer(n)"
-				default=""
 				/>
 			<check key="area"
 				text="Area"
@@ -3622,7 +3262,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				de.text="Oberfläche"
 				values="asphalt,paving_stones,concrete,cobblestone,compacted,paved,unpaved"
 				display_values="Asphalt,Pflastersteine,Beton,Kopfsteinpflaster,Verdichtet,Befestigt,Unbefestigt"
-				default=""
 				/>
 			<key key="public_transport"
 				value="platform" />
@@ -3631,19 +3270,16 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				de.text="Rollstuhlgerecht"
 				values="yes,no,limited"
 				display_values="Ja,Nein,Eingeschränkt"
-				default=""
 				/>
 			<combo key="tactile_paving"
 				text="Tactile Paving"
 				de.text="Ertastbarer Untergrund"
 				values="yes,no,incorrect"
 				display_values="Ja,Nein,Ja (aber nicht sinnvoll)"
-				default=""
 				/>
 			<text key="height"
 				text="Platform height (in meters, e. g. 0.76)"
 				de.text="Bahnsteighöhe (in Metern, z. B. 0.76)"
-				default=""
 				/>
 			<check key="train"
 				text="Railway traffic?"
@@ -3674,17 +3310,14 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<text key="operator"
 				text="Operator (e.g. 'ÖBB-Personenverkehr AG')"
 				de.text="Betreiber (z. B. 'ÖBB-Personenverkehr AG')"
-				default=""
 				/>
 			<text key="name"
 				text="Name (e.g. 'Reisezentrum')"
 				de.text="Name (z. B. 'Reisezentrum')"
-				default=""
 				/>
 			<text key="opening_hours"
 				text="Opening hours"
 				de.text="Öffnungszeiten"
-				default=""
 				/>
 		</item>
 		<item name="U-Bahn-Zugang" icon="landuse.png" type="node">
@@ -3694,14 +3327,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<text key="name"
 				text="Name"
 				de.text="Name"
-				default=""
 				/>
 			<combo key="wheelchair"
 				text="Wheelchair"
 				de.text="Rollstuhlgerecht"
 				values="yes,no,limited"
 				display_values="Ja,Nein,Eingeschränkt"
-				default=""
 				/>
 			<check key="bicycle"
 				text="Accessible with bicycles"
@@ -3717,17 +3348,14 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<text key="start_date"
 				text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 				de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
-				default=""
 				/>
 			<text key="image"
 				text="Image URL"
 				de.text="URL eines Bildes"
-				default=""
 				/>
 			<text key="ele"
 				text="Height above sea level (m)"
 				de.text="Höhe über Meeresspiegel (m)"
-				default=""
 				/>
 		</item>
 		<item name="Bahngelände" icon="landuse.png" type="closedway">
@@ -3761,7 +3389,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				de.text="Mode"
 				values="analogue,gsm-r"
 				display_values="Analog,GSM-R"
-				default=""
 				/>
 		</item>
 		<separator />
@@ -3839,7 +3466,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<text key="name"
 					text="Name"
 					de.text="Name"
-					default=""
 					/>
 			</item>
 			<item name="Werkstatt" icon="workshop.png" type="node,closedway">
@@ -3854,7 +3480,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<text key="name"
 					text="Name"
 					de.text="Name"
-					default=""
 					/>
 			</item>
 		</group>
@@ -3881,7 +3506,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<text key="name"
 					text="Name"
 					de.text="Name"
-					default=""
 					/>
 				<check key="lit"
 					text="Lit"
@@ -3893,12 +3517,10 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Oberfläche"
 					values="asphalt,paving_stones,concrete,cobblestone,compacted,paved,unpaved"
 					display_values="Asphalt,Pflastersteine,Beton,Kopfsteinpflaster,Verdichtet,Befestigt,Unbefestigt"
-					default=""
 					/>
 				<text key="height"
 					text="Ramp height (m) - 0 for loading streets"
 					de.text="Rampenhöhe (m) - bei Ladestraße 0 eintragen"
-					default=""
 					/>
 				<check key="area"
 					text="Area"
@@ -3908,7 +3530,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<text key="operator"
 					text="Operator (e.g. 'ÖBB-Infrastruktur AG')"
 					de.text="Betreiber (z. B. 'ÖBB-Infrastruktur AG')"
-					default=""
 					/>
 			</item>
 			<separator />
@@ -3921,22 +3542,18 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<text key="name"
 					text="Name"
 					de.text="Name"
-					default=""
 					/>
 				<text key="uic_ref"
 					text="UIC-ID"
 					de.text="UIC-Bahnhofsnummer"
-					default=""
 					/>
 				<text key="uic_name"
 					text="UIC name"
 					de.text="UIC-Bahnhofsname"
-					default=""
 					/>
 				<text key="operator"
 					text="Operator"
 					de.text="Betreiber"
-					default=""
 					/>
 			</item>
 			<item name="Eisenbahnfährverlauf" icon="ferry-way.png" type="way">
@@ -3948,12 +3565,10 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<text key="name"
 					text="Name"
 					de.text="Name"
-					default=""
 					/>
 				<text key="operator"
 					text="Operator"
 					de.text="Betreiber"
-					default=""
 					/>
 			</item>
 			<item name="Eisenbahnfährlinie" icon="ferry-line.png" type="relation">
@@ -3967,12 +3582,10 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<text key="name"
 					text="Name"
 					de.text="Name"
-					default=""
 					/>
 				<text key="operator"
 					text="Operator"
 					de.text="Betreiber"
-					default=""
 					/>
 			</item>
 			<separator />
@@ -3988,12 +3601,10 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<text key="name"
 					text="Name"
 					de.text="Name"
-					default=""
 					/>
 				<text key="wikipedia"
 					text="Wikipedia article in the format (Language):(Article)"
 					de.text="Wikipediaartikel in der Form (Sprachkürzel):(Artikelname)"
-					default=""
 					/>
 			</item>
 			<item name="Rollwagenverladung" icon="carrier-truck-pit.png" type="node">
@@ -4009,32 +3620,26 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<text key="name"
 					text="Name"
 					de.text="Name"
-					default=""
 					/>
 				<text key="operator"
 					text="Operator"
 					de.text="Betreiber"
-					default=""
 					/>
 				<text key="uic_ref"
 					text="UIC-ID"
 					de.text="UIC-Bahnhofsnummer"
-					default=""
 					/>
 				<text key="uic_name"
 					text="UIC name"
 					de.text="UIC-Bahnhofsname"
-					default=""
 					/>
 				<text key="network"
 					text="Network"
 					de.text="Verkehrsverbund"
-					default=""
 					/>
 				<text key="image"
 					text="Image URL"
 					de.text="URL eines Bildes"
-					default=""
 					/>
 			</item>
 			<item name="Autozug-Verladung" icon="carshuttle.png" type="node">
@@ -4045,32 +3650,26 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<text key="name"
 					text="Name"
 					de.text="Name"
-					default=""
 					/>
 				<text key="operator"
 					text="Operator"
 					de.text="Betreiber"
-					default=""
 					/>
 				<text key="uic_ref"
 					text="UIC-ID"
 					de.text="UIC-Bahnhofsnummer"
-					default=""
 					/>
 				<text key="uic_name"
 					text="UIC name"
 					de.text="UIC-Bahnhofsname"
-					default=""
 					/>
 				<text key="network"
 					text="Network"
 					de.text="Verkehrsverbund"
-					default=""
 					/>
 				<text key="image"
 					text="Image URL"
 					de.text="URL eines Bildes"
-					default=""
 					/>
 			</item>
 		</group>
@@ -4109,12 +3708,10 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<text key="name"
 				text="Name"
 				de.text="Name"
-				default=""
 				/>
 			<text key="wikipedia"
 				text="Wikipedia article in the format (Language):(Article)"
 				de.text="Wikipediaartikel in der Form (Sprachkürzel):(Artikelname)"
-				default=""
 				/>
 		</item>
 		<item name="Firma mit Gleisanschluss" icon="industrial.png" type="closedway">
@@ -4126,7 +3723,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<text key="name"
 				text="Name"
 				de.text="Name"
-				default=""
 				/>
 		</item>
 		<item name="Tor" icon="gate.png" type="node">

--- a/josm-presets/at.xml
+++ b/josm-presets/at.xml
@@ -23,19 +23,19 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Line ref (VzG number, e.g. '2379')"
 					de.text="Streckennummer (VzG-Nummer, z. B. '2379')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="railway:track_ref"
 					text="Track ref (inside station)"
 					de.text="Gleisnummer (im Bahnhof)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="name"
 					text="Railway name"
 					de.text="Streckenname"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />	
-				<combo key="usage" text="Usage" de.text="Nutzung" default="" delete_if_empty="true">
+				<combo key="usage" text="Usage" de.text="Nutzung" default="">
 					<list_entry value="main" de.display_value="Hauptbahn" display_value="main line" de.short_description="Strecke mit übergeordneter Bedeutung; meist zweigleisig, meist elektrifiziert, in der Regel zumindest abschnittsweise mit mehr als 100 km/h befahrbar" short_description="An important line; often double tracks, electrified; usually more than 100 km/h" />
 					<list_entry value="branch" de.display_value="Nebenbahn" display_value="branch line" de.short_description="Strecke mit untergeordneter Bedeutung; oft nicht elektrifiziert, oft eingleisig. Keinesfalls mit mehr als 100 km/h befahrbar." short_description="less important line; often single-tracked; not electrified; less than 100 km/h" />
 					<list_entry value="industrial" de.display_value="Industriebahn" display_value="industrial line" de.short_description="Eine Strecke, die ausschließlich dem Güterverkehr dient und in der Regel Eigentum eines Industrieunternehmens ist. Meist nur innerhalb von Hafengebieten, Industrieanlagen, Tagebauen." short_description="A line only used for freight trains inside industrial areas or mines." />
@@ -49,53 +49,53 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="mixed,passenger,freight"
 					display_values="Gemischt,Personenverkehr,Güterverkehr"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<check key="highspeed"
 					text="High-speed line (~ >200 km/h)"
 					de.text="Hochgeschwindigkeitsstrecke (~ >200 km/h)"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="railway:tilting"
 					text="Used by tilting trains"
 					de.text="Neigetechnik-Ausrüstung"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<space />
 				<check key="lit"
 					text="Lit"
 					de.text="Beleuchtung"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="railway:pzb"
 					text="PZB"
 					de.text="Punktförmige Zugbeeinflussung (PZB)"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="railway:lzb"
 					text="Linienzugbeeinflussung (LZB)"
 					de.text="Linienzugbeeinflussung (LZB)"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:etcs"
 					text="ETCS"
 					de.text="ETCS"
 					values="yes,no,0,1,2,3"
 					display_values="Ja,Nein,Level 0,Level 1,Level 2,Level 3"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:radio"
 					text="Radio"
 					de.text="Zugfunk"
 					values="analogue,gsm-r"
 					display_values="Analog,GSM-R"
 					default=""
-					delete_if_empty="true" />
-				<combo key="railway:preferred_direction" text="Direction of use (depends on direction of OSM way)" de.text="Regelfahrtrichtung (abhängig von Richtung des OSM-Ways)" default="" delete_if_empty="true">
+					/>
+				<combo key="railway:preferred_direction" text="Direction of use (depends on direction of OSM way)" de.text="Regelfahrtrichtung (abhängig von Richtung des OSM-Ways)" default="">
 					<list_entry value="forward" display_value="In Wegrichtung" short_description="Das Gleis wird üblicherweise in die Richtung befahren, in die der OSM-Way führt. Nur für mehrgleisige Strecken." />
 					<list_entry value="backward" display_value="Entgegen Wegrichtung" short_description="Das Gleis wird üblicherweise entgegen der Richtung befahren, in die der OSM-Way führt. Nur für mehrgleisige Strecken." />
 					<list_entry value="both" display_value="Beide Richtungen" short_description="Es gibt keine Richtung, in die die Züge üblicherweise fahren bzw. nicht fahren. Nur für eingleisige Strecken." />
 				</combo>
-				<combo key="railway:bidirectional" text="Bidirectional traffic (depends on direction of OSM way)" de.text="Gleiswechselbetrieb (abhängig von Richtung des OSM-Ways)" default="" delete_if_empty="true">
+				<combo key="railway:bidirectional" text="Bidirectional traffic (depends on direction of OSM way)" de.text="Gleiswechselbetrieb (abhängig von Richtung des OSM-Ways)" default="">
 					<list_entry value="regular" display_value="Gleiswechselbetrieb" short_description="Das Gleis ist für beide Fahrtrichtungen mit Signalen ausgestattet und kann daher regulär entgegen der üblichen Fahrtrichtung befahren werden." />
 					<list_entry value="signals" display_value="Signalisierter Falschfahrbetrieb" short_description="Das Gleis ist signaltechnisch nur für eine Fahrtrichtung ausgelegt, sodass weiterhin Falschfahrten notwendig sind, diese sind aber durch Signale geregelt." />
 					<list_entry value="possible" display_value="Falschfahrt möglich" short_description="Signaltechnisch besteht keine Möglichkeit einer Befahrung des Gegengleises. Es ist ein schriftlicher Befehl notwendig." />
@@ -104,7 +104,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<combo key="maxspeed" default=""
 					text="Maxspeed (km/h)"
 					de.text="Höchstgeschwindigkeit (km/h)"
-					delete_if_empty="true"
 					values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,none"
 					display_values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,keine" />
 				<label text="Unterschiedliche Geschwindigkeiten je Richtung können manuell mit maxspeed:forward=* bzw. maxspeed:backward=* getaggt werden." />
@@ -115,62 +114,62 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="yes,no,contact_line,rail"
 					display_values="Ja,Nein,Ja (mit Oberleitung),Ja (mit Stromschiene)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="voltage"
 					text="Voltage"
 					de.text="Spannung"
 					values="15000,500,550,600,750,850,1000,1200,1500,2400,3000,6500,6600,11000,25000"
 					display_values="15 kV (Standard in Österreich),500 V,550 V,600 V,750 V,850 V,1000 V,1200 V,1500 V,2400 V,3000 V,6500 V,6600 V,11 kV,25 kV"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="frequency"
 					text="Frequency"
 					de.text="Frequenz"
 					values="16.7,0,16.67,50,60,25"
 					display_values="16.7 Hz (Standard in Österreich),Gleichspannung,16 2/3 Hz,50 Hz,60 Hz,25 Hz"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<key key="gauge"
 					value="1435" />
 				<check key="railway:ballastless"
 					text="Ballastless"
 					de.text="Feste Fahrbahn"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="rack"
 					text="Rack"
 					de.text="Zahnstange"
 					values="yes,no,riggenbach,strub,abt,locher,riggenbach-klose,marsh,von_roll"
 					display_values="Ja,Nein,System Riggenbach,System Strub,System Abt,System Locher,System Riggenbach-Klose,System Marsh,System Von Roll"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="incline"
 					text="Incline (e.g.. '3%')"
 					de.text="Steigung (z. B. '3%')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<text key="start_date"
 					text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="operator"
 					text="Operator (e.g. 'ÖBB-Infrastruktur AG')"
 					de.text="Betreiber (z. B. 'ÖBB-Infrastruktur AG')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<check key="embankment"
 					text="Embankment"
 					de.text="Damm"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="cutting"
 					text="Cutting"
 					de.text="Einschnitt"
 					default="off"
-					delete_if_empty="true" />
+					/>
 			</item>
 			<item name="Hauptgleis" icon="siding.png" type="way">
 				<label text="Nicht durchgehendes Hauptgleis in einem Bahnhof und alle sonstigen Gleise, die weder durchgehendes Hauptgleis, noch Nebengleis, Anschlussgleis, Abstellgleis oder Überleitgleis sind. Jedes Gleis wird einzeln erfasst." />
@@ -183,7 +182,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Track ref (inside station)"
 					de.text="Gleisnummer (im Bahnhof)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<combo key="railway:traffic_mode"
 					text="Traffic mode"
@@ -191,46 +190,45 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="mixed,passenger,freight"
 					display_values="Gemischt,Personenverkehr,Güterverkehr"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<check key="highspeed"
 					text="High-speed line (~ >200 km/h)"
 					de.text="Hochgeschwindigkeitsstrecke (~ >200 km/h)"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<space />
 				<check key="lit"
 					text="Lit"
 					de.text="Beleuchtung"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="railway:pzb"
 					text="PZB"
 					de.text="Punktförmige Zugbeeinflussung (PZB)"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="railway:lzb"
 					text="Linienzugbeeinflussung (LZB)"
 					de.text="Linienzugbeeinflussung (LZB)"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:etcs"
 					text="ETCS"
 					de.text="ETCS"
 					values="yes,no,0,1,2,3"
 					display_values="Ja,Nein,Level 0,Level 1,Level 2,Level 3"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:radio"
 					text="Radio"
 					de.text="Zugfunk"
 					values="analogue,gsm-r"
 					display_values="Analog,GSM-R"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="maxspeed" default=""
 					text="Maxspeed (km/h)"
 					de.text="Höchstgeschwindigkeit (km/h)"
-					delete_if_empty="true"
 					values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,none"
 					display_values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,keine" />
 				<label text="Unterschiedliche Geschwindigkeiten je Richtung können manuell mit maxspeed:forward=* bzw. maxspeed:backward=* getaggt werden." />
@@ -241,62 +239,62 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="yes,no,contact_line,rail"
 					display_values="Ja,Nein,Oberleitung,Stromschiene"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="voltage"
 					text="Voltage"
 					de.text="Spannung"
 					values="15000,500,550,600,750,850,1000,1200,1500,2400,3000,6500,6600,11000,25000"
 					display_values="15 kV (Standard in Österreich),500 V,550 V,600 V,750 V,850 V,1000 V,1200 V,1500 V,2400 V,3000 V,6500 V,6600 V,11 kV,25 kV"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="frequency"
 					text="Frequency"
 					de.text="Frequenz"
 					values="16.7,0,16.67,50,60,25"
 					display_values="16.7 Hz (Standard in Österreich),Gleichspannung,16 2/3 Hz,50 Hz,60 Hz,25 Hz"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<key key="gauge"
 					value="1435" />
 				<check key="railway:ballastless"
 					text="Ballastless"
 					de.text="Feste Fahrbahn"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="rack"
 					text="Rack"
 					de.text="Zahnstange"
 					values="yes,no,riggenbach,strub,abt,locher,riggenbach-klose,marsh,von_roll"
 					display_values="Ja,Nein,System Riggenbach,System Strub,System Abt,System Locher,System Riggenbach-Klose,System Marsh,System Von Roll"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="incline"
 					text="Incline (e.g.. '3%')"
 					de.text="Steigung (z. B. '3%')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<text key="start_date"
 					text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="operator"
 					text="Operator (e.g. 'ÖBB-Infrastruktur AG')"
 					de.text="Betreiber (z. B. 'ÖBB-Infrastruktur AG')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<check key="embankment"
 					text="Embankment"
 					de.text="Damm"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="cutting"
 					text="Cutting"
 					de.text="Einschnitt"
 					default="off"
-					delete_if_empty="true" />
+					/>
 			</item>
 			<item name="Nebengleis / Abstellgleis" icon="yard.png" type="way">
 				<label text="Abstellgleise in Rangier-, Güter- oder Betriebsbahnhöfen, auf denen Züge zusammengestellt und Wagen abgestellt werden. Jedes Gleis wird einzeln erfasst." />
@@ -309,7 +307,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Track ref (inside station)"
 					de.text="Gleisnummer (im Bahnhof)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<combo key="railway:traffic_mode"
 					text="Traffic mode"
@@ -317,36 +315,35 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="mixed,passenger,freight"
 					display_values="Gemischt,Personenverkehr,Güterverkehr"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<check key="lit"
 					text="Lit"
 					de.text="Beleuchtung"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="railway:pzb"
 					text="PZB"
 					de.text="Punktförmige Zugbeeinflussung (PZB)"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:etcs"
 					text="ETCS"
 					de.text="ETCS"
 					values="yes,no,0,1,2,3"
 					display_values="Ja,Nein,Level 0,Level 1,Level 2,Level 3"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:radio"
 					text="Radio"
 					de.text="Zugfunk"
 					values="analogue,gsm-r"
 					display_values="Analog,GSM-R"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="maxspeed" default=""
 					text="Maxspeed (km/h)"
 					de.text="Höchstgeschwindigkeit (km/h)"
-					delete_if_empty="true"
 					values="10,20,30,40,50,60,70,80,90,100,none"
 					display_values="10,20,30,40,50,60,70,80,90,100,keine" />
 				<label text="Unterschiedliche Geschwindigkeiten je Richtung können manuell mit maxspeed:forward=* bzw. maxspeed:backward=* getaggt werden." />
@@ -357,62 +354,62 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="yes,no,contact_line,rail"
 					display_values="Ja,Nein,Oberleitung,Stromschiene"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="voltage"
 					text="Voltage"
 					de.text="Spannung"
 					values="15000,500,550,600,750,850,1000,1200,1500,2400,3000,6500,6600,11000,25000"
 					display_values="15 kV (Standard in Österreich),500 V,550 V,600 V,750 V,850 V,1000 V,1200 V,1500 V,2400 V,3000 V,6500 V,6600 V,11 kV,25 kV"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="frequency"
 					text="Frequency"
 					de.text="Frequenz"
 					values="16.7,0,16.67,50,60,25"
 					display_values="16.7 Hz (Standard in Österreich),Gleichspannung,16 2/3 Hz,50 Hz,60 Hz,25 Hz"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<key key="gauge"
 					value="1435" />
 				<check key="railway:ballastless"
 					text="Ballastless"
 					de.text="Feste Fahrbahn"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="rack"
 					text="Rack"
 					de.text="Zahnstange"
 					values="yes,no,riggenbach,strub,abt,locher,riggenbach-klose,marsh,von_roll"
 					display_values="Ja,Nein,System Riggenbach,System Strub,System Abt,System Locher,System Riggenbach-Klose,System Marsh,System Von Roll"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="incline"
 					text="Incline (e.g.. '3%')"
 					de.text="Steigung (z. B. '3%')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<text key="start_date"
 					text="Year of opening"
 					de.text="Zeitpunkt der Inbetriebnahme"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="operator"
 					text="Operator (e.g. 'ÖBB-Infrastruktur AG')"
 					de.text="Betreiber (z. B. 'ÖBB-Infrastruktur AG')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<check key="embankment"
 					text="Embankment"
 					de.text="Damm"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="cutting"
 					text="Cutting"
 					de.text="Einschnitt"
 					default="off"
-					delete_if_empty="true" />
+					/>
 			</item>
 			<item name="Anschluss- oder Verladegleis" icon="spur.png" type="way">
 				<label text="Kurze Gleise, die Industriebetriebe an eine Bahnstrecke anschließen oder Verladegleise in Industrieanlagen." />
@@ -429,35 +426,34 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Lit"
 					de.text="Beleuchtung"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="railway:pzb"
 					text="PZB"
 					de.text="Punktförmige Zugbeeinflussung (PZB)"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="railway:lzb"
 					text="Linienzugbeeinflussung (LZB)"
 					de.text="Linienzugbeeinflussung (LZB)"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:etcs"
 					text="ETCS"
 					de.text="ETCS"
 					values="yes,no,0,1,2,3"
 					display_values="Ja,Nein,Level 0,Level 1,Level 2,Level 3"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:radio"
 					text="Radio"
 					de.text="Zugfunk"
 					values="analogue,gsm-r"
 					display_values="Analog,GSM-R"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="maxspeed" default=""
 					text="Maxspeed (km/h)"
 					de.text="Höchstgeschwindigkeit (km/h)"
-					delete_if_empty="true"
 					values="10,20,30,40,50,60,70,80,90,100,none"
 					display_values="10,20,30,40,50,60,70,80,90,100,keine" />
 				<label text="Unterschiedliche Geschwindigkeiten je Richtung können manuell mit maxspeed:forward=* bzw. maxspeed:backward=* getaggt werden." />
@@ -468,62 +464,62 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="yes,no,contact_line,rail"
 					display_values="Ja,Nein,Oberleitung,Stromschiene"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="voltage"
 					text="Voltage"
 					de.text="Spannung"
 					values="15000,500,550,600,750,850,1000,1200,1500,2400,3000,6500,6600,11000,25000"
 					display_values="15 kV (Standard in Deutschland),500 V,550 V,600 V,750 V,850 V,1000 V,1200 V,1500 V,2400 V,3000 V,6500 V,6600 V,11 kV,25 kV"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="frequency"
 					text="Frequency"
 					de.text="Frequenz"
 					values="16.7,16.67,50,60,25,0"
 					display_values="16.7 Hz (Standard in Deutschland),16 2/3 Hz (in Teilen Deutschlands),50 Hz,60 Hz,25 Hz,Gleichspannung"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<key key="gauge"
 					value="1435" />
 				<check key="railway:ballastless"
 					text="Ballastless"
 					de.text="Feste Fahrbahn"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="rack"
 					text="Rack"
 					de.text="Zahnstange"
 					values="yes,no,riggenbach,strub,abt,locher,riggenbach-klose,marsh,von_roll"
 					display_values="Ja,Nein,System Riggenbach,System Strub,System Abt,System Locher,System Riggenbach-Klose,System Marsh,System Von Roll"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="incline"
 					text="Incline (e.g.. '3%')"
 					de.text="Steigung (z. B. '3%')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<text key="start_date"
 					text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="operator"
 					text="Operator (e.g. 'ÖBB-Infrastruktur AG')"
 					de.text="Betreiber (z. B. 'ÖBB-Infrastruktur AG')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<check key="embankment"
 					text="Embankment"
 					de.text="Damm"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="cutting"
 					text="Cutting"
 					de.text="Einschnitt"
 					default="off"
-					delete_if_empty="true" />
+					/>
 			</item>
 			<item name="Überleitgleis" icon="siding.png" type="way">
 				<label text="Überleitgleis, das den Wechsel zwischen zwei Gleisen einer Strecke ermöglicht." />
@@ -539,47 +535,46 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="mixed,passenger,freight"
 					display_values="Gemischt,Personenverkehr,Güterverkehr"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<check key="highspeed"
 					text="High-speed line (~ >200 km/h)"
 					de.text="Hochgeschwindigkeitsstrecke (~ >200 km/h)"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<space />
 				<check key="lit"
 					text="Lit"
 					de.text="Beleuchtung"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="railway:pzb"
 					text="PZB"
 					de.text="Punktförmige Zugbeeinflussung (PZB)"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="railway:lzb"
 					text="LZB"
 					de.text="Linienzugbeeinflussung (LZB)"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:etcs"
 					text="ETCS"
 					de.text="ETCS"
 					values="yes,no,0,1,2,3"
 					display_values="Ja,Nein,Level 0,Level 1,Level 2,Level 3"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:radio"
 					text="Radio"
 					de.text="Zugfunk"
 					values="analogue,gsm-r"
 					display_values="Analog,GSM-R"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<combo key="maxspeed" default=""
 					text="Maxspeed (km/h)"
 					de.text="Höchstgeschwindigkeit (km/h)"
-					delete_if_empty="true"
 					values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,none"
 					display_values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,keine" />
 				<label text="Unterschiedliche Geschwindigkeiten je Richtung können manuell mit maxspeed:forward=* bzw. maxspeed:backward=* getaggt werden." />
@@ -590,62 +585,62 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="yes,no,contact_line,rail"
 					display_values="Ja,Nein,Oberleitung,Stromschiene"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="voltage"
 					text="Voltage"
 					de.text="Spannung"
 					values="15000,500,550,600,750,850,1000,1200,1500,2400,3000,6500,6600,11000,25000"
 					display_values="15 kV (Standard in Österreich),500 V,550 V,600 V,750 V,850 V,1000 V,1200 V,1500 V,2400 V,3000 V,6500 V,6600 V,11 kV,25 kV"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="frequency"
 					text="Frequency"
 					de.text="Frequenz"
 					values="16.7,0,16.67,50,60,25"
 					display_values="16.7 Hz (Standard in Österreich),Gleichspannung,16 2/3 Hz,50 Hz,60 Hz,25 Hz"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<key key="gauge"
 					value="1435" />
 				<check key="railway:ballastless"
 					text="Ballastless"
 					de.text="Feste Fahrbahn"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="rack"
 					text="Rack"
 					de.text="Zahnstange"
 					values="yes,no,riggenbach,strub,abt,locher,riggenbach-klose,marsh,von_roll"
 					display_values="Ja,Nein,System Riggenbach,System Strub,System Abt,System Locher,System Riggenbach-Klose,System Marsh,System Von Roll"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="incline"
 					text="Incline (e.g.. '3%')"
 					de.text="Steigung (z. B. '3%')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<text key="start_date"
 					text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="operator"
 					text="Operator (e.g. 'ÖBB-Infrastruktur AG')"
 					de.text="Betreiber (z. B. 'ÖBB-Infrastruktur AG')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<check key="embankment"
 					text="Embankment"
 					de.text="Damm"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="cutting"
 					text="Cutting"
 					de.text="Einschnitt"
 					default="off"
-					delete_if_empty="true" />
+					/>
 			</item>
 			<separator />
 			<item name="Schmalspurgleis" icon="narrowgauge.png" type="way">
@@ -657,19 +652,19 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Line ref (VzG number, e.g. '2379')"
 					de.text="Streckennummer (VzG-Nummer, z. B. '2379')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="railway:track_ref"
 					text="Track ref (inside station)"
 					de.text="Gleisnummer (im Bahnhof)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="name"
 					text="Railway name"
 					de.text="Streckenname"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
-				<combo key="usage" text="Usage (leave empty if main track or line)" de.text="Nutzung (leer lassen bei Strecken- und Hauptgleisen)" default="" delete_if_empty="true">
+				<combo key="usage" text="Usage (leave empty if main track or line)" de.text="Nutzung (leer lassen bei Strecken- und Hauptgleisen)" default="">
 					<list_entry value="branch" display_value="Reguläre Strecke" short_description="Eine Schmalspurbahn, auf der regulärer Personen- und/oder Güterverkehr stattfindet." />
 					<list_entry value="industrial" display_value="Industriebahn" short_description="Eine Strecke, die ausschließlich dem Güterverkehr dient und in der Regel Eigentum eines Industrieunternehmens ist. Meist nur innerhalb von Hafengebieten, Industrieanlagen, Tagebauen." />
 					<list_entry value="military" display_value="Militärbahn" short_description="Eine Strecke, die ausschließlich dem Militärverkehr dient. Meistens Strecken zwischen normalen Bahnstrecken und Munitionsdepots oder Truppenübungsplätzen." />
@@ -682,8 +677,8 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="mixed,passenger,freight"
 					display_values="Gemischt,Personenverkehr,Güterverkehr"
 					default=""
-					delete_if_empty="true" />
-				<combo key="service" text="Track service" de.text="Gleisfunktion" default="" delete_if_empty="true">
+					/>
+				<combo key="service" text="Track service" de.text="Gleisfunktion" default="">
 				  <list_entry value="siding" display_value="Nebengleis" short_description="Gleise in Bahnhöfen, die parallel zum durchgehenden Hauptgleis verlaufen und zum Überholen und Halten von Zügen dienen" /><!-- FIXME: Abgrenzung zwischen (nicht durchgehenden) Hauptgleisen und (planmäßig nicht von Zügen befahrenen) Nebengleisen herausstellen -->
 					<list_entry value="yard" display_value="Abstellgleis" short_description="Gleise in Rangier-, Güter- oder Betriebsbahnhöfen, die zum Rangieren, Zusammenstellen von Zügen und Abstellen von Wagen dienen" />
 					<list_entry value="crossover" display_value="Überleitgleis" short_description="Kurze Gleise, die das Wechseln zwischen zwei Gleisen ermöglichen" />
@@ -695,37 +690,37 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Lit"
 					de.text="Beleuchtung"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="railway:pzb"
 					text="PZB"
 					de.text="Punktförmige Zugbeeinflussung (PZB)"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="railway:lzb"
 					text="LZB"
 					de.text="Linienzugbeeinflussung (LZB)"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:etcs"
 					text="ETCS"
 					de.text="ETCS"
 					values="yes,no,0,1,2,3"
 					display_values="Ja,Nein,Level 0,Level 1,Level 2,Level 3"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:radio"
 					text="Radio"
 					de.text="Zugfunk"
 					values="analogue,gsm-r"
 					display_values="Analog,GSM-R"
 					default=""
-					delete_if_empty="true" />
-				<combo key="railway:preferred_direction" text="Direction of use (depends on direction of OSM way)" de.text="Regelfahrtrichtung (abhängig von Richtung des OSM-Ways)" default="" delete_if_empty="true">
+					/>
+				<combo key="railway:preferred_direction" text="Direction of use (depends on direction of OSM way)" de.text="Regelfahrtrichtung (abhängig von Richtung des OSM-Ways)" default="">
 					<list_entry value="forward" display_value="In Wegrichtung" short_description="Das Gleis wird üblicherweise in die Richtung befahren, in die der OSM-Way führt. Nur für mehrgleisige Strecken." />
 					<list_entry value="backward" display_value="Entgegen Wegrichtung" short_description="Das Gleis wird üblicherweise entgegen der Richtung befahren, in die der OSM-Way führt. Nur für mehrgleisige Strecken." />
 					<list_entry value="both" display_value="Beide Richtungen" short_description="Es gibt keine Richtung, in die die Züge üblicherweise fahren bzw. nicht fahren. Nur für eingleisige Strecken." />
 				</combo>
-				<combo key="railway:bidirectional" text="Bidirectional traffic (depends on direction of OSM way)" de.text="Gleiswechselbetrieb (abhängig von Richtung des OSM-Ways)" default="" delete_if_empty="true">
+				<combo key="railway:bidirectional" text="Bidirectional traffic (depends on direction of OSM way)" de.text="Gleiswechselbetrieb (abhängig von Richtung des OSM-Ways)" default="">
 					<list_entry value="regular" display_value="Gleiswechselbetrieb" short_description="Das Gleis ist für beide Fahrtrichtungen mit Signalen ausgestattet und kann daher regulär entgegen der üblichen Fahrtrichtung befahren werden." />
 					<list_entry value="signals" display_value="Signalisierter Falschfahrbetrieb" short_description="Das Gleis ist signaltechnisch nur für eine Fahrtrichtung ausgelegt, sodass weiterhin Falschfahrten notwendig sind, diese sind aber durch Signale geregelt." />
 					<list_entry value="possible" display_value="Falschfahrt möglich" short_description="Signaltechnisch besteht keine Möglichkeit einer Befahrung des Gegengleises. Es ist ein schriftlicher Befehl notwendig." />
@@ -733,7 +728,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<combo key="maxspeed" default=""
 					text="Maxspeed (km/h)"
 					de.text="Höchstgeschwindigkeit (km/h)"
-					delete_if_empty="true"
 					values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,none"
 					display_values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,keine" />
 				<label text="Unterschiedliche Geschwindigkeiten je Richtung können manuell mit maxspeed:forward=* bzw. maxspeed:backward=* getaggt werden." />
@@ -744,67 +738,67 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="yes,no,contact_line,rail"
 					display_values="Ja,Nein,Oberleitung,Stromschiene"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="voltage"
 					text="Voltage"
 					de.text="Spannung"
 					values="15000,500,550,600,750,850,1000,1200,1500,2400,3000,6500,6600,11000,25000"
 					display_values="15 kV (Standard in Österreich),500 V,550 V,600 V,750 V,850 V,1000 V,1200 V,1500 V,2400 V,3000 V,6500 V,6600 V,11 kV,25 kV"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="frequency"
 					text="Frequency"
 					de.text="Frequenz"
 					values="16.7,0,16.67,50,60,25"
 					display_values="16.7 Hz (Standard in Österreich),Gleichspannung,16 2/3 Hz,50 Hz,60 Hz,25 Hz"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="gauge"
 					text="Gauge"
 					de.text="Spurweite"
 					values="1040,1000,900,880,800,760,750,580,500"
 					display_values="1040 mm,1000 mm (Meterspur),900 mm,880 mm,800 mm,760mm (Bosnische Spur),750 mm,580 mm,500 mm"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<check key="railway:ballastless"
 					text="Ballastless"
 					de.text="Feste Fahrbahn"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="rack"
 					text="Rack"
 					de.text="Zahnstange"
 					values="yes,no,riggenbach,strub,abt,locher,riggenbach-klose,marsh,von_roll"
 					display_values="Ja,Nein,System Riggenbach,System Strub,System Abt,System Locher,System Riggenbach-Klose,System Marsh,System Von Roll"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="incline"
 					text="Incline (e.g.. '3%')"
 					de.text="Steigung (z. B. '3%')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<text key="start_date"
 					text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="operator"
 					text="Operator (e.g. 'ÖBB-Infrastruktur AG')"
 					de.text="Betreiber (z. B. 'ÖBB-Infrastruktur AG')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<check key="embankment"
 					text="Embankment"
 					de.text="Damm"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="cutting"
 					text="Cutting"
 					de.text="Einschnitt"
 					default="off"
-					delete_if_empty="true" />
+					/>
 			</item>
 			<item name="Erhaltene Bahnstrecke" icon="preserved.png" type="way">
 				<label text="Ein Gleis, auf dem kein regulärer Betrieb mehr stattfindet und nun für touristische Zwecke erhalten bleibt (z. B. Draisinenstrecken)." />
@@ -815,17 +809,17 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Line ref (VzG number, e.g. '2379')"
 					de.text="Streckennummer (VzG-Nummer, z. B. '2379')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="railway:track_ref"
 					text="Track ref (inside station)"
 					de.text="Gleisnummer (im Bahnhof)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="name"
 					text="Railway name"
 					de.text="Streckenname"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<combo key="railway:traffic_mode"
 					text="Traffic mode"
@@ -833,8 +827,8 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="mixed,passenger,freight"
 					display_values="Gemischt,Personenverkehr,Güterverkehr"
 					default=""
-					delete_if_empty="true" />
-				<combo key="service" text="Track service" de.text="Gleisfunktion" default="" delete_if_empty="true">
+					/>
+				<combo key="service" text="Track service" de.text="Gleisfunktion" default="">
 					<list_entry value="siding" display_value="Nebengleis" short_description="Gleise in Bahnhöfen, die parallel zum durchgehenden Hauptgleis verlaufen und zum Überholen und Halten von Zügen dienen" />
 					<list_entry value="yard" display_value="Abstellgleis" short_description="Gleise in Rangier-, Güter- oder Betriebsbahnhöfen, die zum Rangieren, Zusammenstellen von Zügen und Abstellen von Wagen dienen" />
 					<list_entry value="crossover" display_value="Überleitgleis" short_description="Kurze Gleise, die das Wechseln zwischen zwei Gleisen ermöglichen" />
@@ -846,25 +840,25 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Lit"
 					de.text="Beleuchtung"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="railway:pzb"
 					text="PZB"
 					de.text="Punktförmige Zugbeeinflussung (PZB)"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:radio"
 					text="Radio"
 					de.text="Zugfunk"
 					values="analogue,gsm-r"
 					display_values="Analog,GSM-R"
 					default=""
-					delete_if_empty="true" />
-				<combo key="railway:preferred_direction" text="Direction of use (depends on direction of OSM way)" de.text="Regelfahrtrichtung (abhängig von Richtung des OSM-Ways)" default="" delete_if_empty="true">
+					/>
+				<combo key="railway:preferred_direction" text="Direction of use (depends on direction of OSM way)" de.text="Regelfahrtrichtung (abhängig von Richtung des OSM-Ways)" default="">
 					<list_entry value="forward" display_value="In Wegrichtung" short_description="Das Gleis wird üblicherweise in die Richtung befahren, in die der OSM-Way führt. Nur für mehrgleisige Strecken." />
 					<list_entry value="backward" display_value="Entgegen Wegrichtung" short_description="Das Gleis wird üblicherweise entgegen der Richtung befahren, in die der OSM-Way führt. Nur für mehrgleisige Strecken." />
 					<list_entry value="both" display_value="Beide Richtungen" short_description="Es gibt keine Richtung, in die die Züge üblicherweise fahren bzw. nicht fahren. Nur für eingleisige Strecken." />
 				</combo>
-				<combo key="railway:bidirectional" text="Bidirectional traffic (depends on direction of OSM way)" de.text="Gleiswechselbetrieb (abhängig von Richtung des OSM-Ways)" default="" delete_if_empty="true">
+				<combo key="railway:bidirectional" text="Bidirectional traffic (depends on direction of OSM way)" de.text="Gleiswechselbetrieb (abhängig von Richtung des OSM-Ways)" default="">
 					<list_entry value="regular" display_value="Gleiswechselbetrieb" short_description="Das Gleis ist für beide Fahrtrichtungen mit Signalen ausgestattet und kann daher regulär entgegen der üblichen Fahrtrichtung befahren werden." />
 					<list_entry value="signals" display_value="Signalisierter Falschfahrbetrieb" short_description="Das Gleis ist signaltechnisch nur für eine Fahrtrichtung ausgelegt, sodass weiterhin Falschfahrten notwendig sind, diese sind aber durch Signale geregelt." />
 					<list_entry value="possible" display_value="Falschfahrt möglich" short_description="Signaltechnisch besteht keine Möglichkeit einer Befahrung des Gegengleises. Es ist ein schriftlicher Befehl notwendig." />
@@ -872,7 +866,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<combo key="maxspeed" default=""
 					text="Maxspeed (km/h)"
 					de.text="Höchstgeschwindigkeit (km/h)"
-					delete_if_empty="true"
 					values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,none"
 					display_values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,keine" />
 				<label text="Unterschiedliche Geschwindigkeiten je Richtung können manuell mit maxspeed:forward=* bzw. maxspeed:backward=* getaggt werden." />
@@ -883,67 +876,67 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="yes,no,contact_line,rail"
 					display_values="Ja,Nein,Oberleitung,Stromschiene"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="voltage"
 					text="Voltage"
 					de.text="Spannung"
 					values="15000,500,550,600,750,850,1000,1200,1500,2400,3000,6500,6600,11000,25000"
 					display_values="15 kV (Standard in Österreich),500 V,550 V,600 V,750 V,850 V,1000 V,1200 V,1500 V,2400 V,3000 V,6500 V,6600 V,11 kV,25 kV"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="frequency"
 					text="Frequency"
 					de.text="Frequenz"
 					values="16.7,0,16.67,50,60,25"
 					display_values="16.7 Hz (Standard in Österreich),Gleichspannung,16 2/3 Hz,50 Hz,60 Hz,25 Hz"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="gauge"
 					text="Gauge"
 					de.text="Spurweite"
 					values="1435,1040,1000,900,880,800,760,750,580,500,381,184,127"
 					display_values="1435 mm (Normalspur),1040 mm,1000 mm (Meterspur),900 mm,880 mm,800 mm,760mm (Bosnische Spur),750 mm,580 mm,500 mm,381 mm,184 mm,127 mm"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<check key="railway:ballastless"
 					text="Ballastless"
 					de.text="Feste Fahrbahn"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="rack"
 					text="Rack"
 					de.text="Zahnstange"
 					values="yes,no,riggenbach,strub,abt,locher,riggenbach-klose,marsh,von_roll"
 					display_values="Ja,Nein,System Riggenbach,System Strub,System Abt,System Locher,System Riggenbach-Klose,System Marsh,System Von Roll"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="incline"
 					text="Incline (e.g.. '3%')"
 					de.text="Steigung (z. B. '3%')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<text key="start_date"
 					text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="operator"
 					text="Operator (e.g. 'ÖBB-Infrastruktur AG')"
 					de.text="Betreiber (z. B. 'ÖBB-Infrastruktur AG')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<check key="embankment"
 					text="Embankment"
 					de.text="Damm"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="cutting"
 					text="Cutting"
 					de.text="Einschnitt"
 					default="off"
-					delete_if_empty="true" />
+					/>
 			</item>
 			<item name="Miniaturbahn / Parkeisenbahn" icon="miniature.png" type="way">
 				<label text="Parkeisenbahnen und vergleichbare, in der Regel touristisch genutzte, Schmalspurbahnen bis etwa 600 mm Spurweite." />
@@ -954,14 +947,14 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Track ref (inside station)"
 					de.text="Gleisnummer (im Bahnhof)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="name"
 					text="Railway name"
 					de.text="Streckenname"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
-				<combo key="usage" text="Usage (leave empty if main track or line)" de.text="Nutzung (leer lassen bei Strecken- und Hauptgleisen)" default="" delete_if_empty="true">
+				<combo key="usage" text="Usage (leave empty if main track or line)" de.text="Nutzung (leer lassen bei Strecken- und Hauptgleisen)" default="">
 					<list_entry value="branch" display_value="Reguläre Strecke" short_description="Eine Schmalspurbahn, auf der regulärer Personen- und/oder Güterverkehr stattfindet." />
 					<list_entry value="industrial" display_value="Industriebahn" short_description="Eine Strecke, die ausschließlich dem Güterverkehr dient und in der Regel Eigentum eines Industrieunternehmens ist. Meist nur innerhalb von Hafengebieten, Industrieanlagen, Tagebauen." />
 					<list_entry value="tourism" display_value="Tourismusbahn" short_description="Eine Strecke, die ausschließlich touristischen Zwecken dient, z. B. Museumsstrecken oder Draisinenbahnen." />
@@ -972,8 +965,8 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="mixed,passenger,freight"
 					display_values="Gemischt,Personenverkehr,Güterverkehr"
 					default=""
-					delete_if_empty="true" />
-				<combo key="service" text="Track service" de.text="Gleisfunktion" default="" delete_if_empty="true">
+					/>
+				<combo key="service" text="Track service" de.text="Gleisfunktion" default="">
 					<list_entry value="siding" display_value="Nebengleis" short_description="Gleise in Bahnhöfen, die parallel zum durchgehenden Hauptgleis verlaufen und zum Überholen und Halten von Zügen dienen" />
 					<list_entry value="yard" display_value="Abstellgleis" short_description="Gleise in Rangier-, Güter- oder Betriebsbahnhöfen, die zum Rangieren, Zusammenstellen von Zügen und Abstellen von Wagen dienen" />
 					<list_entry value="crossover" display_value="Überleitgleis" short_description="Kurze Gleise, die das Wechseln zwischen zwei Gleisen ermöglichen" />
@@ -985,18 +978,17 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Lit"
 					de.text="Beleuchtung"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:radio"
 					text="Radio"
 					de.text="Zugfunk"
 					values="analogue,gsm-r"
 					display_values="Analog,GSM-R"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="maxspeed" default=""
 					text="Maxspeed (km/h)"
 					de.text="Höchstgeschwindigkeit (km/h)"
-					delete_if_empty="true"
 					values="10,20,30,40,50,60,70,80,90,100,none"
 					display_values="10,20,30,40,50,60,70,80,90,100,keine" />
 				<label text="Unterschiedliche Geschwindigkeiten je Richtung können manuell mit maxspeed:forward=* bzw. maxspeed:backward=* getaggt werden." />
@@ -1007,67 +999,67 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="yes,no,contact_line,rail"
 					display_values="Ja,Nein,Oberleitung,Stromschiene"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="voltage"
 					text="Voltage"
 					de.text="Spannung"
 					values="500,550,600,750,850,1000,1200,1500,2400,3000,6500,6600"
 					display_values="500 V,550 V,600 V,750 V,850 V,1000 V,1200 V,1500 V,2400 V,3000 V,6500 V,6600 V"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="frequency"
 					text="Frequency"
 					de.text="Frequenz"
 					values="16.7,0,16.67,50,60,25"
 					display_values="16.7 Hz (Standard in Österreich),Gleichspannung,16 2/3 Hz,50 Hz,60 Hz,25 Hz"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="gauge"
 					text="Gauge"
 					de.text="Spurweite"
 					values="381,184,127"
 					display_values="381 mm,184 mm,127 mm"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<check key="railway:ballastless"
 					text="Ballastless"
 					de.text="Feste Fahrbahn"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="rack"
 					text="Rack"
 					de.text="Zahnstange"
 					values="yes,no,riggenbach,strub,abt,locher,riggenbach-klose,marsh,von_roll"
 					display_values="Ja,Nein,System Riggenbach,System Strub,System Abt,System Locher,System Riggenbach-Klose,System Marsh,System Von Roll"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="incline"
 					text="Incline (e.g.. '3%')"
 					de.text="Steigung (z. B. '3%')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<text key="start_date"
 					text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="operator"
 					text="Operator (e.g. 'ÖBB-Infrastruktur AG')"
 					de.text="Betreiber (z. B. 'ÖBB-Infrastruktur AG')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<check key="embankment"
 					text="Embankment"
 					de.text="Damm"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="cutting"
 					text="Cutting"
 					de.text="Einschnitt"
 					default="off"
-					delete_if_empty="true" />
+					/>
 			</item>
 			<separator />
 			<item name="Straßenbahngleis" icon="tram.png" type="way">
@@ -1079,17 +1071,17 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Line ref"
 					de.text="Streckennummer"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="railway:track_ref"
 					text="Track ref (inside station)"
 					de.text="Gleisnummer (im Bahnhof)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="name"
 					text="Railway name"
 					de.text="Streckenname"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<combo key="railway:traffic_mode"
 					text="Traffic mode"
@@ -1097,8 +1089,8 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="mixed,freight, "
 					display_values="Gemischt,Güterverkehr,Personenverkehr"
 					default="passenger"
-					delete_if_empty="true" />
-				<combo key="service" text="Track service" de.text="Gleisfunktion" default="" delete_if_empty="true">
+					/>
+				<combo key="service" text="Track service" de.text="Gleisfunktion" default="">
 					<list_entry value="siding" display_value="Nebengleis" short_description="Gleise in Bahnhöfen, die parallel zum durchgehenden Hauptgleis verlaufen und zum Überholen und Halten von Zügen dienen" />
 					<list_entry value="yard" display_value="Abstellgleis" short_description="Gleise in Rangier-, Güter- oder Betriebsbahnhöfen, die zum Rangieren, Zusammenstellen von Zügen und Abstellen von Wagen dienen" />
 					<list_entry value="crossover" display_value="Überleitgleis" short_description="Kurze Gleise, die das Wechseln zwischen zwei Gleisen ermöglichen" />
@@ -1109,30 +1101,30 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Lit"
 					de.text="Beleuchtung"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="railway:pzb"
 					text="PZB"
 					de.text="Punktförmige Zugbeeinflussung (PZB)"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="railway:lzb"
 					text="LZB"
 					de.text="Linienzugbeeinflussung (LZB)"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:etcs"
 					text="ETCS"
 					de.text="ETCS"
 					values="yes,no,0,1,2,3"
 					display_values="Ja,Nein,Level 0,Level 1,Level 2,Level 3"
 					default=""
-					delete_if_empty="true" />
-				<combo key="railway:preferred_direction" text="Direction of use (depends on direction of OSM way)" de.text="Regelfahrtrichtung (abhängig von Richtung des OSM-Ways)" default="" delete_if_empty="true">
+					/>
+				<combo key="railway:preferred_direction" text="Direction of use (depends on direction of OSM way)" de.text="Regelfahrtrichtung (abhängig von Richtung des OSM-Ways)" default="">
 					<list_entry value="forward" display_value="In Wegrichtung" short_description="Das Gleis wird üblicherweise in die Richtung befahren, in die der OSM-Way führt. Nur für mehrgleisige Strecken." />
 					<list_entry value="backward" display_value="Entgegen Wegrichtung" short_description="Das Gleis wird üblicherweise entgegen der Richtung befahren, in die der OSM-Way führt. Nur für mehrgleisige Strecken." />
 					<list_entry value="both" display_value="Beide Richtungen" short_description="Es gibt keine Richtung, in die die Züge üblicherweise fahren bzw. nicht fahren. Nur für eingleisige Strecken." />
 				</combo>
-				<combo key="railway:bidirectional" text="Bidirectional traffic (depends on direction of OSM way)" de.text="Gleiswechselbetrieb (abhängig von Richtung des OSM-Ways)" default="" delete_if_empty="true">
+				<combo key="railway:bidirectional" text="Bidirectional traffic (depends on direction of OSM way)" de.text="Gleiswechselbetrieb (abhängig von Richtung des OSM-Ways)" default="">
 					<list_entry value="regular" display_value="Gleiswechselbetrieb" short_description="Das Gleis ist für beide Fahrtrichtungen mit Signalen ausgestattet und kann daher regulär entgegen der üblichen Fahrtrichtung befahren werden." />
 					<list_entry value="signals" display_value="Signalisierter Falschfahrbetrieb" short_description="Das Gleis ist signaltechnisch nur für eine Fahrtrichtung ausgelegt, sodass weiterhin Falschfahrten notwendig sind, diese sind aber durch Signale geregelt." />
 					<list_entry value="possible" display_value="Falschfahrt möglich" short_description="Signaltechnisch besteht keine Möglichkeit einer Befahrung des Gegengleises. Es ist ein schriftlicher Befehl notwendig." />
@@ -1140,7 +1132,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<combo key="maxspeed" default=""
 					text="Maxspeed (km/h)"
 					de.text="Höchstgeschwindigkeit (km/h)"
-					delete_if_empty="true"
 					values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,none"
 					display_values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,keine" />
 				<label text="Unterschiedliche Geschwindigkeiten je Richtung können manuell mit maxspeed:forward=* bzw. maxspeed:backward=* getaggt werden." />
@@ -1151,60 +1142,60 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="yes,no,contact_line,rail"
 					display_values="Ja,Nein,Oberleitung,Stromschiene"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="voltage"
 					text="Voltage"
 					de.text="Spannung"
 					values="500,550,600,750,850,1000,1200,1500,2400,3000,6500,6600"
 					display_values="500 V,550 V,600 V,750 V,850 V,1000 V,1200 V,1500 V,2400 V,3000 V,6500 V,6600 V"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="frequency"
 					text="Frequency"
 					de.text="Frequenz"
 					values="0,16.7,16.67,50,60,25"
 					display_values="Gleichspannung,16.7 Hz,16 2/3 Hz,50 Hz,60 Hz,25 Hz"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="gauge"
 					text="Gauge"
 					de.text="Spurweite"
 					values="1435,1040,1000,900,760,750"
 					display_values="1435 mm (Normalspur),1040 mm,1000 mm (Meterspur),900 mm,760mm (Bosnische Spur),750 mm"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<check key="railway:ballastless"
 					text="Ballastless (slab track)"
 					de.text="Feste Fahrbahn"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<text key="incline"
 					text="Incline (e.g.. '3%')"
 					de.text="Steigung (z. B. '3%')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<text key="start_date"
 					text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="operator"
 					text="Operator (e.g. 'Wiener Linien GmbH &amp; Co KG')"
 					de.text="Betreiber (z. B. 'Wiener Linien GmbH &amp; Co KG')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<check key="embankment"
 					text="Embankment"
 					de.text="Damm"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="cutting"
 					text="Cutting"
 					de.text="Einschnitt"
 					default="off"
-					delete_if_empty="true" />
+					/>
 			</item>
 			<item name="U-Bahngleis" icon="subway.png" type="way">
 				<label text="Unterirdisch verlegte Stadt- und Schnellbahnen, teilweise auch oberirdischer Verlauf möglich. Jedes Gleis wird einzeln erfasst. Zusätzlich noch im Menü 'Tunnel' auswählen!" />
@@ -1215,19 +1206,19 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Line ref"
 					de.text="Streckennummer"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="railway:track_ref"
 					text="Track ref (inside station)"
 					de.text="Gleisnummer (im Bahnhof)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="name"
 					text="Railway name"
 					de.text="Streckenname"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
-				<combo key="service" text="Track service" de.text="Gleisfunktion" default="" delete_if_empty="true">
+				<combo key="service" text="Track service" de.text="Gleisfunktion" default="">
 					<list_entry value="siding" display_value="Nebengleis" short_description="Gleise in Bahnhöfen, die parallel zum durchgehenden Hauptgleis verlaufen und zum Überholen und Halten von Zügen dienen" />
 					<list_entry value="yard" display_value="Abstellgleis" short_description="Gleise in Rangier-, Güter- oder Betriebsbahnhöfen, die zum Rangieren, Zusammenstellen von Zügen und Abstellen von Wagen dienen" />
 					<list_entry value="crossover" display_value="Überleitgleis" short_description="Kurze Gleise, die das Wechseln zwischen zwei Gleisen ermöglichen" />
@@ -1237,30 +1228,30 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Lit"
 					de.text="Beleuchtung"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="railway:pzb"
 					text="PZB"
 					de.text="Punktförmige Zugbeeinflussung (PZB)"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="railway:lzb"
 					text="LZB"
 					de.text="Linienzugbeeinflussung (LZB)"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:etcs"
 					text="ETCS"
 					de.text="ETCS"
 					values="yes,no,0,1,2,3"
 					display_values="Ja,Nein,Level 0,Level 1,Level 2,Level 3"
 					default=""
-					delete_if_empty="true" />
-				<combo key="railway:preferred_direction" text="Direction of use (depends on direction of OSM way)" de.text="Regelfahrtrichtung (abhängig von Richtung des OSM-Ways)" default="" delete_if_empty="true">
+					/>
+				<combo key="railway:preferred_direction" text="Direction of use (depends on direction of OSM way)" de.text="Regelfahrtrichtung (abhängig von Richtung des OSM-Ways)" default="">
 					<list_entry value="forward" display_value="In Wegrichtung" short_description="Das Gleis wird üblicherweise in die Richtung befahren, in die der OSM-Way führt. Nur für mehrgleisige Strecken." />
 					<list_entry value="backward" display_value="Entgegen Wegrichtung" short_description="Das Gleis wird üblicherweise entgegen der Richtung befahren, in die der OSM-Way führt. Nur für mehrgleisige Strecken." />
 					<list_entry value="both" display_value="Beide Richtungen" short_description="Es gibt keine Richtung, in die die Züge üblicherweise fahren bzw. nicht fahren. Nur für eingleisige Strecken." />
 				</combo>
-				<combo key="railway:bidirectional" text="Bidirectional traffic (depends on direction of OSM way)" de.text="Gleiswechselbetrieb (abhängig von Richtung des OSM-Ways)" default="" delete_if_empty="true">
+				<combo key="railway:bidirectional" text="Bidirectional traffic (depends on direction of OSM way)" de.text="Gleiswechselbetrieb (abhängig von Richtung des OSM-Ways)" default="">
 					<list_entry value="regular" display_value="Gleiswechselbetrieb" short_description="Das Gleis ist für beide Fahrtrichtungen mit Signalen ausgestattet und kann daher regulär entgegen der üblichen Fahrtrichtung befahren werden." />
 					<list_entry value="signals" display_value="Signalisierter Falschfahrbetrieb" short_description="Das Gleis ist signaltechnisch nur für eine Fahrtrichtung ausgelegt, sodass weiterhin Falschfahrten notwendig sind, diese sind aber durch Signale geregelt." />
 					<list_entry value="possible" display_value="Falschfahrt möglich" short_description="Signaltechnisch besteht keine Möglichkeit einer Befahrung des Gegengleises. Es ist ein schriftlicher Befehl notwendig." />
@@ -1268,7 +1259,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<combo key="maxspeed" default=""
 					text="Maxspeed (km/h)"
 					de.text="Höchstgeschwindigkeit (km/h)"
-					delete_if_empty="true"
 					values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,none"
 					display_values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,keine" />
 				<label text="Unterschiedliche Geschwindigkeiten je Richtung können manuell mit maxspeed:forward=* bzw. maxspeed:backward=* getaggt werden." />
@@ -1279,49 +1269,49 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="yes,no,contact_line,rail"
 					display_values="Ja,Nein,Oberleitung,Stromschiene"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="voltage"
 					text="Voltage"
 					de.text="Spannung"
 					values="500,550,600,750,850,1000,1200,1500,2400,3000,6500,6600,11000"
 					display_values="500 V,550 V,600 V,750 V,850 V,1000 V,1200 V,1500 V,2400 V,3000 V,6500 V,6600 V,11 kV"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="frequency"
 					text="Frequency"
 					de.text="Frequenz"
 					values="0,16.7,16.67,50,60,25"
 					display_values="Gleichspannung,16.7 Hz,16 2/3 Hz,50 Hz,60 Hz,25 Hz"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="gauge"
 					text="Gauge"
 					de.text="Spurweite"
 					values="1435,1040,1000,900,760,750"
 					display_values="1435 mm (Normalspur),1040 mm,1000 mm (Meterspur),900 mm,760mm (Bosnische Spur),750 mm"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<check key="railway:ballastless"
 					text="Ballastless"
 					de.text="Feste Fahrbahn"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<text key="incline"
 					text="Incline (e.g.. '3%')"
 					de.text="Steigung (z. B. '3%')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<text key="start_date"
 					text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="operator"
 					text="Operator (e.g. 'Wiener Linien GmbH &amp; Co KG')"
 					de.text="Betreiber (z. B. 'Wiener Linien GmbH &amp; Co KG')"
 					default=""
-					delete_if_empty="true" />
+					/>
 			</item>
 			<item name="Stadt-/Schnellbahngleis" icon="light-rail.png" type="way">
 				<label text="Stadtbahnen und straßenbahnähnliche Untergrund- oder Überlandbahnen. Unterscheiden sich meist durch ein anderes Stromsystem, eigene Signaltechnik oder einen speziellen Fuhrpark (z. B. S-Bahnen Hamburg und Berlin, Hamburger Hochbahn) und sind meist völlig vom restlichen Straßenverkehr getrennt. Jedes Gleis wird einzeln erfasst." />
@@ -1332,21 +1322,21 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Line ref"
 					de.text="Streckennummer"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="railway:track_ref"
 					text="Track ref (inside station)"
 					de.text="Gleisnummer (im Bahnhof)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="name"
 					text="Railway name"
 					de.text="Streckenname"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<key key="railway:traffic_mode"
 					value="passenger" />
-				<combo key="service" text="Track service" de.text="Gleisfunktion" default="" delete_if_empty="true">
+				<combo key="service" text="Track service" de.text="Gleisfunktion" default="">
 					<list_entry value="siding" display_value="Nebengleis" short_description="Gleise in Bahnhöfen, die parallel zum durchgehenden Hauptgleis verlaufen und zum Überholen und Halten von Zügen dienen" />
 					<list_entry value="yard" display_value="Abstellgleis" short_description="Gleise in Rangier-, Güter- oder Betriebsbahnhöfen, die zum Rangieren, Zusammenstellen von Zügen und Abstellen von Wagen dienen" />
 					<list_entry value="crossover" display_value="Überleitgleis" short_description="Kurze Gleise, die das Wechseln zwischen zwei Gleisen ermöglichen" />
@@ -1357,30 +1347,30 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Lit"
 					de.text="Beleuchtung"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="railway:pzb"
 					text="PZB"
 					de.text="Punktförmige Zugbeeinflussung (PZB)"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="railway:lzb"
 					text="LZB"
 					de.text="Linienzugbeeinflussung (LZB)"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:etcs"
 					text="ETCS"
 					de.text="ETCS"
 					values="yes,no,0,1,2,3"
 					display_values="Ja,Nein,Level 0,Level 1,Level 2,Level 3"
 					default=""
-					delete_if_empty="true" />
-				<combo key="railway:preferred_direction" text="Direction of use (depends on direction of OSM way)" de.text="Regelfahrtrichtung (abhängig von Richtung des OSM-Ways)" default="" delete_if_empty="true">
+					/>
+				<combo key="railway:preferred_direction" text="Direction of use (depends on direction of OSM way)" de.text="Regelfahrtrichtung (abhängig von Richtung des OSM-Ways)" default="">
 					<list_entry value="forward" display_value="In Wegrichtung" short_description="Das Gleis wird üblicherweise in die Richtung befahren, in die der OSM-Way führt. Nur für mehrgleisige Strecken." />
 					<list_entry value="backward" display_value="Entgegen Wegrichtung" short_description="Das Gleis wird üblicherweise entgegen der Richtung befahren, in die der OSM-Way führt. Nur für mehrgleisige Strecken." />
 					<list_entry value="both" display_value="Beide Richtungen" short_description="Es gibt keine Richtung, in die die Züge üblicherweise fahren bzw. nicht fahren. Nur für eingleisige Strecken." />
 				</combo>
-				<combo key="railway:bidirectional" text="Bidirectional traffic (depends on direction of OSM way)" de.text="Gleiswechselbetrieb (abhängig von Richtung des OSM-Ways)" default="" delete_if_empty="true">
+				<combo key="railway:bidirectional" text="Bidirectional traffic (depends on direction of OSM way)" de.text="Gleiswechselbetrieb (abhängig von Richtung des OSM-Ways)" default="">
 					<list_entry value="regular" display_value="Gleiswechselbetrieb" short_description="Das Gleis ist für beide Fahrtrichtungen mit Signalen ausgestattet und kann daher regulär entgegen der üblichen Fahrtrichtung befahren werden." />
 					<list_entry value="signals" display_value="Signalisierter Falschfahrbetrieb" short_description="Das Gleis ist signaltechnisch nur für eine Fahrtrichtung ausgelegt, sodass weiterhin Falschfahrten notwendig sind, diese sind aber durch Signale geregelt." />
 					<list_entry value="possible" display_value="Falschfahrt möglich" short_description="Signaltechnisch besteht keine Möglichkeit einer Befahrung des Gegengleises. Es ist ein schriftlicher Befehl notwendig." />
@@ -1388,7 +1378,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<combo key="maxspeed" default=""
 					text="Maxspeed (km/h)"
 					de.text="Höchstgeschwindigkeit (km/h)"
-					delete_if_empty="true"
 					values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,none"
 					display_values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,keine" />
 				<label text="Unterschiedliche Geschwindigkeiten je Richtung können manuell mit maxspeed:forward=* bzw. maxspeed:backward=* getaggt werden." />
@@ -1399,60 +1388,60 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="yes,no,contact_line,rail"
 					display_values="Ja,Nein,Oberleitung,Stromschiene"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="voltage"
 					text="Voltage"
 					de.text="Spannung"
 					values="15000,500,550,600,750,850,1000,1200,1500,2400,3000,6500,6600,11000,25000"
 					display_values="15 kV,500 V,550 V,600 V,750 V,850 V,1000 V,1200 V,1500 V,2400 V,3000 V,6500 V,6600 V,11 kV,25 kV"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="frequency"
 					text="Frequency"
 					de.text="Frequenz"
 					values="0,16.7,16.67,50,60,25"
 					display_values="Gleichspannung,16.7 Hz,16 2/3 Hz,50 Hz,60 Hz,25 Hz"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="gauge"
 					text="Gauge"
 					de.text="Spurweite"
 					values="1435,1040,1000,900,760,750"
 					display_values="1435 mm (Normalspur),1040 mm,1000 mm (Meterspur),900 mm,760mm (Bosnische Spur),750 mm"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<check key="railway:ballastless"
 					text="Ballastless"
 					de.text="Feste Fahrbahn"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<text key="incline"
 					text="Incline (e.g.. '3%')"
 					de.text="Steigung (z. B. '3%')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<text key="start_date"
 					text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="operator"
 					text="Operator (e.g. 'Wiener Linien GmbH &amp; Co KG')"
 					de.text="Betreiber (z. B. 'Wiener Linien GmbH &amp; Co KG')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<check key="embankment"
 					text="Embankment"
 					de.text="Damm"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="cutting"
 					text="Cutting"
 					de.text="Einschnitt"
 					default="off"
-					delete_if_empty="true" />
+					/>
 			</item>
 			<separator />
 			<item name="Geplantes Gleis" icon="proposed.png" type="way">
@@ -1464,19 +1453,19 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Line ref (VzG number, e.g. '2379')"
 					de.text="Streckennummer (VzG-Nummer, z. B. '2379')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="railway:track_ref"
 					text="Track ref (inside station)"
 					de.text="Gleisnummer (im Bahnhof)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="name"
 					text="Railway name"
 					de.text="Streckenname"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
-				<combo key="usage" text="Usage" de.text="Nutzung" default="" delete_if_empty="true">
+				<combo key="usage" text="Usage" de.text="Nutzung" default="">
 					<list_entry value="main" display_value="Hauptbahn" short_description="Strecke mit übergeordneter Bedeutung; meist zweigleisig, meist elektrifiziert, zumindest abschnittsweise mit mehr als 100 km/h befahrbar" />
 					<list_entry value="branch" display_value="Nebenbahn" short_description="Strecke mit untergeordneter Bedeutung; oft nicht elektrifiziert, oft eingleisig. Keinesfalls mit mehr als 100 km/h befahrbar." />
 					<list_entry value="industrial" display_value="Industriebahn" short_description="Eine Strecke, die ausschließlich dem Güterverkehr dient und in der Regel Eigentum eines Industrieunternehmens ist. Meist nur innerhalb von Hafengebieten, Industrieanlagen, Tagebauen." />
@@ -1490,48 +1479,48 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="mixed,passenger,freight"
 					display_values="Gemischt,Personenverkehr,Güterverkehr"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<check key="highspeed"
 					text="Highspeed traffic (~ >200 km/h)"
 					de.text="Hochgeschwindigkeitsstrecke (~ >200 km/h)"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="railway:tilting"
 					text="Used by tilting trains"
 					de.text="Neigetechnik-Ausrüstung"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<space />
 				<check key="railway:pzb"
 					text="PZB"
 					de.text="Punktförmige Zugbeeinflussung (PZB)"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="railway:lzb"
 					text="LZB"
 					de.text="Linienzugbeeinflussung (LZB)"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:etcs"
 					text="ETCS"
 					de.text="ETCS"
 					values="yes,no,0,1,2,3"
 					display_values="Ja,Nein,Level 0,Level 1,Level 2,Level 3"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:radio"
 					text="Radio"
 					de.text="Zugfunk"
 					values="analogue,gsm-r"
 					display_values="Analog,GSM-R"
 					default=""
-					delete_if_empty="true" />
-				<combo key="railway:preferred_direction" text="Direction of use (depends on direction of OSM way)" de.text="Regelfahrtrichtung (abhängig von Richtung des OSM-Ways)" default="" delete_if_empty="true">
+					/>
+				<combo key="railway:preferred_direction" text="Direction of use (depends on direction of OSM way)" de.text="Regelfahrtrichtung (abhängig von Richtung des OSM-Ways)" default="">
 					<list_entry value="forward" display_value="In Wegrichtung" short_description="Das Gleis wird üblicherweise in die Richtung befahren, in die der OSM-Way führt. Nur für mehrgleisige Strecken." />
 					<list_entry value="backward" display_value="Entgegen Wegrichtung" short_description="Das Gleis wird üblicherweise entgegen der Richtung befahren, in die der OSM-Way führt. Nur für mehrgleisige Strecken." />
 					<list_entry value="both" display_value="Beide Richtungen" short_description="Es gibt keine Richtung, in die die Züge üblicherweise fahren bzw. nicht fahren. Nur für eingleisige Strecken." />
 				</combo>
-				<combo key="railway:bidirectional" text="Bidirectional traffic (depends on direction of OSM way)" de.text="Gleiswechselbetrieb (abhängig von Richtung des OSM-Ways)" default="" delete_if_empty="true">
+				<combo key="railway:bidirectional" text="Bidirectional traffic (depends on direction of OSM way)" de.text="Gleiswechselbetrieb (abhängig von Richtung des OSM-Ways)" default="">
 					<list_entry value="regular" display_value="Gleiswechselbetrieb" short_description="Das Gleis ist für beide Fahrtrichtungen mit Signalen ausgestattet und kann daher regulär entgegen der üblichen Fahrtrichtung befahren werden." />
 					<list_entry value="signals" display_value="Signalisierter Falschfahrbetrieb" short_description="Das Gleis ist signaltechnisch nur für eine Fahrtrichtung ausgelegt, sodass weiterhin Falschfahrten notwendig sind, diese sind aber durch Signale geregelt." />
 					<list_entry value="possible" display_value="Falschfahrt möglich" short_description="Signaltechnisch besteht keine Möglichkeit einer Befahrung des Gegengleises. Es ist ein schriftlicher Befehl notwendig." />
@@ -1540,7 +1529,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<combo key="maxspeed" default=""
 					text="Maxspeed (km/h)"
 					de.text="Höchstgeschwindigkeit (km/h)"
-					delete_if_empty="true"
 					values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,none"
 					display_values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,keine" />
 				<label text="Unterschiedliche Geschwindigkeiten je Richtung können manuell mit maxspeed:forward=* bzw. maxspeed:backward=* getaggt werden." />
@@ -1551,67 +1539,67 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="yes,no,contact_line,rail"
 					display_values="Ja,Nein,Oberleitung,Stromschiene"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="voltage"
 					text="Voltage"
 					de.text="Spannung"
 					values="15000,500,550,600,750,850,1000,1200,1500,2400,3000,6500,6600,11000,25000"
 					display_values="15 kV (Standard in Österreich),500 V,550 V,600 V,750 V,850 V,1000 V,1200 V,1500 V,2400 V,3000 V,6500 V,6600 V,11 kV,25 kV"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="frequency"
 					text="Frequency"
 					de.text="Frequenz"
 					values="16.7,0,16.67,50,60,25"
 					display_values="16.7 Hz (Standard in Österreich),Gleichspannung,16 2/3 Hz,50 Hz,60 Hz,25 Hz"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="gauge"
 					text="Gauge"
 					de.text="Spurweite"
 					values="1435,1040,1000,900,880,800,760,750,580,500,381,184,127"
 					display_values="1435 mm (Normalspur),1040 mm,1000 mm (Meterspur),900 mm,880 mm,800 mm,760mm (Bosnische Spur),750 mm,580 mm,500 mm,381 mm,184 mm,127 mm"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<check key="railway:ballastless"
 					text="Ballastless"
 					de.text="Feste Fahrbahn"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="rack"
 					text="Rack"
 					de.text="Zahnstange"
 					values="yes,no,riggenbach,strub,abt,locher,riggenbach-klose,marsh,von_roll"
 					display_values="Ja,Nein,System Riggenbach,System Strub,System Abt,System Locher,System Riggenbach-Klose,System Marsh,System Von Roll"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="incline"
 					text="Incline (e.g.. '3%')"
 					de.text="Steigung (z. B. '3%')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<text key="start_date"
 					text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="operator"
 					text="Operator (e.g. 'ÖBB-Infrastruktur AG')"
 					de.text="Betreiber (z. B. 'ÖBB-Infrastruktur AG')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<check key="embankment"
 					text="Embankment"
 					de.text="Damm"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="cutting"
 					text="Cutting"
 					de.text="Einschnitt"
 					default="off"
-					delete_if_empty="true" />
+					/>
 			</item>
 			<item name="Gleis im Bau" icon="construction.png" type="way">
 				<label text="Ein Gleis, dessen Bau momentan noch nicht fertiggestellt ist." />
@@ -1622,19 +1610,19 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Line ref (VzG number, e.g. '2379')"
 					de.text="Streckennummer (VzG-Nummer, z. B. '2379')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="railway:track_ref"
 					text="Track ref (inside station)"
 					de.text="Gleisnummer (im Bahnhof)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="name"
 					text="Railway name"
 					de.text="Streckenname"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
-				<combo key="usage" text="Usage" de.text="Nutzung" default="" delete_if_empty="true">
+				<combo key="usage" text="Usage" de.text="Nutzung" default="">
 					<list_entry value="main" display_value="Hauptbahn" short_description="Strecke mit übergeordneter Bedeutung; meist zweigleisig, meist elektrifiziert, zumindest abschnittsweise mit mehr als 100 km/h befahrbar" />
 					<list_entry value="branch" display_value="Nebenbahn" short_description="Strecke mit untergeordneter Bedeutung; oft nicht elektrifiziert, oft eingleisig. Keinesfalls mit mehr als 100 km/h befahrbar." />
 					<list_entry value="industrial" display_value="Industriebahn" short_description="Eine Strecke, die ausschließlich dem Güterverkehr dient und in der Regel Eigentum eines Industrieunternehmens ist. Meist nur innerhalb von Hafengebieten, Industrieanlagen, Tagebauen." />
@@ -1648,48 +1636,48 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="mixed,passenger,freight"
 					display_values="Gemischt,Personenverkehr,Güterverkehr"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<check key="highspeed"
 					text="Highspeed traffic (~ >200 km/h)"
 					de.text="Hochgeschwindigkeitsstrecke (~ >200 km/h)"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="railway:tilting"
 					text="Used by tilting trains"
 					de.text="Neigetechnik-Ausrüstung"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<space />
 				<check key="railway:pzb"
 					text="PZB"
 					de.text="Punktförmige Zugbeeinflussung (PZB)"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="railway:lzb"
 					text="LZB"
 					de.text="Linienzugbeeinflussung (LZB)"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:etcs"
 					text="ETCS"
 					de.text="ETCS"
 					values="yes,no,0,1,2,3"
 					display_values="Ja,Nein,Level 0,Level 1,Level 2,Level 3"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:radio"
 					text="Radio"
 					de.text="Zugfunk"
 					values="analogue,gsm-r"
 					display_values="Analog,GSM-R"
 					default=""
-					delete_if_empty="true" />
-				<combo key="railway:preferred_direction" text="Direction of use (depends on direction of OSM way)" de.text="Regelfahrtrichtung (abhängig von Richtung des OSM-Ways)" default="" delete_if_empty="true">
+					/>
+				<combo key="railway:preferred_direction" text="Direction of use (depends on direction of OSM way)" de.text="Regelfahrtrichtung (abhängig von Richtung des OSM-Ways)" default="">
 					<list_entry value="forward" display_value="In Wegrichtung" short_description="Das Gleis wird üblicherweise in die Richtung befahren, in die der OSM-Way führt. Nur für mehrgleisige Strecken." />
 					<list_entry value="backward" display_value="Entgegen Wegrichtung" short_description="Das Gleis wird üblicherweise entgegen der Richtung befahren, in die der OSM-Way führt. Nur für mehrgleisige Strecken." />
 					<list_entry value="both" display_value="Beide Richtungen" short_description="Es gibt keine Richtung, in die die Züge üblicherweise fahren bzw. nicht fahren. Nur für eingleisige Strecken." />
 				</combo>
-				<combo key="railway:bidirectional" text="Bidirectional traffic (depends on direction of OSM way)" de.text="Gleiswechselbetrieb (abhängig von Richtung des OSM-Ways)" default="" delete_if_empty="true">
+				<combo key="railway:bidirectional" text="Bidirectional traffic (depends on direction of OSM way)" de.text="Gleiswechselbetrieb (abhängig von Richtung des OSM-Ways)" default="">
 					<list_entry value="regular" display_value="Gleiswechselbetrieb" short_description="Das Gleis ist für beide Fahrtrichtungen mit Signalen ausgestattet und kann daher regulär entgegen der üblichen Fahrtrichtung befahren werden." />
 					<list_entry value="signals" display_value="Signalisierter Falschfahrbetrieb" short_description="Das Gleis ist signaltechnisch nur für eine Fahrtrichtung ausgelegt, sodass weiterhin Falschfahrten notwendig sind, diese sind aber durch Signale geregelt." />
 					<list_entry value="possible" display_value="Falschfahrt möglich" short_description="Signaltechnisch besteht keine Möglichkeit einer Befahrung des Gegengleises. Es ist ein schriftlicher Befehl notwendig." />
@@ -1698,7 +1686,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<combo key="maxspeed" default=""
 					text="Maxspeed (km/h)"
 					de.text="Höchstgeschwindigkeit (km/h)"
-					delete_if_empty="true"
 					values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,none"
 					display_values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,keine" />
 				<label text="Unterschiedliche Geschwindigkeiten je Richtung können manuell mit maxspeed:forward=* bzw. maxspeed:backward=* getaggt werden." />
@@ -1709,67 +1696,67 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="yes,no,contact_line,rail"
 					display_values="Ja,Nein,Oberleitung,Stromschiene"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="voltage"
 					text="Voltage"
 					de.text="Spannung"
 					values="15000,500,550,600,750,850,1000,1200,1500,2400,3000,6500,6600,11000,25000"
 					display_values="15 kV (Standard in Österreich),500 V,550 V,600 V,750 V,850 V,1000 V,1200 V,1500 V,2400 V,3000 V,6500 V,6600 V,11 kV,25 kV"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="frequency"
 					text="Frequency"
 					de.text="Frequenz"
 					values="16.7,0,16.67,50,60,25"
 					display_values="16.7 Hz (Standard in Österreich),Gleichspannung,16 2/3 Hz,50 Hz,60 Hz,25 Hz"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="gauge"
 					text="Gauge"
 					de.text="Spurweite"
 					values="1435,1040,1000,900,880,800,760,750,580,500,381,184,127"
 					display_values="1435 mm (Normalspur),1040 mm,1000 mm (Meterspur),900 mm,880 mm,800 mm,760mm (Bosnische Spur),750 mm,580 mm,500 mm,381 mm,184 mm,127 mm"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<check key="railway:ballastless"
 					text="Ballastless"
 					de.text="Feste Fahrbahn"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="rack"
 					text="Rack"
 					de.text="Zahnstange"
 					values="yes,no,riggenbach,strub,abt,locher,riggenbach-klose,marsh,von_roll"
 					display_values="Ja,Nein,System Riggenbach,System Strub,System Abt,System Locher,System Riggenbach-Klose,System Marsh,System Von Roll"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="incline"
 					text="Incline (e.g.. '3%')"
 					de.text="Steigung (z. B. '3%')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<text key="start_date"
 					text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="operator"
 					text="Operator (e.g. 'ÖBB-Infrastruktur AG')"
 					de.text="Betreiber (z. B. 'ÖBB-Infrastruktur AG')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<check key="embankment"
 					text="Embankment"
 					de.text="Damm"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="cutting"
 					text="Cutting"
 					de.text="Einschnitt"
 					default="off"
-					delete_if_empty="true" />
+					/>
 			</item>
 			<item name="Stillgelegtes Gleis" icon="disused.png" type="way">
 				<label text="Ein Gleis, das zwar noch vorhanden ist und jederzeit wieder genutzt werden könnte, im Moment aber nicht mehr in Betrieb ist." />
@@ -1780,19 +1767,19 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Line ref (VzG number, e.g. '2379')"
 					de.text="Streckennummer (VzG-Nummer, z. B. '2379')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="railway:track_ref"
 					text="Track ref (inside station)"
 					de.text="Gleisnummer (im Bahnhof)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="name"
 					text="Railway name"
 					de.text="Streckenname"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
-				<combo key="usage" text="Usage" de.text="Nutzung" default="" delete_if_empty="true">
+				<combo key="usage" text="Usage" de.text="Nutzung" default="">
 					<list_entry value="main" display_value="Hauptbahn" short_description="Strecke mit übergeordneter Bedeutung; meist zweigleisig, meist elektrifiziert, zumindest abschnittsweise mit mehr als 100 km/h befahrbar" />
 					<list_entry value="branch" display_value="Nebenbahn" short_description="Strecke mit untergeordneter Bedeutung; oft nicht elektrifiziert, oft eingleisig. Keinesfalls mit mehr als 100 km/h befahrbar." />
 					<list_entry value="industrial" display_value="Industriebahn" short_description="Eine Strecke, die ausschließlich dem Güterverkehr dient und in der Regel Eigentum eines Industrieunternehmens ist. Meist nur innerhalb von Hafengebieten, Industrieanlagen, Tagebauen." />
@@ -1806,43 +1793,43 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="mixed,passenger,freight"
 					display_values="Gemischt,Personenverkehr,Güterverkehr"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<check key="highspeed"
 					text="Highspeed traffic (~ >200 km/h)"
 					de.text="Hochgeschwindigkeitsstrecke (~ >200 km/h)"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<space />
 				<check key="railway:pzb"
 					text="PZB"
 					de.text="Punktförmige Zugbeeinflussung (PZB)"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="railway:lzb"
 					text="LZB"
 					de.text="Linienzugbeeinflussung (LZB)"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:etcs"
 					text="ETCS"
 					de.text="ETCS"
 					values="yes,no,0,1,2,3"
 					display_values="Ja,Nein,Level 0,Level 1,Level 2,Level 3"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:radio"
 					text="Radio"
 					de.text="Zugfunk"
 					values="analogue,gsm-r"
 					display_values="Analog,GSM-R"
 					default=""
-					delete_if_empty="true" />
-				<combo key="railway:preferred_direction" text="Direction of use (depends on direction of OSM way)" de.text="Regelfahrtrichtung (abhängig von Richtung des OSM-Ways)" default="" delete_if_empty="true">
+					/>
+				<combo key="railway:preferred_direction" text="Direction of use (depends on direction of OSM way)" de.text="Regelfahrtrichtung (abhängig von Richtung des OSM-Ways)" default="">
 					<list_entry value="forward" display_value="In Wegrichtung" short_description="Das Gleis wird üblicherweise in die Richtung befahren, in die der OSM-Way führt. Nur für mehrgleisige Strecken." />
 					<list_entry value="backward" display_value="Entgegen Wegrichtung" short_description="Das Gleis wird üblicherweise entgegen der Richtung befahren, in die der OSM-Way führt. Nur für mehrgleisige Strecken." />
 					<list_entry value="both" display_value="Beide Richtungen" short_description="Es gibt keine Richtung, in die die Züge üblicherweise fahren bzw. nicht fahren. Nur für eingleisige Strecken." />
 				</combo>
-				<combo key="railway:bidirectional" text="Bidirectional traffic (depends on direction of OSM way)" de.text="Gleiswechselbetrieb (abhängig von Richtung des OSM-Ways)" default="" delete_if_empty="true">
+				<combo key="railway:bidirectional" text="Bidirectional traffic (depends on direction of OSM way)" de.text="Gleiswechselbetrieb (abhängig von Richtung des OSM-Ways)" default="">
 					<list_entry value="regular" display_value="Gleiswechselbetrieb" short_description="Das Gleis ist für beide Fahrtrichtungen mit Signalen ausgestattet und kann daher regulär entgegen der üblichen Fahrtrichtung befahren werden." />
 					<list_entry value="signals" display_value="Signalisierter Falschfahrbetrieb" short_description="Das Gleis ist signaltechnisch nur für eine Fahrtrichtung ausgelegt, sodass weiterhin Falschfahrten notwendig sind, diese sind aber durch Signale geregelt." />
 					<list_entry value="possible" display_value="Falschfahrt möglich" short_description="Signaltechnisch besteht keine Möglichkeit einer Befahrung des Gegengleises. Es ist ein schriftlicher Befehl notwendig." />
@@ -1850,7 +1837,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<combo key="maxspeed" default=""
 					text="Maxspeed (km/h)"
 					de.text="Höchstgeschwindigkeit (km/h)"
-					delete_if_empty="true"
 					values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,none"
 					display_values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,keine" />
 				<label text="Unterschiedliche Geschwindigkeiten je Richtung können manuell mit maxspeed:forward=* bzw. maxspeed:backward=* getaggt werden." />
@@ -1861,72 +1847,72 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="yes,no,contact_line,rail"
 					display_values="Ja,Nein,Oberleitung,Stromschiene"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="voltage"
 					text="Voltage"
 					de.text="Spannung"
 					values="15000,500,550,600,750,850,1000,1200,1500,1800,2200,2400,3000,6500,6600,11000,25000"
 					display_values="15 kV (Standard in Österreich),500 V,550 V,600 V,750 V,850 V,1000 V,1200 V,1500 V,1800 V,2200 V,2400 V,3000 V,6500 V,6600 V,11 kV,25 kV"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="frequency"
 					text="Frequency"
 					de.text="Frequenz"
 					values="16.7,0,16.67,50,60,25"
 					display_values="16.7 Hz (Standard in Österreich),Gleichspannung,16 2/3 Hz,50 Hz,60 Hz,25 Hz"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="gauge"
 					text="Gauge"
 					de.text="Spurweite"
 					values="1435,1106,1040,1000,900,880,820,800,760,750,600,580,500,381,184,127"
 					display_values="1435 mm (Normalspur),1106,1040 mm,1000 mm (Meterspur),900 mm,880 mm,820 mm,800 mm,760mm (Bosnische Spur),750 mm,600 mm,580 mm,500 mm,381 mm,184 mm,127 mm"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<check key="railway:ballastless"
 					text="Ballastless"
 					de.text="Feste Fahrbahn"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="rack"
 					text="Rack"
 					de.text="Zahnstange"
 					values="yes,no,riggenbach,strub,abt,locher,riggenbach-klose,marsh,von_roll"
 					display_values="Ja,Nein,System Riggenbach,System Strub,System Abt,System Locher,System Riggenbach-Klose,System Marsh,System Von Roll"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="incline"
 					text="Incline (e.g.. '3%')"
 					de.text="Steigung (z. B. '3%')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<text key="start_date"
 					text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="end_date"
 					text="Closed at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Stilllegung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="operator"
 					text="Operator (e.g. 'ÖBB-Infrastruktur AG')"
 					de.text="Betreiber (z. B. 'ÖBB-Infrastruktur AG')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<check key="embankment"
 					text="Embankment"
 					de.text="Damm"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="cutting"
 					text="Cutting"
 					de.text="Einschnitt"
 					default="off"
-					delete_if_empty="true" />
+					/>
 			</item>
 			<item name="Abgebautes Gleis" icon="abandoned.png" type="way">
 				<label text="Ein Gleis, das entfernt wurde. Das Gleisbett ist weiterhin vorhanden und der Streckenverlauf ist weiterhin sichtbar." />
@@ -1937,19 +1923,19 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Line ref (VzG number, e.g. '2379')"
 					de.text="Streckennummer (VzG-Nummer, z. B. '2379')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="railway:track_ref"
 					text="Track ref (inside station)"
 					de.text="Gleisnummer (im Bahnhof)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="name"
 					text="Railway name"
 					de.text="Streckenname"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
-				<combo key="usage" text="Usage" de.text="Nutzung" default="" delete_if_empty="true">
+				<combo key="usage" text="Usage" de.text="Nutzung" default="">
 					<list_entry value="main" display_value="Hauptbahn" short_description="Strecke mit übergeordneter Bedeutung; meist zweigleisig, meist elektrifiziert, zumindest abschnittsweise mit mehr als 100 km/h befahrbar" />
 					<list_entry value="branch" display_value="Nebenbahn" short_description="Strecke mit untergeordneter Bedeutung; oft nicht elektrifiziert, oft eingleisig. Keinesfalls mit mehr als 100 km/h befahrbar." />
 					<list_entry value="industrial" display_value="Industriebahn" short_description="Eine Strecke, die ausschließlich dem Güterverkehr dient und in der Regel Eigentum eines Industrieunternehmens ist. Meist nur innerhalb von Hafengebieten, Industrieanlagen, Tagebauen." />
@@ -1963,43 +1949,43 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="mixed,passenger,freight"
 					display_values="Gemischt,Personenverkehr,Güterverkehr"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<check key="highspeed"
 					text="Highspeed traffic (~ >200 km/h)"
 					de.text="Hochgeschwindigkeitsstrecke (~ >200 km/h)"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<space />
 				<check key="railway:pzb"
 					text="PZB"
 					de.text="Punktförmige Zugbeeinflussung (PZB)"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="railway:lzb"
 					text="LZB"
 					de.text="Linienzugbeeinflussung (LZB)"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:etcs"
 					text="ETCS"
 					de.text="ETCS"
 					values="yes,no,0,1,2,3"
 					display_values="Ja,Nein,Level 0,Level 1,Level 2,Level 3"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:radio"
 					text="Radio"
 					de.text="Zugfunk"
 					values="analogue,gsm-r"
 					display_values="Analog,GSM-R"
 					default=""
-					delete_if_empty="true" />
-				<combo key="railway:preferred_direction" text="Direction of use (depends on direction of OSM way)" de.text="Regelfahrtrichtung (abhängig von Richtung des OSM-Ways)" default="" delete_if_empty="true">
+					/>
+				<combo key="railway:preferred_direction" text="Direction of use (depends on direction of OSM way)" de.text="Regelfahrtrichtung (abhängig von Richtung des OSM-Ways)" default="">
 					<list_entry value="forward" display_value="In Wegrichtung" short_description="Das Gleis wird üblicherweise in die Richtung befahren, in die der OSM-Way führt. Nur für mehrgleisige Strecken." />
 					<list_entry value="backward" display_value="Entgegen Wegrichtung" short_description="Das Gleis wird üblicherweise entgegen der Richtung befahren, in die der OSM-Way führt. Nur für mehrgleisige Strecken." />
 					<list_entry value="both" display_value="Beide Richtungen" short_description="Es gibt keine Richtung, in die die Züge üblicherweise fahren bzw. nicht fahren. Nur für eingleisige Strecken." />
 				</combo>
-				<combo key="railway:bidirectional" text="Bidirectional traffic (depends on direction of OSM way)" de.text="Gleiswechselbetrieb (abhängig von Richtung des OSM-Ways)" default="" delete_if_empty="true">
+				<combo key="railway:bidirectional" text="Bidirectional traffic (depends on direction of OSM way)" de.text="Gleiswechselbetrieb (abhängig von Richtung des OSM-Ways)" default="">
 					<list_entry value="regular" display_value="Gleiswechselbetrieb" short_description="Das Gleis ist für beide Fahrtrichtungen mit Signalen ausgestattet und kann daher regulär entgegen der üblichen Fahrtrichtung befahren werden." />
 					<list_entry value="signals" display_value="Signalisierter Falschfahrbetrieb" short_description="Das Gleis ist signaltechnisch nur für eine Fahrtrichtung ausgelegt, sodass weiterhin Falschfahrten notwendig sind, diese sind aber durch Signale geregelt." />
 					<list_entry value="possible" display_value="Falschfahrt möglich" short_description="Signaltechnisch besteht keine Möglichkeit einer Befahrung des Gegengleises. Es ist ein schriftlicher Befehl notwendig." />
@@ -2007,7 +1993,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<combo key="maxspeed" default=""
 					text="Maxspeed (km/h)"
 					de.text="Höchstgeschwindigkeit (km/h)"
-					delete_if_empty="true"
 					values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,none"
 					display_values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,keine" />
 				<label text="Unterschiedliche Geschwindigkeiten je Richtung können manuell mit maxspeed:forward=* bzw. maxspeed:backward=* getaggt werden." />
@@ -2018,72 +2003,72 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="yes,no,contact_line,rail"
 					display_values="Ja,Nein,Oberleitung,Stromschiene"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="voltage"
 					text="Voltage"
 					de.text="Spannung"
 					values="15000,500,550,600,750,850,1000,1200,1500,1800,2200,2400,3000,6500,6600,11000,25000"
 					display_values="15 kV (Standard in Österreich),500 V,550 V,600 V,750 V,850 V,1000 V,1200 V,1500 V,1800 V,2200 V,2400 V,3000 V,6500 V,6600 V,11 kV,25 kV"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="frequency"
 					text="Frequency"
 					de.text="Frequenz"
 					values="16.7,0,16.67,50,60,25"
 					display_values="16.7 Hz (Standard in Österreich),Gleichspannung,16 2/3 Hz,50 Hz,60 Hz,25 Hz"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="gauge"
 					text="Gauge"
 					de.text="Spurweite"
 					values="1435,1106,1040,1000,900,880,820,800,760,750,600,580,500,381,184,127"
 					display_values="1435 mm (Normalspur),1106,1040 mm,1000 mm (Meterspur),900 mm,880 mm,820 mm,800 mm,760mm (Bosnische Spur),750 mm,600 mm,580 mm,500 mm,381 mm,184 mm,127 mm"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<check key="railway:ballastless"
 					text="Ballastless"
 					de.text="Feste Fahrbahn"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="rack"
 					text="Rack"
 					de.text="Zahnstange"
 					values="yes,no,riggenbach,strub,abt,locher,riggenbach-klose,marsh,von_roll"
 					display_values="Ja,Nein,System Riggenbach,System Strub,System Abt,System Locher,System Riggenbach-Klose,System Marsh,System Von Roll"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="incline"
 					text="Incline (e.g.. '3%')"
 					de.text="Steigung (z. B. '3%')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<text key="start_date"
 					text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="end_date"
 					text="Closed at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Stilllegung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="operator"
 					text="Operator (e.g. 'ÖBB-Infrastruktur AG')"
 					de.text="Betreiber (z. B. 'ÖBB-Infrastruktur AG')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<check key="embankment"
 					text="Embankment"
 					de.text="Damm"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="cutting"
 					text="Cutting"
 					de.text="Einschnitt"
 					default="off"
-					delete_if_empty="true" />
+					/>
 			</item>
 			<item name="Überbauter Streckenverlauf" icon="razed.png" type="way">
 				<label text="Ein ehemaliges Gleis, dessen Verlauf heute durch Überbauung o.ä. nur noch zu erahnen ist." />
@@ -2094,19 +2079,19 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Line ref (VzG number, e.g. '2379')"
 					de.text="Streckennummer (VzG-Nummer, z. B. '2379')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="railway:track_ref"
 					text="Track ref (inside station)"
 					de.text="Gleisnummer (im Bahnhof)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="name"
 					text="Railway name"
 					de.text="Streckenname"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
-				<combo key="usage" text="Usage" de.text="Nutzung" default="" delete_if_empty="true">
+				<combo key="usage" text="Usage" de.text="Nutzung" default="">
 					<list_entry value="main" display_value="Hauptbahn" short_description="Strecke mit übergeordneter Bedeutung; meist zweigleisig, meist elektrifiziert, zumindest abschnittsweise mit mehr als 100 km/h befahrbar" />
 					<list_entry value="branch" display_value="Nebenbahn" short_description="Strecke mit untergeordneter Bedeutung; oft nicht elektrifiziert, oft eingleisig. Keinesfalls mit mehr als 100 km/h befahrbar." />
 					<list_entry value="industrial" display_value="Industriebahn" short_description="Eine Strecke, die ausschließlich dem Güterverkehr dient und in der Regel Eigentum eines Industrieunternehmens ist. Meist nur innerhalb von Hafengebieten, Industrieanlagen, Tagebauen." />
@@ -2121,23 +2106,23 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.display_values="Gemischt,Personenverkehr,Güterverkehr"
 					display_values="mixed,passenger only,freight only"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<check key="highspeed"
 					text="Highspeed traffic (~ >200 km/h)"
 					de.text="Hochgeschwindigkeitsstrecke (~ >200 km/h)"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<space />
 				<check key="railway:pzb"
 					text="PZB"
 					de.text="Punktförmige Zugbeeinflussung (PZB)"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="railway:lzb"
 					text="LZB"
 					de.text="Linienzugbeeinflussung (LZB)"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:etcs"
 					text="ETCS"
 					de.text="ETCS"
@@ -2145,20 +2130,20 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					display_values="Yes,No,Level 0,Level 1,Level 2,Level 3"
 					de.display_values="Ja,Nein,Level 0,Level 1,Level 2,Level 3"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:radio"
 					text="Radio"
 					de.text="Zugfunk"
 					values="analogue,gsm-r"
 					display_values="Analog,GSM-R"
 					default=""
-					delete_if_empty="true" />
-				<combo key="railway:preferred_direction" text="Direction of use (depends on direction of OSM way)" de.text="Regelfahrtrichtung (abhängig von Richtung des OSM-Ways)" default="" delete_if_empty="true">
+					/>
+				<combo key="railway:preferred_direction" text="Direction of use (depends on direction of OSM way)" de.text="Regelfahrtrichtung (abhängig von Richtung des OSM-Ways)" default="">
 					<list_entry value="forward" display_value="In Wegrichtung" short_description="Das Gleis wird üblicherweise in die Richtung befahren, in die der OSM-Way führt. Nur für mehrgleisige Strecken." />
 					<list_entry value="backward" display_value="Entgegen Wegrichtung" short_description="Das Gleis wird üblicherweise entgegen der Richtung befahren, in die der OSM-Way führt. Nur für mehrgleisige Strecken." />
 					<list_entry value="both" display_value="Beide Richtungen" short_description="Es gibt keine Richtung, in die die Züge üblicherweise fahren bzw. nicht fahren. Nur für eingleisige Strecken." />
 				</combo>
-				<combo key="railway:bidirectional" text="Bidirectional traffic (depends on direction of OSM way)" de.text="Gleiswechselbetrieb (abhängig von Richtung des OSM-Ways)" default="" delete_if_empty="true">
+				<combo key="railway:bidirectional" text="Bidirectional traffic (depends on direction of OSM way)" de.text="Gleiswechselbetrieb (abhängig von Richtung des OSM-Ways)" default="">
 					<list_entry value="regular" display_value="Gleiswechselbetrieb" short_description="Das Gleis ist für beide Fahrtrichtungen mit Signalen ausgestattet und kann daher regulär entgegen der üblichen Fahrtrichtung befahren werden." />
 					<list_entry value="signals" display_value="Signalisierter Falschfahrbetrieb" short_description="Das Gleis ist signaltechnisch nur für eine Fahrtrichtung ausgelegt, sodass weiterhin Falschfahrten notwendig sind, diese sind aber durch Signale geregelt." />
 					<list_entry value="possible" display_value="Falschfahrt möglich" short_description="Signaltechnisch besteht keine Möglichkeit einer Befahrung des Gegengleises. Es ist ein schriftlicher Befehl notwendig." />
@@ -2166,7 +2151,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<combo key="maxspeed" default=""
 					text="Maxspeed (km/h)"
 					de.text="Höchstgeschwindigkeit (km/h)"
-					delete_if_empty="true"
 					values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,none"
 					display_values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,keine" />
 				<label text="Unterschiedliche Geschwindigkeiten je Richtung können manuell mit maxspeed:forward=* bzw. maxspeed:backward=* getaggt werden." />
@@ -2177,72 +2161,72 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="yes,no,contact_line,rail"
 					display_values="Ja,Nein,Oberleitung,Stromschiene"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="voltage"
 					text="Voltage"
 					de.text="Spannung"
 					values="15000,500,550,600,750,850,1000,1200,1500,1800,2200,2400,3000,6500,6600,11000,25000"
 					display_values="15 kV (Standard in Österreich),500 V,550 V,600 V,750 V,850 V,1000 V,1200 V,1500 V,1800 V,2200 V,2400 V,3000 V,6500 V,6600 V,11 kV,25 kV"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="frequency"
 					text="Frequency"
 					de.text="Frequenz"
 					values="16.7,0,16.67,50,60,25"
 					display_values="16.7 Hz (Standard in Österreich),Gleichspannung,16 2/3 Hz,50 Hz,60 Hz,25 Hz"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="gauge"
 					text="Gauge"
 					de.text="Spurweite"
 					values="1435,1106,1040,1000,900,880,820,800,760,750,600,580,500,381,184,127"
 					display_values="1435 mm (Normalspur),1106,1040 mm,1000 mm (Meterspur),900 mm,880 mm,820 mm,800 mm,760mm (Bosnische Spur),750 mm,600 mm,580 mm,500 mm,381 mm,184 mm,127 mm"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<check key="railway:ballastless"
 					text="Ballastless"
 					de.text="Feste Fahrbahn"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="rack"
 					text="Rack"
 					de.text="Zahnstange"
 					values="yes,no,riggenbach,strub,abt,locher,riggenbach-klose,marsh,von_roll"
 					display_values="Ja,Nein,System Riggenbach,System Strub,System Abt,System Locher,System Riggenbach-Klose,System Marsh,System Von Roll"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="incline"
 					text="Incline (e.g.. '3%')"
 					de.text="Steigung (z. B. '3%')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<text key="start_date"
 					text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="end_date"
 					text="Closed at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Stilllegung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="operator"
 					text="Operator (e.g. 'ÖBB-Infrastruktur AG')"
 					de.text="Betreiber (z. B. 'ÖBB-Infrastruktur AG')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<check key="embankment"
 					text="Embankment"
 					de.text="Damm"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="cutting"
 					text="Cutting"
 					de.text="Einschnitt"
 					default="off"
-					delete_if_empty="true" />
+					/>
 			</item>
 			<separator />
 			<item name="Brücke" icon="bridge.png" type="way">
@@ -2254,17 +2238,17 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Bridge name"
 					de.text="Name der Brücke"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="image"
 					text="Image URL"
 					de.text="URL eines Bildes"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="wikipedia"
 					text="Wikipedia article in the format (Language):(Article)"
 					de.text="Wikipediaartikel in der Form (Sprachkürzel):(Artikelname)"
 					default=""
-					delete_if_empty="true" />
+					/>
 			</item>
 			<item name="Tunnel" icon="tunnel.png" type="way">
 				<key key="tunnel"
@@ -2275,17 +2259,17 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Tunnel name"
 					de.text="Name des Tunnels"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="image"
 					text="Image URL"
 					de.text="URL eines Bildes"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="wikipedia"
 					text="Wikipedia article in the format (Language):(Article)"
 					de.text="Wikipediaartikel in der Form (Sprachkürzel):(Artikelname)"
 					default=""
-					delete_if_empty="true" />
+					/>
 			</item>
 			<separator />
 			<item name="Prellbock" icon="bufferstop.png" type="node">
@@ -2300,7 +2284,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.display_values="In Wegrichtung,Entgegen Wegrichtung"
 					display_values="forward,backward"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<key key="railway:signal:minor"
 					value="AT-V2:weiterfahrt_verboten" />
 				<key key="railway:signal:minor:form"
@@ -2315,27 +2299,27 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Switch ref"
 					de.text="Weichennummer"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<check key="railway:local_operated"
 					text="Local operated"
 					de.text="Ortsgestellt"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="railway:switch:electric"
 					text="Electric"
 					de.text="Elektrischer Weichenantrieb"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="railway:switch:heated"
 					text="Heated"
 					de.text="Weichenheizung"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="railway:switch:resetting"
 					text="resetting switch"
 					de.text="Rückfallweiche"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:switch"
 					text="Switch type"
 					de.text="Weichentyp"
@@ -2343,7 +2327,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.values="default switch,three way switch,single slip switch,double slip switch,wye switch,abt switch"
 					display_values="Einfache Weiche,Dreiwegweiche,einfache Kreuzungsweiche,Doppelkreuzungsweiche,Y-Weiche,Abtsche Weiche"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:turnout_side"
 					text="Turnout side (only default and resetting switches)"
 					de.text="Seite der Abzweigung (nur bei Standard- und Rückfallweichen)"
@@ -2351,34 +2335,34 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					display_values="Left,Right"
 					de.display_values="Links,Rechts"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="railway:radius"
 					text="Switch radius (m)"
 					de.text="Weichenradius (m)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="railway:maxspeed:straight"
 					text="Maxspeed in straight direction (km/h)"
 					de.text="Geschwindigkeit auf dem geraden Zweig (km/h)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="railway:maxspeed:diverging"
 					text="Maxspeed in diverging direction (km/h)"
 					de.text="Geschwindigkeit auf dem Abzweig (km/h)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:switch:configuration"
 					text="Configuration"
 					de.text="Bauform (bei Doppelkreuzungsweichen)"
 					values="inside,outside"
 					display_values="Innenliegende Zungen (Engländer),Außenliegende Zungen (Baeseler)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<check key="railway:switch:movable_frog"
 					text="Movable frog"
 					de.text="Bewegliches Herzstück"
 					default="off"
-					delete_if_empty="true" />
+					/>
 			</item>
 			<item name="Kreuzung" icon="railway-crossing.png" type="node">
 				<label text="Kreuzung" />
@@ -2389,7 +2373,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Ref"
 					de.text="Bezeichnung/Nummer"
 					default=""
-					delete_if_empty="true" />
+					/>
 			</item>
 			<item name="Gleissperre" icon="derail.png" type="node">
 				<label text="Gleissperre" />
@@ -2402,17 +2386,17 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Ref"
 					de.text="Bezeichnung/Nummer"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<check key="railway:local_operated"
 					text="Local operated"
 					de.text="Ortsbedient"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="railway:signal:minor:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<key key="railway:signal:minor"
 					value="AT-V2:sperrsignal" />
 				<key key="railway:signal:minor:states"
@@ -2434,7 +2418,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					display_values="insulated_rail_joint,axle_counter"
 					de.display_values="Isolierstoß,Achszähler"
 					default=""
-					delete_if_empty="true" />
+					/>
 			</item>
 		</group>
 		<item name="Stellwerk" icon="signalbox.png" type="node,closedway">
@@ -2446,54 +2430,54 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				text="Name"
 				de.text="Name"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<text key="railway:ref"
 				text="Short name"
 				de.text="Abkürzung"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<combo key="railway:signal_box"
 				text="Signal box type"
 				de.text="Stellwerkstechnik"
 				values="mechanical,electric,track_diagram,electronic"
 				display_values="Mechanisches Stellwerk,Elektrisches/Elektromechanisches Stellwerk,Gleisbildstellwerk,Elektronisches Stellwerk (ESTW)"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<text key="start_date"
 				text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 				de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<text key="railway:position"
 				text="Distance indication (rounded, e.g. '12.3'; km)"
 				de.text="Hektometerwert (z. B. '12.3')"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<text key="railway:position:exact"
 				text="Exact distance indication (exact, e.g. '12.345'; km)"
 				de.text="Metergenauer Wert (genau, z. B: '12.345'; km)"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<text key="image"
 				text="Image URL"
 				de.text="URL eines Bildes"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<check key="railway:local_operated"
 				text="Local operated"
 				de.text="Ortsbedient"
 				default="off"
-				delete_if_empty="true" />
+				/>
 			<check key="building"
 				text="Building"
 				de.text="Gebäude"
 				default="off"
-				delete_if_empty="true" />
+				/>
 			<check key="disused"
 				text="out of service"
 				de.text="Außer Betrieb"
 				default="off"
-				delete_if_empty="true" />
+				/>
 		</item>
 		<group name="Betriebsstellen" icon="facilities.png">
 			<item name="Personenbahnhöfe und Bahnhöfe mit gemischter Nutzung" icon="station.png" type="node">
@@ -2509,63 +2493,63 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.display_values="ja,nein"
 					display_values="yes,no"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="name" text="Name"
 					de.text="Name"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="railway:ref"
 					text="Short name (DB 640)"
 					de.text="Abkürzung (nach DB 640, z. B. 'Bbg')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="uic_ref"
 					text="UIC-ID"
 					de.text="UIC-Bahnhofsnummer"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="uic_name"
 					text="UIC name"
 					de.text="UIC-Bahnhofsname"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:station_category"
 					text="Station category"
 					de.text="Bahnhofskategorie"
 					values="1,2,3,4,5,6,7"
 					display_values="1,2,3,4,5,6,7"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="operator"
 					text="Operator (e.g. 'ÖBB-Infrastruktur AG')"
 					de.text="Betreiber (z. B. 'ÖBB-Infrastruktur AG')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="network"
 					text="Network"
 					de.text="Verkehrsverbund"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="start_date"
 					text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="image"
 					text="Image URL"
 					de.text="URL eines Bildes"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="wikipedia"
 					text="Wikipedia article in the format (Language):(Article)"
 					de.text="Wikipediaartikel in der Form (Sprachkürzel):(Artikelname)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="ele"
 					text="Height above sea level (m)"
 					de.text="Höhe über Meeresspiegel (m)"
 					default=""
-					delete_if_empty="true" />
+					/>
 			</item>
 			<item name="Haltestelle" icon="halt.png" type="node">
 				<label text="Haltestelle" />
@@ -2580,63 +2564,63 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.display_values="ja,nein"
 					display_values="yes,no"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="name" text="Name"
 					de.text="Name"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="railway:ref"
 					text="Short name (DB 640)"
 					de.text="Abkürzung (DB 640, z. B. 'Bbg H1')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="uic_ref"
 					text="UIC-ID"
 					de.text="UIC-Bahnhofsnummer"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="uic_name"
 					text="UIC name"
 					de.text="UIC-Bahnhofsname"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:station_category"
 					text="Station category"
 					de.text="Bahnhofskategorie"
 					values="1,2,3,4,5,6,7"
 					display_values="1,2,3,4,5,6,7"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="operator"
 					text="Operator (e.g. 'ÖBB-Infrastruktur AG')"
 					de.text="Betreiber (z. B. 'ÖBB-Infrastruktur AG')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="network"
 					text="Network"
 					de.text="Verkehrsverbund"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="start_date"
 					text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="image"
 					text="Image URL"
 					de.text="URL eines Bildes"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="wikipedia"
 					text="Wikipedia article in the format (Language):(Article)"
 					de.text="Wikipediaartikel in der Form (Sprachkürzel):(Artikelname)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="ele"
 					text="Height above sea level (m)"
 					de.text="Höhe über Meeresspiegel (m)"
 					default=""
-					delete_if_empty="true" />
+					/>
 			</item>
 			<item name="Straßenbahnhaltestelle" icon="tramstop.png" type="node">
 				<label text="Straßenbahnhaltestelle" />
@@ -2651,46 +2635,46 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.display_values="ja,nein"
 					display_values="yes,no"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="name" text="Name"
 					de.text="Name"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="railway:ref"
 					text="Short name"
 					de.text="Abkürzung"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="uic_ref"
 					text="UIC-ID"
 					de.text="UIC-Bahnhofsnummer"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="uic_name"
 					text="UIC name"
 					de.text="UIC-Bahnhofsname"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="operator"
 					text="Operator (e.g. 'Wiener Linien GmbH &amp; Co KG')"
 					de.text="Betreiber (z. B. 'Wiener Linien GmbH &amp; Co KG')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="network"
 					text="Network"
 					de.text="Verkehrsverbund"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="start_date"
 					text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="ele"
 					text="Height above sea level (m)"
 					de.text="Höhe über Meeresspiegel (m)"
 					default=""
-					delete_if_empty="true" />
+					/>
 			</item>
 			<item name="Güterbahnhof/Rangierbahnhof" icon="yard.png" type="node">
 				<label text="Güterbahnhof/Rangierbahnhof" />
@@ -2701,37 +2685,37 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<text key="name" text="Name"
 					de.text="Name"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="railway:ref"
 					text="Short name (DB 640)"
 					de.text="Abkürzung (nach DB 640, z. B. 'Bbg')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="operator"
 					text="Operator (e.g. 'ÖBB-Infrastruktur AG')"
 					de.text="Betreiber (z. B. 'ÖBB-Infrastruktur AG')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="start_date"
 					text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="image"
 					text="Image URL"
 					de.text="URL eines Bildes"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="wikipedia"
 					text="Wikipedia article in the format (Language):(Article)"
 					de.text="Wikipediaartikel in der Form (Sprachkürzel):(Artikelname)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="ele"
 					text="Height above sea level (m)"
 					de.text="Höhe über Meeresspiegel (m)"
 					default=""
-					delete_if_empty="true" />
+					/>
 			</item>
 			<item name="Betriebsbahnhof" icon="service-station.png" type="node">
 				<label text="Betriebsbahnhof" />
@@ -2742,37 +2726,37 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<text key="name" text="Name"
 					de.text="Name"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="railway:ref"
 					text="Short name (DB 640)"
 					de.text="Abkürzung (nach DB 640, z. B. 'Bbg')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="operator"
 					text="Operator (e.g. 'ÖBB-Infrastruktur AG')"
 					de.text="Betreiber (z. B. 'ÖBB-Infrastruktur AG')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="start_date"
 					text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="image"
 					text="Image URL"
 					de.text="URL eines Bildes"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="wikipedia"
 					text="Wikipedia article in the format (Language):(Article)"
 					de.text="Wikipediaartikel in der Form (Sprachkürzel):(Artikelname)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="ele"
 					text="Height above sea level (m)"
 					de.text="Höhe über Meeresspiegel (m)"
 					default=""
-					delete_if_empty="true" />
+					/>
 			</item>
 			<item name="Abzweig" icon="junction.png" type="node">
 				<label text="Abzweig" />
@@ -2784,37 +2768,37 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Name"
 					de.text="Name"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="railway:ref"
 					text="Short name (DB 640, such as 'Bbg')"
 					de.text="Abkürzung (nach DB 640, z. B. 'Bbg')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="operator"
 					text="Operator (e.g. 'ÖBB-Infrastruktur AG')"
 					de.text="Betreiber (z. B. 'ÖBB-Infrastruktur AG')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="start_date"
 					text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="image"
 					text="Image URL"
 					de.text="URL eines Bildes"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="wikipedia"
 					text="Wikipedia article in the format (Language):(Article)"
 					de.text="Wikipediaartikel in der Form (Sprachkürzel):(Artikelname)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="ele"
 					text="Height above sea level (m)"
 					de.text="Höhe über Meeresspiegel (m)"
 					default=""
-					delete_if_empty="true" />
+					/>
 			</item>
 			<item name="Anst / Awanst" icon="junction.png" type="node">
 				<label text="Anschlusstelle oder Ausweichanschlusstelle" />
@@ -2826,37 +2810,37 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Name"
 					de.text="Name"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="railway:ref"
 					text="Short name (DB 640, such as 'Bbg')"
 					de.text="Abkürzung (nach DB 640, z. B. 'Bbg')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="operator"
 					text="Operator (e.g. 'ÖBB-Infrastruktur AG')"
 					de.text="Betreiber (z. B. 'ÖBB-Infrastruktur AG')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="start_date"
 					text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="image"
 					text="Image URL"
 					de.text="URL eines Bildes"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="wikipedia"
 					text="Wikipedia article in the format (Language):(Article)"
 					de.text="Wikipediaartikel in der Form (Sprachkürzel):(Artikelname)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="ele"
 					text="Height above sea level (m)"
 					de.text="Höhe über Meeresspiegel (m)"
 					default=""
-					delete_if_empty="true" />
+					/>
 			</item>
 			<item name="Überleitstelle" icon="crossover.png" type="node">
 				<label text="Überleitstelle" />
@@ -2868,37 +2852,37 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Name"
 					de.text="Name"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="railway:ref"
 					text="Short name (DB 640)"
 					de.text="Abkürzung (nach DB 640, z. B. 'Bbg')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="operator"
 					text="Operator (e.g. 'ÖBB-Infrastruktur AG')"
 					de.text="Betreiber (z. B. 'ÖBB-Infrastruktur AG')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="start_date"
 					text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="image"
 					text="Image URL"
 					de.text="URL eines Bildes"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="wikipedia"
 					text="Wikipedia article in the format (Language):(Article)"
 					de.text="Wikipediaartikel in der Form (Sprachkürzel):(Artikelname)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="ele"
 					text="Height above sea level (m)"
 					de.text="Höhe über Meeresspiegel (m)"
 					default=""
-					delete_if_empty="true" />
+					/>
 			</item>
 			<item name="Bahnhofsteil, Blockstelle" icon="site.png" type="node">
 				<label text="Bahnhofsteil, Blockstelle," />
@@ -2910,37 +2894,37 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Name"
 					de.text="Name"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="railway:ref"
 					text="Short name (DB 640)"
 					de.text="Abkürzung (nach DB 640, z. B. 'Bbg')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="operator"
 					text="Operator (e.g. 'ÖBB-Infrastruktur AG')"
 					de.text="Betreiber (z. B. 'ÖBB-Infrastruktur AG')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="start_date"
 					text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="image"
 					text="Image URL"
 					de.text="URL eines Bildes"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="wikipedia"
 					text="Wikipedia article in the format (Language):(Article)"
 					de.text="Wikipediaartikel in der Form (Sprachkürzel):(Artikelname)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="ele"
 					text="Height above sea level (m)"
 					de.text="Höhe über Meeresspiegel (m)"
 					default=""
-					delete_if_empty="true" />
+					/>
 			</item>
 			<separator />
 			<item name="Halteposition" icon="stop.png" type="node">
@@ -2954,79 +2938,79 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.display_values="ja,nein"
 					display_values="yes,no"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<key key="railway"
 					value="stop" />
 				<text key="name"
 					text="Name"
 					de.text="Name"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="railway:ref"
 					text="Short name (DB 640)"
 					de.text="Abkürzung (nach DB 640, z. B. 'Bbg')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="uic_ref"
 					text="UIC-ID"
 					de.text="UIC-Bahnhofsnummer"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="uic_name"
 					text="UIC name"
 					de.text="UIC-Bahnhofsname"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="local_ref"
 					text="track number (e.g. 5 or 5a)"
 					de.text="Gleisnummer (z.B. 5 oder 5a)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<check key="train"
 					text="Railway traffic?"
 					de.text="Eisenbahnverkehr?"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="light_rail"
 					text="Light rail traffic?"
 					de.text="Stadtbahn- oder Schnellbahn-Verkehr?"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="subway"
 					text="Subway traffic?"
 					de.text="U-Bahn-Verkehr?"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="tram"
 					text="Tram traffic?"
 					de.text="Straßenbahnverkehr?"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<text key="operator"
 					text="Operator (e.g. 'ÖBB-Personenverkehr AG')"
 					de.text="Betreiber (z. B. 'ÖBB-Personenverkehr AG')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="network"
 					text="Network"
 					de.text="Verkehrsverbund"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="ele"
 					text="Height above sea level (m)"
 					de.text="Höhe über Meeresspiegel (m)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="railway:position"
 					text="Distance indication (rounded, e.g. '12.3'; km)"
 					de.text="Entfernungsangabe (gerundet, z. B. '12.3'; km)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="railway:position:exact"
 					text="Exact distance indication (exact, e.g. '12.345'; km)"
 					de.text="Exakte Entfernungsangabe (genau, z.B: '12.345'; km)"
 					default=""
-					delete_if_empty="true" />
+					/>
 			</item>
 			<item name="Bahngelände" icon="landuse.png" type="closedway">
 				<label text="Bahngelände" />
@@ -3045,7 +3029,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.display_values="ja,nein"
 					display_values="yes,no"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="public_transport"
 					text="Public transport?"
 					de.text="Öffentlicher Verkehr?"
@@ -3053,52 +3037,52 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.display_values="ja,nein"
 					display_values="yes,no"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="name"
 					text="Name"
 					de.text="Name"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="uic_ref"
 					text="UIC-ID"
 					de.text="UIC-Bahnhofsnummer"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="uic_name"
 					text="UIC name"
 					de.text="UIC-Bahnhofsname"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="railway:ref"
 					text="Short name (DB 640)"
 					de.text="Abkürzung (nach DB 640, z. B. 'Bbg')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="operator"
 					text="Operator (e.g. 'ÖBB-Infrastruktur AG')"
 					de.text="Betreiber (z. B. 'ÖBB-Infrastruktur AG')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<check key="train"
 					text="Railway traffic?"
 					de.text="Eisenbahnverkehr?"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="light_rail"
 					text="Light rail traffic?"
 					de.text="Stadtbahn- oder Schnellbahn-Verkehr?"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="subway"
 					text="Subway traffic?"
 					de.text="U-Bahn-Verkehr?"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="tram"
 					text="Tram traffic?"
 					de.text="Straßenbahnverkehr?"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<roles>
 					<role key=""
 						text="Railway facility node/area"
@@ -3146,32 +3130,32 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				text="Name of track (e.g. '222 01 Tauernbahn Schwarzach St. Veit – Spittal-Millstättersee')"
 				de.text="Streckenname (z. B. '222 01 Tauernbahn Schwarzach St. Veit – Spittal-Millstättersee')"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<text key="ref"
 				text="Line ref (VzG number, e.g. '222 01')"
 				de.text="Streckennummer (VzG-Nummer, z. B. '222 01')"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<text key="from"
 				text="Initial station"
 				de.text="Streckenanfang"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<text key="to"
 				text="Terminus station"
 				de.text="Streckenende"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<text key="operator"
 				text="Operator (e.g. 'ÖBB-Infrastruktur AG')"
 				de.text="Betreiber (z. B. 'ÖBB-Infrastruktur AG')"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<text key="wikipedia"
 				text="Wikipedia article in the format (Language):(Article)"
 				de.text="Wikipediaartikel in der Form (Sprachkürzel):(Artikelname)"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<roles>
 				<role key=""
 					text="Tracks"
@@ -3191,27 +3175,27 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				text="Name of route (e.g. '220 Tauernbahn')"
 				de.text="Name der Kursbuchstrecke (z. B. '220 Tauernbahn')"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<text key="ref"
 				text="Line ref (KBS number, e.g. '220')"
 				de.text="Streckennummer (KBS-Nummer, z. B. '220')"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<text key="from"
 				text="Initial station"
 				de.text="Streckenanfang"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<text key="to"
 				text="Terminus station"
 				de.text="Streckenende"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<text key="wikipedia"
 				text="Wikipedia article in the format (Language):(Article)"
 				de.text="Wikipediaartikel in der Form (Sprachkürzel):(Artikelname)"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<roles>
 				<role key=""
 					text="Tracks"
@@ -3232,8 +3216,8 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				de.display_values="Zug,Stadt-/Schnellbahn,Straßenbahn,U-Bahn"
 				display_values="train,light rail,tram,subway"
 				default=""
-				delete_if_empty="true" />
-			<combo key="service" text="Zuggattung" default="" delete_if_empty="true">
+				/>
+			<combo key="service" text="Zuggattung" default="">
 				<list_entry value="high_speed" de.display_value="Hochgeschwindigkeitszug" display_value="high speed train" short_description="ICE, Thalys, TGV, Railjet" />
 				<list_entry value="long_distance" de.display_value="Reisezug" display_value="long distance train" short_description="Eurocity, Intercity, D-Zug" />
 				<list_entry value="regional" de.display_value="Regionalzug" display_value="regional train" short_description="Regionalbahn, Regionalexpress" />
@@ -3247,32 +3231,32 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				text="Name of line (e.g. 'S 7 Wien Floridsdorf – Wolfsthal')"
 				de.text="Name der Linie (z. B. 'S 7 Wien Floridsdorf – Wolfsthal')"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<text key="operator"
 				text="Operator"
 				de.text="Betreiber"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<text key="ref"
 				text="Line or train ref (e.g. 'S 7')"
 				de.text="Linien- bzw. Zugnummer (z. B. 'S 7')"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<text key="from"
 				text="Initial station"
 				de.text="Streckenanfang"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<text key="to"
 				text="Terminus station"
 				de.text="Streckenende"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<text key="wikipedia"
 				text="Wikipedia article in the format (Language):(Article)"
 				de.text="Wikipediaartikel in der Form (Sprachkürzel):(Artikelname)"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<roles>
 				<role key=""
 					text="Tracks"
@@ -3329,8 +3313,8 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				de.display_values="Zug,Stadt-/Schnellbahn,Straßenbahn,U-Bahn"
 				display_values="train,light rail,tram,subway"
 				default=""
-				delete_if_empty="true" />
-			<combo key="service" text="Zuggattung" default="" delete_if_empty="true">
+				/>
+			<combo key="service" text="Zuggattung" default="">
 				<list_entry value="high_speed" de.display_value="Hochgeschwindigkeitszug" display_value="high speed train" short_description="ICE, Thalys, TGV, Railjet" />
 				<list_entry value="long_distance" de.display_value="Reisezug" display_value="long distance train" short_description="Eurocity, Intercity, D-Zug" />
 				<list_entry value="regional" de.display_value="Regionalzug" display_value="regional train" short_description="Regionalbahn, Regionalexpress" />
@@ -3344,32 +3328,32 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				text="Name of line (e.g. 'S 7 Wien Floridsdorf – Wolfsthal')"
 				de.text="Name der Linie (z. B. 'S 7 Wien Floridsdorf – Wolfsthal')"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<text key="operator"
 				text="Operator"
 				de.text="Betreiber"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<text key="ref"
 				text="Line or train ref (e.g. 'S 7')"
 				de.text="Linien- bzw. Zugnummer (z. B. 'S 7')"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<text key="from"
 				text="Initial station"
 				de.text="Streckenanfang"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<text key="to"
 				text="Terminus station"
 				de.text="Streckenende"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<text key="wikipedia"
 				text="Wikipedia article in the format (Language):(Article)"
 				de.text="Wikipediaartikel in der Form (Sprachkürzel):(Artikelname)"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<roles>
 				<role key=""
 					text="Tracks"
@@ -3424,17 +3408,17 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				text="Name (no position)"
 				de.text="Name (keine Kilometerangabe oder kreuzende Straße)"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<text key="railway:position"
 				text="Position (rounded, e.g. '12.3'; km)"
 				de.text="Hektometerwert (z. B. '12.3')"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<text key="railway:position:exact"
 				text="Position (exact, e.g. '12.345'; km)"
 				de.text="Metergenauer Wert (z. B. '12.345'; km)"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<space />
 			<combo key="crossing:barrier"
 				text="Barriers" de.text="Schranken"
@@ -3442,52 +3426,52 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				de.display_values="Halbschranke,Vollabschluss ('doppelte Halbschranke'),Vollschranke,Tore (England),Beschrankt,Unbeschrankt"
 				display_values="half boom gate,double half boom gate,full boom gate,gates (turnable),yes,no"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<check key="crossing:light"
 				text="Lights"
 				de.text="Warnlicht"
 				default="off"
-				delete_if_empty="true" />
+				/>
 			<check key="crossing:saltire"
 				text="Saltire"
 				de.text="Andreaskreuz"
 				default="off"
-				delete_if_empty="true" />
+				/>
 			<check key="crossing:bell"
 				text="Bell"
 				de.text="Akustischer Warnton"
 				default="off"
-				delete_if_empty="true" />
+				/>
 			<space />
 			<check key="crossing:chicane"
 				text="Chicane"
 				de.text="Umlaufgitter"
 				default="off"
-				delete_if_empty="true" />
+				/>
 			<combo key="crossing:supervision"
 				text="Type of supervision" de.text="Art der Überwachung"
 				values="no,camera,attendant,automatic,phone"
 				display_values="no,camera,attendant,automatic,phone"
 				de.display_values="keine Überwachung,Kamera,Schrankenwärter/Fahrdienstleiter/Posten,Gefahrenraum-Freimeldeanlage,Telefon (Anrufschranken)"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<combo key="crossing:activation"
 				text="Activation" de.text="Einschaltung"
 				values="automatic,remote,local"
 				display_values="automatic (contacts),remote (signal box), local (attendant/train staff)"
 				de.display_values="Einschaltkontakte, fahrdienstleitergesteuert, vor Ort (Schrankenwärter/Zugpersonal)"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<text key="railway:level_crossing:closure:average"
 				text="average clousure duration (minutes)"
 				de.text="durchschnittliche Schließdauer (in Minuten)"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<check key="crossing:on_demand"
 				text="On demand"
 				de.text="Anrufschranke"
 				default="off"
-				delete_if_empty="true" />
+				/>
 		</item>
 		<item name="Little crossing for pedestrians" de.name="Reisendenübergang"  icon="de-crossing.png" type="node">
 			<label de.text="Reisendenübergang (Übergänge für Reisende/Fußgänger ohne Andreaskreuz" text="Crossing for pedestrians (less secure than common level crossings)" />
@@ -3498,17 +3482,17 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				text="Name (no position)"
 				de.text="Name (keine Kilometerangabe oder kreuzende Straße)"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<text key="railway:position"
 				text="Position (rounded, e.g. '12.3'; km)"
 				de.text="Hektometerwert (z. B. '12.3')"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<text key="railway:position:exact"
 				text="Position (exact, e.g. '12.345'; km)"
 				de.text="Metergenauer Wert (z. B. '12.345'; km)"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<space />
 			<combo key="crossing:barrier"
 				text="Barriers" de.text="Schranken"
@@ -3516,52 +3500,52 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				de.display_values="Halbschranke,Vollabschluss ('doppelte Halbschranke'),Vollschranke,Tore (England),Beschrankt,Unbeschrankt"
 				display_values="half boom gate,double half boom gate,full boom gate,gates (turnable),yes,no"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<check key="crossing:light"
 				text="Lights"
 				de.text="Warnlicht"
 				default="off"
-				delete_if_empty="true" />
+				/>
 			<check key="crossing:saltire"
 				text="Saltire"
 				de.text="Andreaskreuz"
 				default="off"
-				delete_if_empty="true" />
+				/>
 			<check key="crossing:bell"
 				text="Bell"
 				de.text="Akustischer Warnton"
 				default="off"
-				delete_if_empty="true" />
+				/>
 			<space />
 			<check key="crossing:chicane"
 				text="Chicane"
 				de.text="Umlaufgitter"
 				default="off"
-				delete_if_empty="true" />
+				/>
 			<combo key="crossing:supervision"
 				text="Type of supervision" de.text="Art der Überwachung"
 				values="no,camera,attendant,automatic,phone"
 				display_values="no,camera,attendant,automatic,phone"
 				de.display_values="keine Überwachung,Kamera,Schrankenwärter/Fahrdienstleiter/Posten,Gefahrenraum-Freimeldeanlage,Telefon (Anrufschranken)"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<combo key="crossing:activation"
 				text="Activation" de.text="Einschaltung"
 				values="automatic,remote,local"
 				display_values="automatic (contacts),remote (signal box), local (attendant/train staff)"
 				de.display_values="Einschaltkontakte, fahrdienstleitergesteuert, vor Ort (Schrankenwärter/Zugpersonal)"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<text key="railway:level_crossing:closure:average"
 				text="average clousure duration (minutes)"
 				de.text="durchschnittliche Schließdauer (in Minuten)"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<check key="crossing:on_demand"
 				text="On demand"
 				de.text="Anrufschranke"
 				default="off"
-				delete_if_empty="true" />
+				/>
 		</item>
 		<separator />
 		<item name="Kilo-/Hektometertafel" icon="milestone.png" type="node">
@@ -3580,29 +3564,29 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				text="Distance indication (rounded, e.g. '12.3'; km)"
 				de.text="Hektometerwert (z. B. '12.3')"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<text key="railway:position:exact"
 				text="Exact distance indication (exact, e.g. '12.345'; km)"
 				de.text="Metergenauer Wert (z. B. '12.345')"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<check key="railway:milestone:catenary_mast"
 				text="On catenary mast"
 				de.text="Am Oberleitungsmast"
 				default="off"
-				delete_if_empty="true" />
+				/>
 			<check key="railway:milestone:emergency_brake_override"
 				text="Emergency brake override"
 				de.text="Notbremsüberbrückung (NBÜ)"
 				default="off"
-				delete_if_empty="true" />
+				/>
 			<combo key="railway:milestone:emergency_brake_override:direction"
 				text="Direction of emergency brake override (if existing)"
 				de.text="Richtung der Notbremsunterdrückung (falls vorhanden)"
 				values="forward,backward,both"
 				display_values="In Wegrichtung,Entgegen Wegrichtung,Beide Richtungen"
 				default=""
-				delete_if_empty="true" />
+				/>
 		</item>
 		<item name="Bahnsteig" icon="platform.png" type="way,closedway">
 			<label text="Bahnsteig" />
@@ -3612,34 +3596,34 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				text="Caption"
 				de.text="Beschriftung"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<text key="ref"
 				text="Platform number(s)"
 				de.text="Bahnsteignummer(n)"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<check key="area"
 				text="Area"
 				de.text="Fläche"
 				default="off"
-				delete_if_empty="true" />
+				/>
 			<check key="lit"
 				text="Lit"
 				de.text="Beleuchtet"
 				default="off"
-				delete_if_empty="true" />
+				/>
 			<check key="covered"
 				text="Covered"
 				de.text="Überdacht"
 				default="off"
-				delete_if_empty="true" />
+				/>
 			<combo key="surface"
 				text="Surface"
 				de.text="Oberfläche"
 				values="asphalt,paving_stones,concrete,cobblestone,compacted,paved,unpaved"
 				display_values="Asphalt,Pflastersteine,Beton,Kopfsteinpflaster,Verdichtet,Befestigt,Unbefestigt"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<key key="public_transport"
 				value="platform" />
 			<combo key="wheelchair"
@@ -3648,39 +3632,39 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				values="yes,no,limited"
 				display_values="Ja,Nein,Eingeschränkt"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<combo key="tactile_paving"
 				text="Tactile Paving"
 				de.text="Ertastbarer Untergrund"
 				values="yes,no,incorrect"
 				display_values="Ja,Nein,Ja (aber nicht sinnvoll)"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<text key="height"
 				text="Platform height (in meters, e. g. 0.76)"
 				de.text="Bahnsteighöhe (in Metern, z. B. 0.76)"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<check key="train"
 				text="Railway traffic?"
 				de.text="Eisenbahnverkehr?"
 				default="off"
-				delete_if_empty="true" />
+				/>
 			<check key="light_rail"
 				text="Light rail traffic?"
 				de.text="Stadtbahn- oder Schnellbahn-Verkehr?"
 				default="off"
-				delete_if_empty="true" />
+				/>
 			<check key="subway"
 				text="Subway traffic?"
 				de.text="U-Bahn-Verkehr?"
 				default="off"
-				delete_if_empty="true" />
+				/>
 			<check key="tram"
 				text="Tram traffic?"
 				de.text="Straßenbahnverkehr?"
 				default="off"
-				delete_if_empty="true" />
+				/>
 		</item>
 		<item name="Fahrkartenschalter" icon="ticketshop.png" type="node">
 			<label text="Fahrkartenschalter" />
@@ -3691,17 +3675,17 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				text="Operator (e.g. 'ÖBB-Personenverkehr AG')"
 				de.text="Betreiber (z. B. 'ÖBB-Personenverkehr AG')"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<text key="name"
 				text="Name (e.g. 'Reisezentrum')"
 				de.text="Name (z. B. 'Reisezentrum')"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<text key="opening_hours"
 				text="Opening hours"
 				de.text="Öffnungszeiten"
 				default=""
-				delete_if_empty="true" />
+				/>
 		</item>
 		<item name="U-Bahn-Zugang" icon="landuse.png" type="node">
 			<label text="U-Bahn-Zugang" />
@@ -3711,19 +3695,19 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				text="Name"
 				de.text="Name"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<combo key="wheelchair"
 				text="Wheelchair"
 				de.text="Rollstuhlgerecht"
 				values="yes,no,limited"
 				display_values="Ja,Nein,Eingeschränkt"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<check key="bicycle"
 				text="Accessible with bicycles"
 				de.text="Passierbar mit Fahrrädern"
 				default="off"
-				delete_if_empty="true" />
+				/>
 		</item>
 		<item name="Bahnhofsgebäude" icon="train-station.png" type="closedway">
 			<label text="Bahnhofsgebäude" />
@@ -3734,17 +3718,17 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 				de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<text key="image"
 				text="Image URL"
 				de.text="URL eines Bildes"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<text key="ele"
 				text="Height above sea level (m)"
 				de.text="Höhe über Meeresspiegel (m)"
 				default=""
-				delete_if_empty="true" />
+				/>
 		</item>
 		<item name="Bahngelände" icon="landuse.png" type="closedway">
 			<label text="Bahngelände" />
@@ -3778,7 +3762,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				values="analogue,gsm-r"
 				display_values="Analog,GSM-R"
 				default=""
-				delete_if_empty="true" />
+				/>
 		</item>
 		<separator />
 		<item name="Grenzpunkt" icon="ownerchange.png" type="node">
@@ -3801,7 +3785,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Building"
 					de.text="Gebäude"
 					default="off"
-					delete_if_empty="true" />
+					/>
 			</item>
 			<item name="Wasserkran" icon="water-crane.png" type="node">
 				<label text="Wasserkran" />
@@ -3826,7 +3810,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Area"
 					de.text="Fläche"
 					default="off"
-					delete_if_empty="true" />
+					/>
 			</item>
 			<item name="Waschanlage" icon="wash.png" type="node,closedway">
 				<label text="Waschanlage" />
@@ -3836,7 +3820,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Building"
 					de.text="Gebäude"
 					default="off"
-					delete_if_empty="true" />
+					/>
 			</item>
 			<item name="Lokgrube" icon="pit.png" type="node">
 				<label text="Lokgrube" />
@@ -3851,12 +3835,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Building"
 					de.text="Gebäude"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<text key="name"
 					text="Name"
 					de.text="Name"
 					default=""
-					delete_if_empty="true" />
+					/>
 			</item>
 			<item name="Werkstatt" icon="workshop.png" type="node,closedway">
 				<label text="Werkstatt" />
@@ -3866,12 +3850,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Building"
 					de.text="Gebäude"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<text key="name"
 					text="Name"
 					de.text="Name"
 					default=""
-					delete_if_empty="true" />
+					/>
 			</item>
 		</group>
 		<group name="Verladeeinrichtungen" icon="loading.png">
@@ -3898,34 +3882,34 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Name"
 					de.text="Name"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<check key="lit"
 					text="Lit"
 					de.text="Beleuchtung"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="surface"
 					text="Surface"
 					de.text="Oberfläche"
 					values="asphalt,paving_stones,concrete,cobblestone,compacted,paved,unpaved"
 					display_values="Asphalt,Pflastersteine,Beton,Kopfsteinpflaster,Verdichtet,Befestigt,Unbefestigt"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="height"
 					text="Ramp height (m) - 0 for loading streets"
 					de.text="Rampenhöhe (m) - bei Ladestraße 0 eintragen"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<check key="area"
 					text="Area"
 					de.text="Fläche"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<text key="operator"
 					text="Operator (e.g. 'ÖBB-Infrastruktur AG')"
 					de.text="Betreiber (z. B. 'ÖBB-Infrastruktur AG')"
 					default=""
-					delete_if_empty="true" />
+					/>
 			</item>
 			<separator />
 			<item name="Eisenbahnfährverladestelle" icon="ferry-terminal.png" type="node">
@@ -3938,22 +3922,22 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Name"
 					de.text="Name"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="uic_ref"
 					text="UIC-ID"
 					de.text="UIC-Bahnhofsnummer"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="uic_name"
 					text="UIC name"
 					de.text="UIC-Bahnhofsname"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="operator"
 					text="Operator"
 					de.text="Betreiber"
 					default=""
-					delete_if_empty="true" />
+					/>
 			</item>
 			<item name="Eisenbahnfährverlauf" icon="ferry-way.png" type="way">
 				<label text="Eisenbahnfährverlauf" />
@@ -3965,12 +3949,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Name"
 					de.text="Name"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="operator"
 					text="Operator"
 					de.text="Betreiber"
 					default=""
-					delete_if_empty="true" />
+					/>
 			</item>
 			<item name="Eisenbahnfährlinie" icon="ferry-line.png" type="relation">
 				<label text="Eisenbahnfährlinie" />
@@ -3984,12 +3968,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Name"
 					de.text="Name"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="operator"
 					text="Operator"
 					de.text="Betreiber"
 					default=""
-					delete_if_empty="true" />
+					/>
 			</item>
 			<separator />
 			<item name="Container-Umschlagbahnhof" icon="containerterminal.png" type="node,closedway">
@@ -4005,12 +3989,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Name"
 					de.text="Name"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="wikipedia"
 					text="Wikipedia article in the format (Language):(Article)"
 					de.text="Wikipediaartikel in der Form (Sprachkürzel):(Artikelname)"
 					default=""
-					delete_if_empty="true" />
+					/>
 			</item>
 			<item name="Rollwagenverladung" icon="carrier-truck-pit.png" type="node">
 				<label text="Rollwagenverladung" />
@@ -4026,32 +4010,32 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Name"
 					de.text="Name"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="operator"
 					text="Operator"
 					de.text="Betreiber"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="uic_ref"
 					text="UIC-ID"
 					de.text="UIC-Bahnhofsnummer"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="uic_name"
 					text="UIC name"
 					de.text="UIC-Bahnhofsname"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="network"
 					text="Network"
 					de.text="Verkehrsverbund"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="image"
 					text="Image URL"
 					de.text="URL eines Bildes"
 					default=""
-					delete_if_empty="true" />
+					/>
 			</item>
 			<item name="Autozug-Verladung" icon="carshuttle.png" type="node">
 				<label text="Autozug-Verladung" />
@@ -4062,32 +4046,32 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Name"
 					de.text="Name"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="operator"
 					text="Operator"
 					de.text="Betreiber"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="uic_ref"
 					text="UIC-ID"
 					de.text="UIC-Bahnhofsnummer"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="uic_name"
 					text="UIC name"
 					de.text="UIC-Bahnhofsname"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="network"
 					text="Network"
 					de.text="Verkehrsverbund"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="image"
 					text="Image URL"
 					de.text="URL eines Bildes"
 					default=""
-					delete_if_empty="true" />
+					/>
 			</item>
 		</group>
 		<item name="Drehscheibe" icon="turntable.png" type="node,closedway">
@@ -4126,12 +4110,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				text="Name"
 				de.text="Name"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<text key="wikipedia"
 				text="Wikipedia article in the format (Language):(Article)"
 				de.text="Wikipediaartikel in der Form (Sprachkürzel):(Artikelname)"
 				default=""
-				delete_if_empty="true" />
+				/>
 		</item>
 		<item name="Firma mit Gleisanschluss" icon="industrial.png" type="closedway">
 			<label text="Firma mit Gleisanschluss" />
@@ -4143,7 +4127,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				text="Name"
 				de.text="Name"
 				default=""
-				delete_if_empty="true" />
+				/>
 		</item>
 		<item name="Tor" icon="gate.png" type="node">
 			<label text="Gate" de.text="Tor" />

--- a/josm-presets/de-avg-signals.xml
+++ b/josm-presets/de-avg-signals.xml
@@ -23,26 +23,26 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				text="Signal ref"
 				de.text="Signalbezeichnung"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<check key="railway:signal:main:deactivated"
 				text="Out of order"
 				de.text="Ungültigkeitskreuz"
 				default="off"
-				delete_if_empty="true" />
+				/>
 			<combo key="railway:signal:position"
 				text="Signal position"
 				de.text="Signalstandort"
 				values="left,right,bridge"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<combo key="railway:signal:direction"
 				text="Direction"
 				de.text="Anzeigerichtung"
 				values="forward,backward"
 				display_values="In Wegrichtung,Entgegen Wegrichtung"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<space />
 			<key key="railway:signal:main"
 				value="DE-ESO:hp" />
@@ -54,7 +54,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				values="normal,dwarf"
 				display_values="Mastbauform,Zwergsignal"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<key key="railway:signal:main:states"
 				value="DE-ESO:hp0;DE-ESO:hp1;DE-AVG:hp2" />
 			<key key="railway:signal:main:function" 
@@ -65,7 +65,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				delimiter=";"
 				values="DE-ESO:db:zs1;DE-ESO:db:zs7;DE-ESO:db:zs12"
 				display_values="Ersatzsignal (ex-DB);Vorsichtsignal;M-Tafel"
-				delete_if_empty="true" />
+				/>
 			<space />
 			<preset_link preset_name="Geschwindigkeitsanzeiger (Zs 3)" />
 			<preset_link preset_name="Sh-1-Licht" />
@@ -82,21 +82,21 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				text="Out of order"
 				de.text="Ungültigkeitskreuz"
 				default="off"
-				delete_if_empty="true" />
+				/>
 			<combo key="railway:signal:position"
 				text="Signal position"
 				de.text="Signalstandort"
 				values="left,right,bridge"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<combo key="railway:signal:direction"
 				text="Direction"
 				de.text="Anzeigerichtung"
 				values="forward,backward"
 				display_values="In Wegrichtung,Entgegen Wegrichtung"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<space />
 			<key key="railway:signal:distant"
 				value="DE-AVG:vf1" />
@@ -106,7 +106,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				text="Shortened distance"
 				de.text="Verkürzter Bremsweg"
 				default="off"
-				delete_if_empty="true" />
+				/>
 		</item>
 		<separator />
 		<item name="Bü-Überwachungssignal (Bü 200/Bü 201)" type="node">
@@ -119,21 +119,21 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				text="Out of order"
 				de.text="Ungültigkeitskreuz"
 				default="off"
-				delete_if_empty="true" />
+				/>
 			<combo key="railway:signal:position"
 				text="Signal position"
 				de.text="Signalstandort"
 				values="left,right,bridge"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<combo key="railway:signal:direction"
 				text="Direction"
 				de.text="Anzeigerichtung"
 				values="forward,backward"
 				display_values="In Wegrichtung,Entgegen Wegrichtung"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<space />
 			<key key="railway:signal:crossing"
 				value="DE-AVG:bü200" />
@@ -152,21 +152,21 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				text="Out of order"
 				de.text="Ungültigkeitskreuz"
 				default="off"
-				delete_if_empty="true" />
+				/>
 			<combo key="railway:signal:position"
 				text="Signal position"
 				de.text="Signalstandort"
 				values="left,right,bridge,overhead"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke,Oberleitung"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<combo key="railway:signal:direction"
 				text="Direction"
 				de.text="Anzeigerichtung"
 				values="forward,backward"
 				display_values="In Wegrichtung,Entgegen Wegrichtung"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<space />
 			<key key="railway:signal:crossing_distant"
 				value="DE-AVG:bü200v" />
@@ -186,26 +186,26 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				text="Signal ref"
 				de.text="Signalbezeichnung"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<check key="railway:signal:main:deactivated"
 				text="Out of order"
 				de.text="Ungültigkeitskreuz"
 				default="off"
-				delete_if_empty="true" />
+				/>
 			<combo key="railway:signal:position"
 				text="Signal position"
 				de.text="Signalstandort"
 				values="left,right,bridge"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<combo key="railway:signal:direction"
 				text="Direction"
 				de.text="Anzeigerichtung"
 				values="forward,backward"
 				display_values="In Wegrichtung,Entgegen Wegrichtung"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<space />
 			<key key="railway:signal:main"
 				value="DE-AVG:f" />
@@ -217,7 +217,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				values="normal,dwarf"
 				display_values="Mastbauform,Zwergsignal"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<key key="railway:signal:main:states"
 				value="DE-AVG:f0;DE-AVG:f1"/>
 			<check key="railway:signal:route"
@@ -230,7 +230,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				text="Possible track numbers"
 				de.text="Mögliche Gleisnummern"
 				default=""
-				delete_if_empty="true" />
+				/>
 		</item>
 		<item name="Weichensignal (BOStrab-Art)" icon="de/bostrab/w5-16.png" type="node">
 			<label text="Weichensignale (BOStrab-Art)" />
@@ -242,21 +242,21 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				text="Out of order"
 				de.text="Ungültigkeitskreuz"
 				default="off"
-				delete_if_empty="true" />
+				/>
 			<combo key="railway:signal:position"
 				text="Signal position"
 				de.text="Signalstandort"
 				values="left,right,overhead,bridge"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Oberleitung,Signalbrücke"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<combo key="railway:signal:direction"
 				text="Direction"
 				de.text="Anzeigerichtung"
 				values="forward,backward"
 				display_values="In Wegrichtung,Entgegen Wegrichtung"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<space />
 			<key key="railway:signal:switch"
 				value="DE-AVG:w" />
@@ -268,14 +268,14 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				delimiter=";"
 				values="DE-AVG:w1;DE-AVG:w2;DE-AVG:w3;DE-AVG:w4;DE-AVG:w5;DE-AVG:w11;DE-AVG:w12;DE-AVG:w13 "
 				de.display_values="geradeaus 30 km/h;rechts 30 km/h;links 30 km/h;Störung;Weiche stellbereit;geradeaus (vmax);rechts;links"
-				delete_if_empty="true" />
+				/>
 			<combo key="railway:signal:switch:height"
 				text="Signal height"
 				de.text="Signalbauform"
 				values="normal,dwarf"
 				default=""
 				display_values="Mastbauform,Zwergsignal"
-				delete_if_empty="true" />
+				/>
 		</item>
 		<item name="Weichenvorrücksignal (Wv)" type="node">
 			<label text="Weichenvorrücksignal (Wv)" />
@@ -287,21 +287,21 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				text="Out of order"
 				de.text="Ungültigkeitskreuz"
 				default="off"
-				delete_if_empty="true" />
+				/>
 			<combo key="railway:signal:position"
 				text="Signal position"
 				de.text="Signalstandort"
 				values="left,right,overhead,bridge"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Oberleitung,Signalbrücke"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<combo key="railway:signal:direction"
 				text="Direction"
 				de.text="Anzeigerichtung"
 				values="forward,backward"
 				display_values="In Wegrichtung,Entgegen Wegrichtung"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<space />
 			<key key="railway:signal:switch"
 				value="DE-AVG:wv" />
@@ -315,7 +315,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				values="normal,dwarf"
 				default=""
 				display_values="Mastbauform,Zwergsignal"
-				delete_if_empty="true" />
+				/>
 		</item>
 		<separator />
 		<item name="Streckentrenner (El 1, St 7)" type="node">
@@ -328,21 +328,21 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				text="Out of order"
 				de.text="Ungültigkeitskreuz"
 				default="off"
-				delete_if_empty="true" />
+				/>
 			<combo key="railway:signal:position"
 				text="Signal position"
 				de.text="Signalstandort"
 				values="left,right,overhead"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Oberleitung"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<combo key="railway:signal:direction"
 				text="Direction"
 				de.text="Anzeigerichtung"
 				values="forward,backward"
 				display_values="In Wegrichtung,Entgegen Wegrichtung"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<space />
 			<combo key="railway:signal:electricity"
 				text="Exact type"
@@ -350,14 +350,14 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				values="DE-AVG:el1,DE-AVG:st7"
 				display_values="Ausschaltsignal (El 1) ohne darauf folgendes Einschaltsignal (El 2),Streckentrenner (St 7)"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<combo key="railway:signal:electricity:height"
 				text="Signal height"
 				de.text="Signalbauform"
 				values="normal,dwarf"
 				default=""
 				display_values="Mastbauform,Zwergsignal"
-				delete_if_empty="true" />
+				/>
 			<key key="railway:signal:electricity:type"
 				value="power_off_shortly"/>
 			<key key="railway:signal:electricity:form"
@@ -374,21 +374,21 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				text="Out of order"
 				de.text="Ungültigkeitskreuz"
 				default="off"
-				delete_if_empty="true" />
+				/>
 			<combo key="railway:signal:position"
 				text="Signal position"
 				de.text="Signalstandort"
 				values="left,right,bridge"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<combo key="railway:signal:direction"
 				text="Direction"
 				de.text="Anzeigerichtung"
 				values="forward,backward"
 				display_values="In Wegrichtung,Entgegen Wegrichtung"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<key key="railway:signal:request"
 				value="DE-AVG:st9" />
 			<key key="railway:signal:request:states"
@@ -407,21 +407,21 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				text="Out of order"
 				de.text="Ungültigkeitskreuz"
 				default="off"
-				delete_if_empty="true" />
+				/>
 			<combo key="railway:signal:position"
 				text="Signal position"
 				de.text="Signalstandort"
 				values="left,right,bridge"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<combo key="railway:signal:direction"
 				text="Direction"
 				de.text="Anzeigerichtung"
 				values="forward,backward"
 				display_values="In Wegrichtung,Entgegen Wegrichtung,"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<key key="railway:signal:departure"
 				value="DE-AVG:a1" />
 			<key key="railway:signal:departure:states"
@@ -440,21 +440,21 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				text="Out of order"
 				de.text="Ungültigkeitskreuz"
 				default="off"
-				delete_if_empty="true" />
+				/>
 			<combo key="railway:signal:position"
 				text="Signal position"
 				de.text="Signalstandort"
 				values="left,right,bridge"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<combo key="railway:signal:direction"
 				text="Direction"
 				de.text="Anzeigerichtung"
 				values="forward,backward"
 				display_values="In Wegrichtung,Entgegen Wegrichtung,"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<key key="railway:signal:train_protection"
 				value="DE-AVG:so1" />
 			<key key="railway:signal:train_protection:type"
@@ -472,21 +472,21 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				text="Out of order"
 				de.text="Ungültigkeitskreuz"
 				default="off"
-				delete_if_empty="true" />
+				/>
 			<combo key="railway:signal:position"
 				text="Signal position"
 				de.text="Signalstandort"
 				values="left,right,bridge"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<combo key="railway:signal:direction"
 				text="Direction"
 				de.text="Anzeigerichtung"
 				values="forward,backward"
 				display_values="In Wegrichtung,Entgegen Wegrichtung,"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<key key="railway:signal:train_protection"
 				value="DE-AVG:so2" />
 			<key key="railway:signal:train_protection:type"
@@ -504,21 +504,21 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				text="Out of order"
 				de.text="Ungültigkeitskreuz"
 				default="off"
-				delete_if_empty="true" />
+				/>
 			<combo key="railway:signal:position"
 				text="Signal position"
 				de.text="Signalstandort"
 				values="left,right,bridge"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<combo key="railway:signal:direction"
 				text="Direction"
 				de.text="Anzeigerichtung"
 				values="forward,backward"
 				display_values="In Wegrichtung,Entgegen Wegrichtung,"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<key key="railway:signal:loading_gauge"
 				value="DE-AVG:ra14" />
 			<key key="railway:signal:loading_gauge:form"
@@ -534,21 +534,21 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				text="Out of order"
 				de.text="Ungültigkeitskreuz"
 				default="off"
-				delete_if_empty="true" />
+				/>
 			<combo key="railway:signal:position"
 				text="Signal position"
 				de.text="Signalstandort"
 				values="left,right,bridge"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<combo key="railway:signal:direction"
 				text="Direction"
 				de.text="Anzeigerichtung"
 				values="forward,backward"
 				display_values="In Wegrichtung,Entgegen Wegrichtung,"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<key key="railway:signal:stop_demand"
 				value="DE-AVG:hw1" />
 			<key key="railway:signal:stop_demand:states"

--- a/josm-presets/de-avg-signals.xml
+++ b/josm-presets/de-avg-signals.xml
@@ -22,7 +22,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<text key="ref"
 				text="Signal ref"
 				de.text="Signalbezeichnung"
-				default=""
 				/>
 			<check key="railway:signal:main:deactivated"
 				text="Out of order"
@@ -34,14 +33,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				de.text="Signalstandort"
 				values="left,right,bridge"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
-				default=""
 				/>
 			<combo key="railway:signal:direction"
 				text="Direction"
 				de.text="Anzeigerichtung"
 				values="forward,backward"
 				display_values="In Wegrichtung,Entgegen Wegrichtung"
-				default=""
 				/>
 			<space />
 			<key key="railway:signal:main"
@@ -53,7 +50,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				de.text="Signalbauform"
 				values="normal,dwarf"
 				display_values="Mastbauform,Zwergsignal"
-				default=""
 				/>
 			<key key="railway:signal:main:states"
 				value="DE-ESO:hp0;DE-ESO:hp1;DE-AVG:hp2" />
@@ -88,14 +84,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				de.text="Signalstandort"
 				values="left,right,bridge"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
-				default=""
 				/>
 			<combo key="railway:signal:direction"
 				text="Direction"
 				de.text="Anzeigerichtung"
 				values="forward,backward"
 				display_values="In Wegrichtung,Entgegen Wegrichtung"
-				default=""
 				/>
 			<space />
 			<key key="railway:signal:distant"
@@ -125,14 +119,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				de.text="Signalstandort"
 				values="left,right,bridge"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
-				default=""
 				/>
 			<combo key="railway:signal:direction"
 				text="Direction"
 				de.text="Anzeigerichtung"
 				values="forward,backward"
 				display_values="In Wegrichtung,Entgegen Wegrichtung"
-				default=""
 				/>
 			<space />
 			<key key="railway:signal:crossing"
@@ -158,14 +150,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				de.text="Signalstandort"
 				values="left,right,bridge,overhead"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke,Oberleitung"
-				default=""
 				/>
 			<combo key="railway:signal:direction"
 				text="Direction"
 				de.text="Anzeigerichtung"
 				values="forward,backward"
 				display_values="In Wegrichtung,Entgegen Wegrichtung"
-				default=""
 				/>
 			<space />
 			<key key="railway:signal:crossing_distant"
@@ -185,7 +175,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<text key="ref"
 				text="Signal ref"
 				de.text="Signalbezeichnung"
-				default=""
 				/>
 			<check key="railway:signal:main:deactivated"
 				text="Out of order"
@@ -197,14 +186,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				de.text="Signalstandort"
 				values="left,right,bridge"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
-				default=""
 				/>
 			<combo key="railway:signal:direction"
 				text="Direction"
 				de.text="Anzeigerichtung"
 				values="forward,backward"
 				display_values="In Wegrichtung,Entgegen Wegrichtung"
-				default=""
 				/>
 			<space />
 			<key key="railway:signal:main"
@@ -216,7 +203,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				de.text="Signalbauform"
 				values="normal,dwarf"
 				display_values="Mastbauform,Zwergsignal"
-				default=""
 				/>
 			<key key="railway:signal:main:states"
 				value="DE-AVG:f0;DE-AVG:f1"/>
@@ -225,11 +211,10 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				de.text="Anzeige einer Gleisnummer?"
 				value_on="DE-AVG:f1"
 				value_off=""
-				default="" />
+				/>
 			<text key="railway:signal:route:states"
 				text="Possible track numbers"
 				de.text="Mögliche Gleisnummern"
-				default=""
 				/>
 		</item>
 		<item name="Weichensignal (BOStrab-Art)" icon="de/bostrab/w5-16.png" type="node">
@@ -248,14 +233,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				de.text="Signalstandort"
 				values="left,right,overhead,bridge"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Oberleitung,Signalbrücke"
-				default=""
 				/>
 			<combo key="railway:signal:direction"
 				text="Direction"
 				de.text="Anzeigerichtung"
 				values="forward,backward"
 				display_values="In Wegrichtung,Entgegen Wegrichtung"
-				default=""
 				/>
 			<space />
 			<key key="railway:signal:switch"
@@ -273,7 +256,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				text="Signal height"
 				de.text="Signalbauform"
 				values="normal,dwarf"
-				default=""
 				display_values="Mastbauform,Zwergsignal"
 				/>
 		</item>
@@ -293,14 +275,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				de.text="Signalstandort"
 				values="left,right,overhead,bridge"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Oberleitung,Signalbrücke"
-				default=""
 				/>
 			<combo key="railway:signal:direction"
 				text="Direction"
 				de.text="Anzeigerichtung"
 				values="forward,backward"
 				display_values="In Wegrichtung,Entgegen Wegrichtung"
-				default=""
 				/>
 			<space />
 			<key key="railway:signal:switch"
@@ -313,7 +293,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				text="Signal height"
 				de.text="Signalbauform"
 				values="normal,dwarf"
-				default=""
 				display_values="Mastbauform,Zwergsignal"
 				/>
 		</item>
@@ -334,14 +313,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				de.text="Signalstandort"
 				values="left,right,overhead"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Oberleitung"
-				default=""
 				/>
 			<combo key="railway:signal:direction"
 				text="Direction"
 				de.text="Anzeigerichtung"
 				values="forward,backward"
 				display_values="In Wegrichtung,Entgegen Wegrichtung"
-				default=""
 				/>
 			<space />
 			<combo key="railway:signal:electricity"
@@ -349,13 +326,11 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				de.text="Signaltyp"
 				values="DE-AVG:el1,DE-AVG:st7"
 				display_values="Ausschaltsignal (El 1) ohne darauf folgendes Einschaltsignal (El 2),Streckentrenner (St 7)"
-				default=""
 				/>
 			<combo key="railway:signal:electricity:height"
 				text="Signal height"
 				de.text="Signalbauform"
 				values="normal,dwarf"
-				default=""
 				display_values="Mastbauform,Zwergsignal"
 				/>
 			<key key="railway:signal:electricity:type"
@@ -380,14 +355,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				de.text="Signalstandort"
 				values="left,right,bridge"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
-				default=""
 				/>
 			<combo key="railway:signal:direction"
 				text="Direction"
 				de.text="Anzeigerichtung"
 				values="forward,backward"
 				display_values="In Wegrichtung,Entgegen Wegrichtung"
-				default=""
 				/>
 			<key key="railway:signal:request"
 				value="DE-AVG:st9" />
@@ -413,14 +386,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				de.text="Signalstandort"
 				values="left,right,bridge"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
-				default=""
 				/>
 			<combo key="railway:signal:direction"
 				text="Direction"
 				de.text="Anzeigerichtung"
 				values="forward,backward"
 				display_values="In Wegrichtung,Entgegen Wegrichtung,"
-				default=""
 				/>
 			<key key="railway:signal:departure"
 				value="DE-AVG:a1" />
@@ -446,14 +417,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				de.text="Signalstandort"
 				values="left,right,bridge"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
-				default=""
 				/>
 			<combo key="railway:signal:direction"
 				text="Direction"
 				de.text="Anzeigerichtung"
 				values="forward,backward"
 				display_values="In Wegrichtung,Entgegen Wegrichtung,"
-				default=""
 				/>
 			<key key="railway:signal:train_protection"
 				value="DE-AVG:so1" />
@@ -478,14 +447,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				de.text="Signalstandort"
 				values="left,right,bridge"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
-				default=""
 				/>
 			<combo key="railway:signal:direction"
 				text="Direction"
 				de.text="Anzeigerichtung"
 				values="forward,backward"
 				display_values="In Wegrichtung,Entgegen Wegrichtung,"
-				default=""
 				/>
 			<key key="railway:signal:train_protection"
 				value="DE-AVG:so2" />
@@ -510,14 +477,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				de.text="Signalstandort"
 				values="left,right,bridge"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
-				default=""
 				/>
 			<combo key="railway:signal:direction"
 				text="Direction"
 				de.text="Anzeigerichtung"
 				values="forward,backward"
 				display_values="In Wegrichtung,Entgegen Wegrichtung,"
-				default=""
 				/>
 			<key key="railway:signal:loading_gauge"
 				value="DE-AVG:ra14" />
@@ -540,14 +505,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				de.text="Signalstandort"
 				values="left,right,bridge"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
-				default=""
 				/>
 			<combo key="railway:signal:direction"
 				text="Direction"
 				de.text="Anzeigerichtung"
 				values="forward,backward"
 				display_values="In Wegrichtung,Entgegen Wegrichtung,"
-				default=""
 				/>
 			<key key="railway:signal:stop_demand"
 				value="DE-AVG:hw1" />

--- a/josm-presets/de-signals-eso.xml
+++ b/josm-presets/de-signals-eso.xml
@@ -24,26 +24,26 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						text="Signal ref"
 						de.text="Signalbezeichnung"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<check key="railway:signal:distant:deactivated"
 						text="Out of order"
 						de.text="Ungültigkeitskreuz"
 						default="off"
-						delete_if_empty="true" />
+						/>
 					<combo key="railway:signal:position"
 						text="Signal position"
 						de.text="Signalstandort"
 						values="left,right,bridge"
 						display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<combo key="railway:signal:direction"
 						text="Direction"
 						de.text="Anzeigerichtung"
 						values="forward,backward"
 						display_values="In Wegrichtung,Entgegen Wegrichtung"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<space />
 					<key key="railway:signal:distant"
 						value="DE-ESO:ks" />
@@ -55,11 +55,10 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						values="normal,dwarf"
 						display_values="Mastbauform,Zwergsignal"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<combo key="railway:signal:distant:states" default="DE-ESO:ks1;DE-ESO:ks2"
 						text="Signal states"
 						de.text="Signalzustände"
-						delete_if_empty="true"
 						delimiter="|"
 						values="DE-ESO:ks1;DE-ESO:ks2|DE-ESO:ks1;DE-ESO:ks2;DE-ESO:kennlicht|DE-ESO:ks1;DE-ESO:ks2;off|DE-ESO:ks2"
 						de.display_values="Ks 1 und Ks 2|Ks 1, Ks 2 und Kennlicht|Ks 1, Ks 2 und Dunkelschaltung|ausschließlich Ks 2 (gelbes Licht, exotisches Signal)"
@@ -68,12 +67,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						text="Shortened distance"
 						de.text="Verkürzter Bremsweg"
 						default="off"
-						delete_if_empty="true" />
+						/>
 					<check key="railway:signal:distant:repeated"
 						text="Repeated Signal"
 						de.text="Vorsignalwiederholer"
 						default="off"
-						delete_if_empty="true" />
+						/>
 					<space />
 					<preset_link preset_name="Richtungsvoranzeiger (Zs 2v)" />
 					<preset_link preset_name="Geschwindigkeitsvoranzeiger (Zs 3v)" />
@@ -89,26 +88,26 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						text="Signal ref"
 						de.text="Signalbezeichnung"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<check key="railway:signal:combined:deactivated"
 						text="Out of order"
 						de.text="Ungültigkeitskreuz"
 						default="off"
-						delete_if_empty="true" />
+						/>
 					<combo key="railway:signal:position"
 						text="Signal position"
 						de.text="Signalstandort"
 						values="left,right,bridge"
 						display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<combo key="railway:signal:direction"
 						text="Direction"
 						de.text="Anzeigerichtung"
 						values="forward,backward"
 						display_values="In Wegrichtung,Entgegen Wegrichtung"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<space />
 					<key key="railway:signal:combined"
 						value="DE-ESO:ks" />
@@ -120,11 +119,10 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						values="normal,dwarf"
 						display_values="Mastbauform,Zwergsignal"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<combo key="railway:signal:combined:states" default="DE-ESO:hp0;DE-ESO:ks1;DE-ESO:ks2"
 						text="Signal states"
 						de.text="Signalzustände"
-						delete_if_empty="true"
 						delimiter="|"
 						values="DE-ESO:hp0;DE-ESO:ks1;DE-ESO:ks2|DE-ESO:hp0;DE-ESO:ks1;DE-ESO:ks2;DE-ESO:kennlicht|DE-ESO:hp0;DE-ESO:ks1;DE-ESO:ks2;off|DE-ESO:hp0;DE-ESO:ks2"
 						de.display_values="Hp 0, Ks 1 und Ks 2|Hp 0, Ks 1, Ks 2 und Kennlicht|Hp 0, Ks 1, Ks 2 und Dunkelschaltung|nur Hp 0 (Halt) und Ks 2 (Halt erwarten)"
@@ -133,21 +131,21 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						text="Shortened distance"
 						de.text="Verkürzter Bremsweg"
 						default="off"
-						delete_if_empty="true" />
+						/>
 					<combo key="railway:signal:combined:function"
 						text="Signal function"
 						de.text="Signalaufgabe"
 						values="entry,exit,block,intermediate"
 						display_values="Einfahrsignal,Ausfahrsignal,Blocksignal,Zwischensignal"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<multiselect key="railway:signal:combined:substitute_signal"
 						text="Substitute signal (multi-selection)"
 						de.text="Ersatzsignal (Mehrfachauswahl)"
 						delimiter=";"
 						values="DE-ESO:dr:zs1;DE-ESO:db:zs7;DE-ESO:db:zs12"
 						display_values="Ersatzsignal;Vorsichtsignal;M-Tafel"
-						delete_if_empty="true" />
+						/>
 					<space />
 					<preset_link preset_name="Richtungsanzeiger (Zs 2)" />
 					<preset_link preset_name="Richtungsvoranzeiger (Zs 2v)" />
@@ -169,26 +167,26 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						text="Signal ref"
 						de.text="Signalbezeichnung"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<check key="railway:signal:main:deactivated"
 						text="Out of order"
 						de.text="Ungültigkeitskreuz"
 						default="off"
-						delete_if_empty="true" />
+						/>
 					<combo key="railway:signal:position"
 						text="Signal position"
 						de.text="Signalstandort"
 						values="left,right,bridge"
 						display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<combo key="railway:signal:direction"
 						text="Direction"
 						de.text="Anzeigerichtung"
 						values="forward,backward"
 						display_values="In Wegrichtung,Entgegen Wegrichtung"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<space />
 					<key key="railway:signal:main"
 						value="DE-ESO:ks" />
@@ -200,11 +198,10 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						values="normal,dwarf"
 						display_values="Mastbauform,Zwergsignal"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<combo key="railway:signal:main:states" default=""
 						text="Signal states"
 						de.text="Signalzustände"
-						delete_if_empty="true"
 						delimiter="|"
 						values="DE-ESO:hp0;DE-ESO:ks1|DE-ESO:hp0;DE-ESO:ks1;DE-ESO:kennlicht|DE-ESO:hp0;DE-ESO:ks1;off"
 						de.display_values="Hp 0 und Ks 1|Hp 0, Ks 1 und Kennlicht|Hp 0, Ks 1 und Dunkelschaltung"
@@ -215,14 +212,14 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						values="entry,exit,block,intermediate"
 						display_values="Einfahrsignal,Ausfahrsignal,Blocksignal,Zwischensignal"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<multiselect key="railway:signal:main:substitute_signal"
 						text="Substitute signal (multi-selection)"
 						de.text="Ersatzsignal (Mehrfachauswahl)"
 						delimiter=";"
 						values="DE-ESO:dr:zs1;DE-ESO:db:zs7;DE-ESO:db:zs12"
 						display_values="Ersatzsignal;Vorsichtsignal;M-Tafel"
-						delete_if_empty="true" />
+						/>
 					<space />
 					<preset_link preset_name="Richtungsanzeiger (Zs 2)" />
 					<preset_link preset_name="Geschwindigkeitsanzeiger (Zs 3)" />
@@ -243,26 +240,26 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Signal ref"
 					de.text="Signalbezeichnung"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<check key="railway:signal:combined:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
 					de.text="Signalstandort"
 					values="left,right,bridge"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:signal:direction"
 					text="Direction"
 					de.text="Anzeigerichtung"
 					values="forward,backward"
 					display_values="In Wegrichtung,Entgegen Wegrichtung"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<key key="railway:signal:combined"
 					value="DE-ESO:sv" />
@@ -274,7 +271,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="normal,dwarf"
 					display_values="Mastbauform,Zwergsignal"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<multiselect key="railway:signal:combined:states"
 					text="Signal states, Hamburg names (multi-selection)"
 					de.text="Signalzustände, Hamburger Kürzel (Mehrfachauswahl)"
@@ -282,26 +279,26 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="DE-ESO:hp0;DE-ESO:sv1;DE-ESO:sv2;DE-ESO:sv3;DE-ESO:sv4;DE-ESO:sv5;DE-ESO:sv6;DE-ESO:sv0;DE-ESO:kennlicht"
 					display_values="Hp 0;Sv 1;Sv 2;Sv 3;Sv 4;Sv 5;Sv 6;Sv 0;marker light"
 					de.display_values="Hp 0;Sv 1;Sv 2;Sv 3;Sv 4;Sv 5;Sv 6;Sv 0;Kennlicht"
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:signal:combined:function"
 					text="Signal function"
 					de.text="Signalaufgabe"
 					values="entry,exit,block,intermediate"
 					display_values="Einfahrsignal,Ausfahrsignal,Blocksignal,Zwischensignal"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<multiselect key="railway:signal:combined:substitute_signal"
 					text="Substitute signal (multi-selection)"
 					de.text="Ersatzsignal (Mehrfachauswahl)"
 					delimiter=";"
 					values="DE-ESO:dr:zs1;DE-ESO:db:zs7;DE-ESO:db:zs12"
 					display_values="Ersatzsignal;Vorsichtsignal;M-Tafel"
-					delete_if_empty="true" />
+					/>
 				<check key="railway:signal:distant:shortened"
 					text="Shortened distance"
 					de.text="Verkürzter Bremsweg (Weißer Bremspfeil)"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<space />
 				<preset_link preset_name="Richtungsanzeiger (Zs 2)" />
 				<preset_link preset_name="Richtungsvoranzeiger (Zs 2v)" />
@@ -324,26 +321,26 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						text="Signal ref"
 						de.text="Signalbezeichnung"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<check key="railway:signal:combined:deactivated"
 						text="Out of order"
 						de.text="Ungültigkeitskreuz"
 						default="off"
-						delete_if_empty="true" />
+						/>
 					<combo key="railway:signal:position"
 						text="Signal position"
 						de.text="Signalstandort"
 						values="left,right,bridge"
 						display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<combo key="railway:signal:direction"
 						text="Direction"
 						de.text="Anzeigerichtung"
 						values="forward,backward"
 						display_values="In Wegrichtung,Entgegen Wegrichtung"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<space />
 					<key key="railway:signal:combined"
 						value="DE-ESO:hl" />
@@ -355,7 +352,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						values="normal,dwarf"
 						display_values="Mastbauform,Zwergsignal"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<multiselect key="railway:signal:combined:states"
 						text="Signal states (multi-selection)"
 						de.text="Signalzustände (Mehrfachauswahl)"
@@ -369,14 +366,14 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						values="entry,exit,block,intermediate"
 						display_values="Einfahrsignal,Ausfahrsignal,Blocksignal,Zwischensignal"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<multiselect key="railway:signal:combined:substitute_signal"
 						text="Substitute signal (multi-selection)"
 						de.text="Ersatzsignal (Mehrfachauswahl)"
 						delimiter=";"
 						values="DE-ESO:dr:zs1;DE-ESO:db:zs12"
 						display_values="Ersatzsignal;M-Tafel"
-						delete_if_empty="true" />
+						/>
 					<space />
 					<preset_link preset_name="Richtungsanzeiger (Zs 2)" />
 					<preset_link preset_name="Richtungsvoranzeiger (Zs 2v)" />
@@ -396,26 +393,26 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						text="Signal ref"
 						de.text="Signalbezeichnung"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<check key="railway:signal:main:deactivated"
 						text="Out of order"
 						de.text="Ungültigkeitskreuz"
 						default="off"
-						delete_if_empty="true" />
+						/>
 					<combo key="railway:signal:position"
 						text="Signal position"
 						de.text="Signalstandort"
 						values="left,right,bridge"
 						display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<combo key="railway:signal:direction"
 						text="Direction"
 						de.text="Anzeigerichtung"
 						values="forward,backward"
 						display_values="In Wegrichtung,Entgegen Wegrichtung"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<space />
 					<key key="railway:signal:main"
 						value="DE-ESO:hl" />
@@ -427,7 +424,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						values="normal,dwarf"
 						display_values="Mastbauform,Zwergsignal"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<multiselect key="railway:signal:main:states"
 						text="Signal states (multi-selection)"
 						de.text="Signalzustände (Mehrfachauswahl)"
@@ -441,14 +438,14 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						values="entry,exit,block,intermediate"
 						display_values="Einfahrsignal,Ausfahrsignal,Blocksignal,Zwischensignal"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<multiselect key="railway:signal:main:substitute_signal"
 						text="Substitute signal (multi-selection)"
 						de.text="Ersatzsignal (Mehrfachauswahl)"
 						delimiter=";"
 						values="DE-ESO:dr:zs1;DE-ESO:db:zs12"
 						display_values="Ersatzsignal;M-Tafel"
-						delete_if_empty="true" />
+						/>
 					<space />
 					<preset_link preset_name="Richtungsanzeiger (Zs 2)" />
 					<preset_link preset_name="Geschwindigkeitsanzeiger (Zs 3)" />
@@ -468,26 +465,26 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						text="Signal ref"
 						de.text="Signalbezeichnung"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<check key="railway:signal:distant:deactivated"
 						text="Out of order"
 						de.text="Ungültigkeitskreuz"
 						default="off"
-						delete_if_empty="true" />
+						/>
 					<combo key="railway:signal:position"
 						text="Signal position"
 						de.text="Signalstandort"
 						values="left,right,bridge"
 						display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<combo key="railway:signal:direction"
 						text="Direction"
 						de.text="Anzeigerichtung"
 						values="forward,backward"
 						display_values="In Wegrichtung,Entgegen Wegrichtung"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<space />
 					<key key="railway:signal:distant"
 						value="DE-ESO:hl" />
@@ -504,7 +501,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						text="Repeated Signal"
 						de.text="Vorsignalwiederholer"
 						default="off"
-						delete_if_empty="true" />
+						/>
 					<check key="railway:signal:distant:shortened"
 						text="Shortened Breaking Distance"
 						de.text="Reduzierter Bremswegabstand"
@@ -524,26 +521,26 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						text="Signal ref"
 						de.text="Signalbezeichnung"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<check key="railway:signal:combined:deactivated"
 						text="Out of order"
 						de.text="Ungültigkeitskreuz"
 						default="off"
-						delete_if_empty="true" />
+						/>
 					<combo key="railway:signal:position"
 						text="Signal position"
 						de.text="Signalstandort"
 						values="left,right,bridge"
 						display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<combo key="railway:signal:direction"
 						text="Direction"
 						de.text="Anzeigerichtung"
 						values="forward,backward"
 						display_values="In Wegrichtung,Entgegen Wegrichtung"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<space />
 					<key key="railway:signal:combined"
 						value="DE-ESO:sk" />
@@ -555,11 +552,10 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						values="normal,dwarf"
 						display_values="Mastbauform,Zwergsignal"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<combo key="railway:signal:combined:states" default="DE-ESO:hp0;DE-ESO:sk1;DE-ESO:sk2"
 						text="Signal states"
 						de.text="Signalzustände"
-						delete_if_empty="true"
 						delimiter="|"
 						values="DE-ESO:hp0;DE-ESO:sk1;DE-ESO:sk2|DE-ESO:hp0;DE-ESO:sk1;DE-ESO:sk2;DE-ESO:kennlicht"
 						de.display_values="kein Kennlicht|Kennlicht möglich"
@@ -570,14 +566,14 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						values="entry,exit,block,intermediate"
 						display_values="Einfahrsignal,Ausfahrsignal,Blocksignal,Zwischensignal"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<multiselect key="railway:signal:combined:substitute_signal"
 						text="Substitute signal (multi-selection)"
 						de.text="Ersatzsignal (Mehrfachauswahl)"
 						delimiter=";"
 						values="DE-ESO:dr:zs1;DE-ESO:db:zs7"
 						display_values="Ersatzsignal;Vorsichtsignal"
-						delete_if_empty="true" />
+						/>
 					<space />
 					<preset_link preset_name="Geschwindigkeitsanzeiger (Zs 3)" />
 					<preset_link preset_name="Geschwindigkeitsvoranzeiger (Zs 3v)" />
@@ -599,26 +595,26 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						text="Signal ref"
 						de.text="Signalbezeichnung"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<check key="railway:signal:main:deactivated"
 						text="Out of order"
 						de.text="Ungültigkeitskreuz"
 						default="off"
-						delete_if_empty="true" />
+						/>
 					<combo key="railway:signal:position"
 						text="Signal position"
 						de.text="Signalstandort"
 						values="left,right,bridge"
 						display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<combo key="railway:signal:direction"
 						text="Direction"
 						de.text="Anzeigerichtung"
 						values="forward,backward"
 						display_values="In Wegrichtung,Entgegen Wegrichtung"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<space />
 					<key key="railway:signal:main"
 						value="DE-ESO:sk" />
@@ -630,11 +626,10 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						values="normal,dwarf"
 						display_values="Mastbauform,Zwergsignal"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<combo key="railway:signal:main:states" default="DE-ESO:hp0;DE-ESO:sk1"
 						text="Signal states"
 						de.text="Signalzustände"
-						delete_if_empty="true"
 						delimiter="|"
 						values="DE-ESO:hp0;DE-ESO:sk1|DE-ESO:hp0;DE-ESO:sk1;DE-ESO:kennlicht"
 						de.display_values="kein Kennlicht|Kennlicht möglich"
@@ -645,14 +640,14 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						values="entry,exit,block,intermediate"
 						display_values="Einfahrsignal,Ausfahrsignal,Blocksignal,Zwischensignal"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<multiselect key="railway:signal:main:substitute_signal"
 						text="Substitute signal (multi-selection)"
 						de.text="Ersatzsignal (Mehrfachauswahl)"
 						delimiter=";"
 						values="DE-ESO:dr:zs1;DE-ESO:db:zs7"
 						display_values="Ersatzsignal;Vorsichtsignal"
-						delete_if_empty="true" />
+						/>
 					<space />
 					<preset_link preset_name="Richtungsanzeiger (Zs 2)" />
 					<preset_link preset_name="Geschwindigkeitsanzeiger (Zs 3)" />
@@ -672,26 +667,26 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						text="Signal ref"
 						de.text="Signalbezeichnung"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<check key="railway:signal:distant:deactivated"
 						text="Out of order"
 						de.text="Ungültigkeitskreuz"
 						default="off"
-						delete_if_empty="true" />
+						/>
 					<combo key="railway:signal:position"
 						text="Signal position"
 						de.text="Signalstandort"
 						values="left,right,bridge"
 						display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<combo key="railway:signal:direction"
 						text="Direction"
 						de.text="Anzeigerichtung"
 						values="forward,backward"
 						display_values="In Wegrichtung,Entgegen Wegrichtung"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<space />
 					<key key="railway:signal:distant"
 						value="DE-ESO:sk" />
@@ -700,7 +695,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<combo key="railway:signal:distant:states" default="DE-ESO:sk1;DE-ESO:sk2"
 						text="Signal states"
 						de.text="Signalzustände"
-						delete_if_empty="true"
 						delimiter="|"
 						values="DE-ESO:sk1;DE-ESO:sk2|DE-ESO:sk1;DE-ESO:sk2;DE-ESO:kennlicht"
 						de.display_values="kein Kennlicht|Kennlicht möglich"
@@ -709,12 +703,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						text="Shortened distance"
 						de.text="Verkürzter Bremsweg"
 						default="off"
-						delete_if_empty="true" />
+						/>
 					<check key="railway:signal:distant:repeated"
 						text="Repeated Signal"
 						de.text="Vorsignalwiederholer"
 						default="off"
-						delete_if_empty="true" />
+						/>
 					<space />
 					<preset_link preset_name="Richtungsvoranzeiger (Zs 2v)" />
 					<preset_link preset_name="Geschwindigkeitsvoranzeiger (Zs 3v)" />
@@ -731,26 +725,26 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						text="Signal ref"
 						de.text="Signalbezeichnung"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<check key="railway:signal:main:deactivated"
 						text="Out of order"
 						de.text="Ungültigkeitskreuz"
 						default="off"
-						delete_if_empty="true" />
+						/>
 					<combo key="railway:signal:position"
 						text="Signal position"
 						de.text="Signalstandort"
 						values="left,right,bridge"
 						display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<combo key="railway:signal:direction"
 						text="Direction"
 						de.text="Anzeigerichtung"
 						values="forward,backward"
 						display_values="In Wegrichtung,Entgegen Wegrichtung"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<space />
 					<key key="railway:signal:main"
 						value="DE-ESO:hp" />
@@ -762,7 +756,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						values="normal,dwarf"
 						display_values="Mastbauform,Zwergsignal"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<multiselect key="railway:signal:main:states"
 						text="Signal states (multi-selection)"
 						de.text="Signalzustände (Mehrfachauswahl)"
@@ -770,21 +764,21 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						values="DE-ESO:hp0;DE-ESO:hp1;DE-ESO:hp2"
 						display_values="Stop;Proceed;Proceed at reduced speed"
 						de.display_values="Halt;Fahrt;Langsamfahrt"
-						delete_if_empty="true" />
+						/>
 					<combo key="railway:signal:main:function"
 						text="Signal function"
 						de.text="Signalaufgabe"
 						values="entry,exit,block,intermediate"
 						display_values="Einfahrsignal,Ausfahrsignal,Blocksignal,Zwischensignal"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<multiselect key="railway:signal:main:substitute_signal"
 						text="Substitute signal (multi-selection)"
 						de.text="Ersatzsignal (Mehrfachauswahl)"
 						delimiter=";"
 						values="DE-ESO:db:zs1;DE-ESO:dr:zs1;DE-ESO:db:zs7;DE-ESO:db:zs12"
 						display_values="Ersatzsignal (ex-DB);Ersatzsignal (ex-DR);Vorsichtsignal;M-Tafel"
-						delete_if_empty="true" />
+						/>
 					<space />
 					<preset_link preset_name="Geschwindigkeitsanzeiger (Zs 3)" />
 					<preset_link preset_name="Stumpfgleis- und Frühhaltanzeiger (Zs 13)" />
@@ -802,26 +796,26 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						text="Signal ref"
 						de.text="Signalbezeichnung"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<check key="railway:signal:main:deactivated"
 						text="Out of order"
 						de.text="Ungültigkeitskreuz"
 						default="off"
-						delete_if_empty="true" />
+						/>
 					<combo key="railway:signal:position"
 						text="Signal position"
 						de.text="Signalstandort"
 						values="left,right,bridge"
 						display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<combo key="railway:signal:direction"
 						text="Direction"
 						de.text="Anzeigerichtung"
 						values="forward,backward"
 						display_values="In Wegrichtung,Entgegen Wegrichtung"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<space />
 					<key key="railway:signal:main"
 						value="DE-ESO:hp" />
@@ -833,7 +827,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						values="normal,dwarf"
 						display_values="Mastbauform,Zwergsignal"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<multiselect key="railway:signal:main:states"
 						text="Signal states (multi-selection)"
 						de.text="Signalzustände (Mehrfachauswahl)"
@@ -841,21 +835,21 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						values="DE-ESO:hp0;DE-ESO:hp1;DE-ESO:hp2;DE-ESO:kennlicht"
 						display_values="Stop;Proceed;Proceed at reduced speed;marker light"
 						de.display_values="Halt;Fahrt;Langsamfahrt;Kennlicht"
-						delete_if_empty="true" />
+						/>
 					<combo key="railway:signal:main:function"
 						text="Signal function"
 						de.text="Signalaufgabe"
 						values="entry,exit,block,intermediate"
 						display_values="Einfahrsignal,Ausfahrsignal,Blocksignal,Zwischensignal"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<multiselect key="railway:signal:main:substitute_signal"
 						text="Substitute signal (multi-selection)"
 						de.text="Ersatzsignal (Mehrfachauswahl)"
 						delimiter=";"
 						values="DE-ESO:db:zs1;DE-ESO:dr:zs1;DE-ESO:db:zs7;DE-ESO:db:zs12"
 						display_values="Ersatzsignal (ex-DB);Ersatzsignal (ex-DR);Vorsichtsignal;M-Tafel"
-						delete_if_empty="true" />
+						/>
 					<space />
 					<preset_link preset_name="Vr-Licht-Vorsignal" />
 					<preset_link preset_name="Richtungsanzeiger (Zs 2)" />
@@ -877,26 +871,26 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						text="Signal ref"
 						de.text="Signalbezeichnung"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<check key="railway:signal:distant:deactivated"
 						text="Out of order"
 						de.text="Ungültigkeitskreuz"
 						default="off"
-						delete_if_empty="true" />
+						/>
 					<combo key="railway:signal:position"
 						text="Signal position"
 						de.text="Signalstandort"
 						values="left,right,bridge"
 						display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<combo key="railway:signal:direction"
 						text="Direction"
 						de.text="Anzeigerichtung"
 						values="forward,backward"
 						display_values="In Wegrichtung,Entgegen Wegrichtung"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<space />
 					<key key="railway:signal:distant"
 						value="DE-ESO:vr" />
@@ -908,26 +902,26 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						values="normal,dwarf"
 						display_values="Mastbauform,Zwergsignal"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<multiselect key="railway:signal:distant:states"
 						text="Signal states (multi-selection)"
 						de.text="Signalzustände (Mehrfachauswahl)"
 						delimiter=";"
 						values="DE-ESO:vr0;DE-ESO:vr1;DE-ESO:vr2"
 						display_values="Halt erwarten;Fahrt erwarten;Langsamfahrt erwarten"
-						delete_if_empty="true" />
+						/>
 					<combo key="railway:signal:distant:shortened"
 						text="Shortened distance"
 						de.text="Verkürzter Bremsweg"
 						values="DE-ESO:db:ne2,DE-ESO:dr:so3c"
 						display_values="DB (weißes Dreieck),DR (Kreis)"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<check key="railway:signal:distant:repeated"
 						text="Repeated Signal"
 						de.text="Vorsignalwiederholer"
 						default="off"
-						delete_if_empty="true" />
+						/>
 					<space />
 					<preset_link preset_name="Richtungsvoranzeiger (Zs 2v)" />
 					<preset_link preset_name="Geschwindigkeitsvoranzeiger (Zs 3v)" />
@@ -942,26 +936,26 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						text="Signal ref"
 						de.text="Signalbezeichnung"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<check key="railway:signal:distant:deactivated"
 						text="Out of order"
 						de.text="Ungültigkeitskreuz"
 						default="off"
-						delete_if_empty="true" />
+						/>
 					<combo key="railway:signal:position"
 						text="Signal position"
 						de.text="Signalstandort"
 						values="left,right,bridge"
 						display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<combo key="railway:signal:direction"
 						text="Direction"
 						de.text="Anzeigerichtung"
 						values="forward,backward"
 						display_values="In Wegrichtung,Entgegen Wegrichtung"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<space />
 					<key key="railway:signal:distant"
 						value="DE-ESO:vr" />
@@ -973,7 +967,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						values="normal,dwarf"
 						display_values="Mastbauform,Zwergsignal"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<multiselect key="railway:signal:distant:states"
 						text="Signal states (multi-selection)"
 						de.text="Signalzustände (Mehrfachauswahl)"
@@ -981,17 +975,17 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						values="DE-ESO:vr0;DE-ESO:vr1;DE-ESO:vr2;DE-ESO:kennlicht"
 						display_values="Expect Stop;Expect Proceed;Expect Proceed at reduced speed;marker light"
 						de.display_values="Halt erwarten;Fahrt erwarten;Langsamfahrt erwarten;Kennlicht"
-						delete_if_empty="true" />
+						/>
 					<check key="railway:signal:distant:shortened"
 						text="Shortened distance"
 						de.text="Verkürzter Bremsweg"
 						default="off"
-						delete_if_empty="true" />
+						/>
 					<check key="railway:signal:distant:repeated"
 						text="Repeated Signal"
 						de.text="Vorsignalwiederholer"
 						default="off"
-						delete_if_empty="true" />
+						/>
 					<space />
 					<preset_link preset_name="Richtungsvoranzeiger (Zs 2v)" />
 					<preset_link preset_name="Geschwindigkeitsvoranzeiger (Zs 3v)" />
@@ -1015,26 +1009,26 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
 					de.text="Signalstandort"
 					values="left,right,bridge"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:signal:direction"
 					text="Direction"
 					de.text="Anzeigerichtung"
 					values="forward,backward"
 					display_values="In Wegrichtung,Entgegen Wegrichtung"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="railway:position:exact"
 					text="Exact position of wrong-line signals (e.g. '13.427')"
 					de.text="Standortangabe an Trapeztafeln im Gegengleis (z. B. '13.427')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<key key="railway:signal:main"
 					value="DE-ESO:ne1" />
@@ -1046,7 +1040,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="normal,dwarf"
 					display_values="Normalhöhe,Zwergsignal"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<key key="railway:signal:main:function"
 					value="entry" />
 			</item>
@@ -1060,21 +1054,21 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
 					de.text="Signalstandort"
 					values="left,right,bridge"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:signal:direction"
 					text="Direction"
 					de.text="Anzeigerichtung"
 					values="forward,backward"
 					display_values="In Wegrichtung,Entgegen Wegrichtung"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<combo key="railway:signal:distant"
 					text="Type"
@@ -1082,7 +1076,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="DE-ESO:db:ne2,DE-ESO:dr:so3,DE-ESO:dr:so3b"
 					display_values="Ne 2 ex-DB,So 3 ex-DR, So 3b ex-DR (mit schwarzem Punkt)"
 					default=""
-					delete_if_empty="true"
 					match="keyvalue!" />
 				<key key="railway:signal:distant:form"
 					value="sign" />
@@ -1090,7 +1083,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Shortened distance"
 					de.text="Verkürzter Bremsweg"
 					default="off"
-					delete_if_empty="true" />
+					/>
 			</item>
 			<item name="Kreuztafel (So 106)" icon="de/so106-32.png" type="node">
 				<label text="Kreuztafel (So 106)" />
@@ -1102,21 +1095,21 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
 					de.text="Signalstandort"
 					values="left,right,bridge"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:signal:direction"
 					text="Direction"
 					de.text="Anzeigerichtung"
 					values="forward,backward"
 					display_values="In Wegrichtung,Entgegen Wegrichtung"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<key key="railway:signal:distant"
 					value="DE-ESO:so106" />
@@ -1135,21 +1128,21 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						text="Out of order"
 						de.text="Ungültigkeitskreuz"
 						default="off"
-						delete_if_empty="true" />
+						/>
 					<combo key="railway:signal:position"
 						text="Signal position"
 						de.text="Signalstandort"
 						values="left,right,bridge"
 						display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<combo key="railway:signal:direction"
 						text="Direction"
 						de.text="Anzeigerichtung"
 						values="forward,backward"
 						display_values="In Wegrichtung,Entgegen Wegrichtung"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<space />
 					<combo key="railway:signal:crossing"
 						text="Exact type"
@@ -1157,7 +1150,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						values="DE-ESO:bü,DE-ESO:so16"
 						display_values="Bü (ex-DB),So 16 (ex-DR)"
 						default=""
-						delete_if_empty="true"
 						match="keyvalue!" />
 					<combo key="railway:signal:crossing:states"
 						text="Signal states"
@@ -1165,19 +1157,19 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						values="DE-ESO:bü0;DE-ESO:bü1,DE-ESO:so16a;DE-ESO:so16b"
 						display_values="Bü 0/1 (ex-DB),So 16a/b (ex-DR)"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<key key="railway:signal:crossing:form"
 						value="light" />
 					<check key="railway:signal:crossing:repeated"
 						text="Repeated"
 						de.text="Signalwiederholer (weiße Scheibe)"
 						default="off"
-						delete_if_empty="true" />
+						/>
 					<check key="railway:signal:crossing:shortened"
 						text="Shortened distance"
 						de.text="Verkürzter Bremswegabstand (weißes Dreieck)"
 						default="off"
-						delete_if_empty="true" />
+						/>
 				</item>
 				<item name="Bü-Überwachungssignal erwarten (Bü 2/So 15)" icon="de/bue2-ds-28.png" type="node">
 					<label text="Bü-Überwachungssignal erwarten (Bü 2/So 15)" />
@@ -1189,21 +1181,21 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						text="Out of order"
 						de.text="Ungültigkeitskreuz"
 						default="off"
-						delete_if_empty="true" />
+						/>
 					<combo key="railway:signal:position"
 						text="Signal position"
 						de.text="Signalstandort"
 						values="left,right,bridge"
 						display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<combo key="railway:signal:direction"
 						text="Direction"
 						de.text="Anzeigerichtung"
 						values="forward,backward"
 						display_values="In Wegrichtung,Entgegen Wegrichtung"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<space />
 					<combo key="railway:signal:crossing_distant"
 						text="Type of signal"
@@ -1211,7 +1203,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						values="DE-ESO:bü2,DE-ESO:so15"
 						display_values="Bü 2 'Rautentafel' ex-DB,So 15 ex-DR"
 						default=""
-						delete_if_empty="true"
 						match="keyvalue!" />
 					<key key="railway:signal:crossing_distant:form"
 						value="sign" />
@@ -1219,12 +1210,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						text="Repeated"
 						de.text="Signalwiederholer (weiße Scheibe)"
 						default="off"
-						delete_if_empty="true" />
+						/>
 					<check key="railway:signal:crossing_distant:shortened"
 						text="Shortened distance"
 						de.text="Verkürzter Bremswegabstand (weißes Dreieck)"
 						default="off"
-						delete_if_empty="true" />
+						/>
 				</item>
 				<item de.name="Einschaltkontakt Bahnübergang/Merktafel (Bü 3)"
 				    name="Activation switch crossing/Reminder Sign (Bü 3)" icon="de-bue3-57.png" type="node">
@@ -1241,21 +1232,21 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						text="Out of order"
 						de.text="Ungültigkeitskreuz"
 						default="off"
-						delete_if_empty="true" />
+						/>
 					<combo key="railway:signal:position"
 						text="Signal position"
 						de.text="Signalstandort"
 						values="left,right,bridge"
 						display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<combo key="railway:signal:direction"
 						text="Direction"
 						de.text="Anzeigerichtung"
 						values="forward,backward"
 						display_values="In Wegrichtung,Entgegen Wegrichtung"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<key key="railway:signal:crossing_distant"
 						value="DE-ESO:bü3"
 						match="keyvalue!" />
@@ -1277,14 +1268,14 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						text="Out of order"
 						de.text="Ungültigkeitskreuz"
 						default="off"
-						delete_if_empty="true" />
+						/>
 					<combo key="railway:signal:position"
 						text="Signal position"
 						de.text="Signalstandort"
 						values="left,right,bridge"
 						display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<key key="railway:signal:direction"
 						value="both" />
 					<key key="railway:signal:crossing_distant"
@@ -1303,21 +1294,21 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						text="Out of order"
 						de.text="Ungültigkeitskreuz"
 						default="off"
-						delete_if_empty="true" />
+						/>
 					<combo key="railway:signal:position"
 						text="Signal position"
 						de.text="Signalstandort"
 						values="left,right,bridge"
 						display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<combo key="railway:signal:direction"
 						text="Direction"
 						de.text="Anzeigerichtung"
 						values="forward,backward"
 						display_values="In Wegrichtung,Entgegen Wegrichtung"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<space />
 					<combo key="railway:signal:whistle"
 						text="Exact type"
@@ -1325,19 +1316,19 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						values="DE-ESO:db:bü4,DE-ESO:dr:pf1,DE-ESO:dr:pf2"
 						display_values="Bü 4 (ex-DB),Pf 1 (einfache Pfeiftafel ex-DR),Pf 2 (doppelte Pfeiftafel ex-DR)"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<key key="railway:signal:whistle:form"
 						value="sign" />
 					<check key="railway:signal:whistle:twice"
 						text="Whistle twice?"
 						de.text="Doppelte Pfeiftafel?"
 						default="off"
-						delete_if_empty="true" />
+						/>
 					<check key="railway:signal:whistle:only_transit"
 						text="Whistle only when train does not stop before crossing?"
 						de.text="Zwei senkrechte Striche?"
 						default="off"
-						delete_if_empty="true" />
+						/>
 				</item>
 				<item name="Läutetafel (Bü 5)" icon="de/bue5-32.png" type="node">
 					<label text="Läutetafel (Bü 5)" />
@@ -1349,21 +1340,21 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						text="Out of order"
 						de.text="Ungültigkeitskreuz"
 						default="off"
-						delete_if_empty="true" />
+						/>
 					<combo key="railway:signal:position"
 						text="Signal position"
 						de.text="Signalstandort"
 						values="left,right,bridge"
 						display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<combo key="railway:signal:direction"
 						text="Direction"
 						de.text="Anzeigerichtung"
 						values="forward,backward"
 						display_values="In Wegrichtung,Entgegen Wegrichtung"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<key key="railway:signal:ring"
 						value="DE-ESO:bü5" />
 					<key key="railway:signal:ring:form"
@@ -1372,7 +1363,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						text="Whistle only when train does not stop before crossing?"
 						de.text="Zwei senkrechte Striche?"
 						default="off"
-						delete_if_empty="true" />
+						/>
 				</item>
 				<item name="Bü-Kennzeichentafel" icon="de/crossing-info.png" type="node">
 					<label text="Bü-Kennzeichentafel" />
@@ -1384,21 +1375,21 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						text="Out of order"
 						de.text="Ungültigkeitskreuz"
 						default="off"
-						delete_if_empty="true" />
+						/>
 					<combo key="railway:signal:position"
 						text="Signal position"
 						de.text="Signalstandort"
 						values="left,right"
 						display_values="Links von Wegrichtung,Rechts von Wegrichtung"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<combo key="railway:signal:direction"
 						text="Direction"
 						de.text="Anzeigerichtung"
 						values="forward,backward"
 						display_values="In Wegrichtung,Entgegen Wegrichtung"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<key key="railway:signal:crossing_info"
 						value="DE-ESO:bü-kennzeichentafel" />
 					<key key="railway:signal:crossing_info:form"
@@ -1407,19 +1398,19 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						text="Caption (e.g. 'Bü 123,4')"
 						de.text="Beschriftung (z. B. 'Bü 123,4')"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<check key="railway:signal:crossing_info:repeated"
 						text="Repeated"
 						de.text="Signalwiederholer (weiße Scheibe)"
 						default="off"
-						delete_if_empty="true" />
+						/>
 					<combo key="railway:signal:crossing_info:height"
 						text="Signal height"
 						de.text="Signalbauform"
 						values="normal,dwarf"
 						default=""
 						display_values="Mastbauform,Zwergsignal"
-						delete_if_empty="true" />
+						/>
 				</item>
 				<item name="Bü-Ankündetafel" icon="de/crossing-hint.png" type="node">
 					<label text="Bü-Ankündetafel" />
@@ -1431,21 +1422,21 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						text="Out of order"
 						de.text="Ungültigkeitskreuz"
 						default="off"
-						delete_if_empty="true" />
+						/>
 					<combo key="railway:signal:position"
 						text="Signal position"
 						de.text="Signalstandort"
 						values="left,right"
 						display_values="Links von Wegrichtung,Rechts von Wegrichtung"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<combo key="railway:signal:direction"
 						text="Direction"
 						de.text="Anzeigerichtung"
 						values="forward,backward"
 						display_values="In Wegrichtung,Entgegen Wegrichtung"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<key key="railway:signal:crossing_hint"
 						value="DE-ESO:bü-ankündetafel" />
 					<key key="railway:signal:crossing_hint:form"
@@ -1454,19 +1445,19 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						text="Caption (e.g. 'Bü 123,4')"
 						de.text="Beschriftung (z. B. 'Bü 123,4')"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<check key="railway:signal:crossing_hint:repeated"
 						text="Repeated"
 						de.text="Signalwiederholer (weiße Scheibe)"
 						default="off"
-						delete_if_empty="true" />
+						/>
 					<combo key="railway:signal:crossing_hint:height"
 						text="Signal height"
 						de.text="Signalbauform"
 						values="normal,dwarf"
 						default=""
 						display_values="Mastbauform,Zwergsignal"
-						delete_if_empty="true" />
+						/>
 				</item>
 			</group>
 			<group name="Schutzsignale" icon="de/sh1-semaphore-normal-32.png">
@@ -1480,26 +1471,26 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						text="Signal ref"
 						de.text="Signalbezeichnung"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<check key="railway:signal:minor:deactivated"
 						text="Out of order"
 						de.text="Ungültigkeitskreuz"
 						default="off"
-						delete_if_empty="true" />
+						/>
 					<combo key="railway:signal:position"
 						text="Signal position"
 						de.text="Signalstandort"
 						values="left,right,bridge,in_track"
 						display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke,Gleismitte/am Prellbock"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<combo key="railway:signal:direction"
 						text="Direction"
 						de.text="Anzeigerichtung"
 						values="forward,backward"
 						display_values="In Wegrichtung,Entgegen Wegrichtung"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<space />
 					<key key="railway:signal:minor"
 						value="DE-ESO:sh" />
@@ -1509,21 +1500,21 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						values="light,semaphore,sign"
 						display_values="Lichtsignal,Formsignal,Tafel"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<combo key="railway:signal:minor:height"
 						text="Signal height"
 						de.text="Signalbauform"
 						values="normal,dwarf"
 						display_values="Mastbauform,Zwergsignal"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<combo key="railway:signal:minor:states"
 						text="Displayed signals"
 						de.text="Angezeigte Signalbilder"
 						values="DE-ESO:hp0;DE-ESO:sh1,DE-ESO:sh0;DE-ESO:sh1,DE-ESO:hp0;DE-ESO:kennlicht"
 						display_values="Lichtsignal (Hp 0/Sh 1),Formsignal (Sh 0/Sh 1),Zugdeckungssignal (Hp 0/Kennlicht)"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<space />
 					<label text="Signal Gsp 2 siehe 'Gleissperre'" />
 				</item>
@@ -1537,21 +1528,21 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						text="Out of order"
 						de.text="Ungültigkeitskreuz"
 						default="off"
-						delete_if_empty="true" />
+						/>
 					<combo key="railway:signal:position"
 						text="Signal position"
 						de.text="Signalstandort"
 						values="left,right,in_track"
 						display_values="Links von Wegrichtung,Rechts von Wegrichtung,Gleismitte/am Prellbock"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<combo key="railway:signal:direction"
 						text="Direction"
 						de.text="Anzeigerichtung"
 						values="forward,backward,both"
 						display_values="In Wegrichtung,Entgegen Wegrichtung,Beide Richtungen"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<space />
 					<key key="railway:signal:minor"
 						value="DE-ESO:sh2" />
@@ -1570,26 +1561,26 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						text="Signal ref"
 						de.text="Signalbezeichnung"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<check key="railway:signal:minor_distant:deactivated"
 						text="Out of order"
 						de.text="Ungültigkeitskreuz"
 						default="off"
-						delete_if_empty="true" />
+						/>
 					<combo key="railway:signal:position"
 						text="Signal position"
 						de.text="Signalstandort"
 						values="left,right,bridge"
 						display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<combo key="railway:signal:direction"
 						text="Direction"
 						de.text="Anzeigerichtung"
 						values="forward,backward"
 						display_values="In Wegrichtung,Entgegen Wegrichtung"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<space />
 					<key key="railway:signal:minor_distant"
 						value="DE-ESO:dr:sh3" />
@@ -1601,7 +1592,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						values="normal,dwarf"
 						display_values="Mastbauform,Zwergsignal"
 						default=""
-						delete_if_empty="true" />
+						/>
 				</item>
 			</group>
 			<group name="Rangiersignale" icon="de/ra11-sign-32.png">
@@ -1615,21 +1606,21 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						text="Out of order"
 						de.text="Ungültigkeitskreuz"
 						default="off"
-						delete_if_empty="true" />
+						/>
 					<combo key="railway:signal:position"
 						text="Signal position"
 						de.text="Signalstandort"
 						values="left,right"
 						display_values="Links von Wegrichtung,Rechts von Wegrichtung"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<combo key="railway:signal:direction"
 						text="Direction"
 						de.text="Anzeigerichtung"
 						values="forward,backward"
 						display_values="In Wegrichtung,Entgegen Wegrichtung"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<space />
 					<key key="railway:signal:shunting"
 						value="DE-ESO:ra10" />
@@ -1641,7 +1632,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						values="normal,dwarf"
 						display_values="Mastbauform,Zwergsignal"
 						default=""
-						delete_if_empty="true" />
+						/>
 				</item>
 				<item name="Rangierhaltsignal" icon="de/ra11-sign-32.png" type="node">
 					<label text="Rangierhaltsignal" />
@@ -1653,21 +1644,21 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						text="Out of order"
 						de.text="Ungültigkeitskreuz"
 						default="off"
-						delete_if_empty="true" />
+						/>
 					<combo key="railway:signal:position"
 						text="Signal position"
 						de.text="Signalstandort"
 						values="left,right"
 						display_values="Links von Wegrichtung,Rechts von Wegrichtung"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<combo key="railway:signal:direction"
 						text="Direction"
 						de.text="Anzeigerichtung"
 						values="forward,backward"
 						display_values="In Wegrichtung,Entgegen Wegrichtung"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<space />
 					<combo key="railway:signal:shunting"
 						text="Type of signal"
@@ -1675,7 +1666,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						values="DE-ESO:ra11,DE-ESO:ra11b"
 						display_values="Ra 11 (gelb),Ra 11b (weiß)"
 						default=""
-						delete_if_empty="true"
 						match="keyvalue!" />
 					<combo key="railway:signal:shunting:form"
 						text="Signal form"
@@ -1683,21 +1673,21 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						values="light,sign"
 						display_values="Lichtsignal mit Sh 1,Tafel"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<combo key="railway:signal:shunting:states"
 						text="Signal states"
 						de.text="Signalzustände"
 						values="DE-ESO:ra11;DE-ESO:sh1, "
 						display_values="Ra 11 / Sh 1,-nur Tafel-"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<combo key="railway:signal:shunting:height"
 						text="Signal height"
 						de.text="Signalbauform"
 						values="normal,dwarf"
 						display_values="Mastbauform,Zwergsignal"
 						default=""
-						delete_if_empty="true" />
+						/>
 				</item>
 				<item name="Abdrücksignal (Ra 6–Ra 9)" icon="de-humping.png" type="node">
 					<label text="Abdrücksignal (Ra 6–Ra 9)" />
@@ -1709,21 +1699,21 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						text="Out of order"
 						de.text="Ungültigkeitskreuz"
 						default="off"
-						delete_if_empty="true" />
+						/>
 					<combo key="railway:signal:position"
 						text="Signal position"
 						de.text="Signalstandort"
 						values="left,right"
 						display_values="Links von Wegrichtung,Rechts von Wegrichtung"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<combo key="railway:signal:direction"
 						text="Direction"
 						de.text="Anzeigerichtung"
 						values="forward,backward"
 						display_values="In Wegrichtung,Entgegen Wegrichtung"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<space />
 					<key key="railway:signal:humping"
 						value="DE-ESO:ra" />
@@ -1733,7 +1723,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						values="light,semaphore"
 						display_values="Lichtsignal,Formsignal"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<key key="railway:signal:humping:states"
 						value="DE-ESO:ra6;DE-ESO:ra7;DE-ESO:ra8;DE-ESO:ra9" />
 					<combo key="railway:signal:humping:height"
@@ -1742,7 +1732,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						values="normal,dwarf"
 						display_values="Mastbauform,Zwergsignal"
 						default=""
-						delete_if_empty="true" />
+						/>
 				</item>
 				<item name="Grenzzeichen (Ra 12)" icon="de/ra12.png" type="node">
 					<label text="Grenzzeichen (Ra 12)" />
@@ -1756,7 +1746,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						values="left,right"
 						display_values="Links von Wegrichtung,Rechts von Wegrichtung"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<key key="railway:signal:fouling_point"
 						value="DE-ESO:ra12" />
 				</item>
@@ -1772,21 +1762,21 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						text="Out of order"
 						de.text="Ungültigkeitskreuz"
 						default="off"
-						delete_if_empty="true" />
+						/>
 					<combo key="railway:signal:position"
 						text="Signal position"
 						de.text="Signalstandort"
 						values="left,right,bridge"
 						display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<combo key="railway:signal:direction"
 						text="Direction"
 						de.text="Anzeigerichtung"
 						values="forward,backward"
 						display_values="In Wegrichtung,Entgegen Wegrichtung"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<space />
 					<key key="railway:signal:route"
 						value="DE-ESO:zs2" />
@@ -1794,7 +1784,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						text="Signal states (separated by ';', use '?' if you don't know all possible values)"
 						de.text="Mögliche Anzeigewerte (getrennt durch ';', verwende '?', wenn du nicht alle Werte kennst)"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<key key="railway:signal:route:form"
 						value="light" />
 				</item>
@@ -1808,21 +1798,21 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						text="Out of order"
 						de.text="Ungültigkeitskreuz"
 						default="off"
-						delete_if_empty="true" />
+						/>
 					<combo key="railway:signal:position"
 						text="Signal position"
 						de.text="Signalstandort"
 						values="left,right,bridge"
 						display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<combo key="railway:signal:direction"
 						text="Direction"
 						de.text="Anzeigerichtung"
 						values="forward,backward"
 						display_values="In Wegrichtung,Entgegen Wegrichtung"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<space />
 					<key key="railway:signal:route_distant"
 						value="DE-ESO:zs2v" />
@@ -1830,7 +1820,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						text="Signal states (separated by ';', use '?' if you don't know all possible values)"
 						de.text="Mögliche Anzeigewerte (getrennt durch ';', verwende '?', wenn du nicht alle Werte kennst)"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<key key="railway:signal:route_distant:form"
 						value="light" />
 				</item>
@@ -1845,21 +1835,21 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						text="Out of order"
 						de.text="Ungültigkeitskreuz"
 						default="off"
-						delete_if_empty="true" />
+						/>
 					<combo key="railway:signal:position"
 						text="Signal position"
 						de.text="Signalstandort"
 						values="left,right,bridge"
 						display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<combo key="railway:signal:direction"
 						text="Direction"
 						de.text="Anzeigerichtung"
 						values="forward,backward"
 						display_values="In Wegrichtung,Entgegen Wegrichtung"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<space />
 					<key key="railway:signal:speed_limit"
 						value="DE-ESO:zs3" />
@@ -1868,11 +1858,10 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						de.text="Anzeigeart"
 						values="light,sign"
 						display_values="Lichtsignal,Tafel"
-						delete_if_empty="true" />
+						/>
 					<multiselect key="railway:signal:speed_limit:speed" 
 						text="Speed (km/h)"
 						de.text="Geschwindigkeit (km/h)"
-						delete_if_empty="true"
 						delimiter=";"
 						values="off;10;20;30;40;50;60;70;80;90;100;110;120;130;140;150;160;170;180;190;200;?"
 						display_values="off;10;20;30;40;50;60;70;80;90;100;110;120;130;140;150;160;170;180;190;200;unknown"
@@ -1883,7 +1872,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						values="normal,dwarf"
 						default=""
 						display_values="Mastbauform,Zwergsignal"
-						delete_if_empty="true" />
+						/>
 				</item>
 				<item name="Geschwindigkeitsvoranzeiger (Zs 3v)" icon="de/zs3v-60-sign-down-32.png" type="node">
 					<label text="Geschwindigkeitsvoranzeiger (Zs 3v)" />
@@ -1895,21 +1884,21 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						text="Out of order"
 						de.text="Ungültigkeitskreuz"
 						default="off"
-						delete_if_empty="true" />
+						/>
 					<combo key="railway:signal:position"
 						text="Signal position"
 						de.text="Signalstandort"
 						values="left,right,bridge"
 						display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<combo key="railway:signal:direction"
 						text="Direction"
 						de.text="Anzeigerichtung"
 						values="forward,backward"
 						display_values="In Wegrichtung,Entgegen Wegrichtung"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<space />
 					<key key="railway:signal:speed_limit_distant"
 						value="DE-ESO:zs3v" />
@@ -1919,11 +1908,10 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						values="light,sign"
 						display_values="Lichtsignal,Tafel"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<multiselect key="railway:signal:speed_limit_distant:speed" 
 						text="Speed (km/h)"
 						de.text="Geschwindigkeit (km/h)"
-						delete_if_empty="true"
 						delimiter=";"
 						values="off;10;20;30;40;50;60;70;80;90;100;110;120;130;140;150;160;170;180;190;200;?"
 						display_values="off;10;20;30;40;50;60;70;80;90;100;110;120;130;140;150;160;170;180;190;200;unknown"
@@ -1934,7 +1922,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						values="normal,dwarf"
 						default=""
 						display_values="Mastbauform,Zwergsignal"
-						delete_if_empty="true" />
+						/>
 				</item>
 				<item name="Endesignal (Zs 10)" icon="de/zs10-sign-32.png" type="node">
 					<label text="Endesignal (Zs 10)" />
@@ -1946,21 +1934,21 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						text="Out of order"
 						de.text="Ungültigkeitskreuz"
 						default="off"
-						delete_if_empty="true" />
+						/>
 					<combo key="railway:signal:position"
 						text="Signal position"
 						de.text="Signalstandort"
 						values="left,right,bridge"
 						display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<combo key="railway:signal:direction"
 						text="Direction"
 						de.text="Anzeigerichtung"
 						values="forward,backward"
 						display_values="In Wegrichtung,Entgegen Wegrichtung"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<space />
 					<key key="railway:signal:speed_limit"
 						value="DE-ESO:db:zs10" />
@@ -1970,7 +1958,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						values="light,sign"
 						display_values="Lichtsignal,Tafel"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<key key="railway:signal:speed_limit:speed"
 						value="none" />
 					<combo key="railway:signal:speed_limit:height"
@@ -1979,7 +1967,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						values="normal,dwarf"
 						default=""
 						display_values="Mastbauform,Zwergsignal"
-						delete_if_empty="true" />
+						/>
 				</item>
 				<separator />
 				<item name="Gegengleisanzeiger (Zs 6)" icon="de/zs6-sign-30.png" type="node">
@@ -1992,23 +1980,23 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						text="Out of order"
 						de.text="Ungültigkeitskreuz"
 						default="off"
-						delete_if_empty="true" />
+						/>
 					<combo key="railway:signal:position"
 						text="Signal position"
 						de.text="Signalstandort"
 						values="left,right,bridge"
 						display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<combo key="railway:signal:direction"
 						text="Direction"
 						de.text="Anzeigerichtung"
 						values="forward,backward"
 						display_values="In Wegrichtung,Entgegen Wegrichtung"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<space />
-					<combo key="railway:signal:wrong_road" text="Type" de.text="Typ" default="" delete_if_empty="true" match="keyvalue!">
+					<combo key="railway:signal:wrong_road" text="Type" de.text="Typ" default="" match="keyvalue!">
 		         	<list_entry value="DE-ESO:db:zs6" display_value="Zs 6 DB" short_description="Gegengleisanzeiger Zs 6 (ex-DB)" />
 		         	<list_entry value="DE-ESO:dr:zs7" display_value="Zs 7 DR" short_description="Gegengleisanzeiger Zs 7 (ex-DR)" />
 		         </combo>
@@ -2018,7 +2006,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						values="sign,light"
 						display_values="Tafel,Leuchtanzeige"
 						default=""
-						delete_if_empty="true" />
+						/>
 				</item>
 				<item name="Gegengleisfahrt-Ersatzsignal (Zs 8)" icon="de-zs8.png" type="node">
 					<label text="Gegengleisfahrt-Ersatzsignal (Zs 8)" />
@@ -2030,23 +2018,23 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						text="Out of order"
 						de.text="Ungültigkeitskreuz"
 						default="off"
-						delete_if_empty="true" />
+						/>
 					<combo key="railway:signal:position"
 						text="Signal position"
 						de.text="Signalstandort"
 						values="left,right,bridge"
 						display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<combo key="railway:signal:direction"
 						text="Direction"
 						de.text="Anzeigerichtung"
 						values="forward,backward"
 						display_values="In Wegrichtung,Entgegen Wegrichtung"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<space />
-					<combo key="railway:signal:wrong_road" text="Type" de.text="Typ" default="" delete_if_empty="true" match="keyvalue!">
+					<combo key="railway:signal:wrong_road" text="Type" de.text="Typ" default="" match="keyvalue!">
 						<list_entry value="DE-ESO:db:zs8" display_value="Zs 8 DB" short_description="Falschfahrt-Auftragssignal Zs 8 (ex-DB)" />
 						<list_entry value="DE-ESO:dr:zs8" display_value="Zs 8 DR" short_description="Linksfahrtersatzsignal Zs 8 (ex-DR)" />
 		            </combo>
@@ -2056,7 +2044,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						values="sign,light"
 						display_values="Tafel,Leuchtanzeige"
 						default=""
-						delete_if_empty="true" />
+						/>
 				</item>
 				<separator />
 				<item name="Stumpfgleis- und Frühhaltanzeiger (Zs 13)" icon="de/zs13-sign-30.png" type="node">
@@ -2069,21 +2057,21 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						text="Out of order"
 						de.text="Ungültigkeitskreuz"
 						default="off"
-						delete_if_empty="true" />
+						/>
 					<combo key="railway:signal:position"
 						text="Signal position"
 						de.text="Signalstandort"
 						values="left,right,bridge"
 						display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<combo key="railway:signal:direction"
 						text="Direction"
 						de.text="Anzeigerichtung"
 						values="forward,backward"
 						display_values="In Wegrichtung,Entgegen Wegrichtung"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<space />
 					<combo key="railway:signal:short_route"
 						text="Type of signal"
@@ -2091,7 +2079,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						values="DE-ESO:zs13,DE-ESO:dr:zs6,DE-ESO:dr:zs106"
 						display_values="Zs 13,Zs 6 (Lichtsignal ex-DR),Zs 106 (Tafel ex-DR)"
 						default=""
-						delete_if_empty="true"
 						match="keyvalue!" />
 					<combo key="railway:signal:short_route:form"
 						text="Signal form"
@@ -2099,14 +2086,14 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						values="light,sign"
 						display_values="Lichtsignal,Tafel"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<combo key="railway:signal:short_route:height"
 						text="Signal height"
 						de.text="Signalbauform"
 						values="normal,dwarf"
 						default=""
 						display_values="Mastbauform,Zwergsignal"
-						delete_if_empty="true" />
+						/>
 				</item>
 			</group>
 			<group name="Langsamfahrsignale (Lf)" icon="de/lf7-70-sign-32.png">
@@ -2120,23 +2107,23 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						text="Out of order"
 						de.text="Ungültigkeitskreuz"
 						default="off"
-						delete_if_empty="true" />
+						/>
 					<combo key="railway:signal:position"
 						text="Signal position"
 						de.text="Signalstandort"
 						values="left,right,bridge"
 						display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<combo key="railway:signal:direction"
 						text="Direction"
 						de.text="Anzeigerichtung"
 						values="forward,backward"
 						display_values="In Wegrichtung,Entgegen Wegrichtung"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<space />
-					<combo key="railway:signal:speed_limit" text="Type of signal" de.text="Signaltyp" default="" delete_if_empty="true" match="keyvalue!">
+					<combo key="railway:signal:speed_limit" text="Type of signal" de.text="Signaltyp" default="" match="keyvalue!">
 						<list_entry value="DE-ESO:lf7" display_value="Lf 7" short_description="Geschwindigkeitssignal Lf 7" />
 						<list_entry value="DE-ESO:dr:lf1/2" display_value="Lf 1/2" short_description="Langsamfahrbeginnscheibe Lf 1/2 (ex-DR)" />
 						<list_entry value="DE-ESO:lf2" display_value="Lf 2" short_description="Anfangsscheibe Lf 2" />
@@ -2149,7 +2136,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<combo key="railway:signal:speed_limit:speed" default=""
 						text="Speed (km/h)"
 						de.text="Geschwindigkeit (km/h)"
-						delete_if_empty="true"
 						values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,none"
 						display_values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,end (Zs 10; Lf 3)"
 						de.display_values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,Aufhebung (Zs 10; Lf 3)" />
@@ -2159,7 +2145,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						values="normal,dwarf"
 						default=""
 						display_values="Mastbauform,Zwergsignal"
-						delete_if_empty="true" />
+						/>
 					<combo key="railway:signal:speed_limit:turn_direction"
 						text="Turn direction arrow – leave this key empty if there is no one."
 						de.text="Richtungspfeil – leer lassen, falls es keinen gibt."
@@ -2167,7 +2153,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						display_values="Left,Through,Right"
 						de.display_values="Links,Geradeaus,Rechts"
 						default=""
-						delete_if_empty="true" />
+						/>
 				</item>
 				<item name="Geschwindigkeits-Ankündesignal" icon="de/lf6-60-sign-down-32.png" type="node">
 					<label text="Geschwindigkeits-Ankündesignal" />
@@ -2179,23 +2165,23 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						text="Out of order"
 						de.text="Ungültigkeitskreuz"
 						default="off"
-						delete_if_empty="true" />
+						/>
 					<combo key="railway:signal:position"
 						text="Signal position"
 						de.text="Signalstandort"
 						values="left,right,bridge"
 						display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<combo key="railway:signal:direction"
 						text="Direction"
 						de.text="Anzeigerichtung"
 						values="forward,backward"
 						display_values="In Wegrichtung,Entgegen Wegrichtung"
 						default=""
-						delete_if_empty="true" />
+						/>
 					<space />
-					<combo key="railway:signal:speed_limit_distant" text="Type of signal" de.text="Signaltyp" default="" delete_if_empty="true" match="keyvalue!">
+					<combo key="railway:signal:speed_limit_distant" text="Type of signal" de.text="Signaltyp" default="" match="keyvalue!">
 						<list_entry value="DE-ESO:lf6" display_value="Lf 6" short_description="Geschwindigkeits-Ankündesignal Lf 6" />
 						<list_entry value="DE-ESO:lf1" display_value="Lf 1" short_description="Langsamfahrscheibe Lf 1" />
 						<list_entry value="DE-ESO:db:lf4" display_value="Lf 4 DB" short_description="Geschwindigkeitstafel Lf 4 (ex-DB)" />
@@ -2206,7 +2192,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<combo key="railway:signal:speed_limit_distant:speed" default=""
 						text="Speed (km/h)"
 						de.text="Geschwindigkeit (km/h)"
-						delete_if_empty="true"
 						values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,off"
 						display_values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,off"
 						de.display_values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,off" />
@@ -2216,7 +2201,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						values="normal,dwarf"
 						default=""
 						display_values="Mastbauform,Zwergsignal"
-						delete_if_empty="true" />
+						/>
 					<combo key="railway:signal:speed_limit_distant:turn_direction"
 						text="Turn direction arrow – leave this key empty if there is no one."
 						de.text="Richtungspfeil – leer lassen, falls es keinen gibt."
@@ -2224,7 +2209,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						display_values="Left,Through,Right"
 						de.display_values="Links,Geradeaus,Rechts"
 						default=""
-						delete_if_empty="true" />
+						/>
 				</item>
 			</group>
 			<item name="Überwachungssignal Rückfallweiche (Ne 13)" icon="de/ne13a-32.png" type="node">
@@ -2237,21 +2222,21 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
 					de.text="Signalstandort"
 					values="left,right"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:signal:direction"
 					text="Direction"
 					de.text="Anzeigerichtung"
 					values="forward,backward"
 					display_values="In Wegrichtung,Entgegen Wegrichtung"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<key key="railway:signal:resetting_switch"
 					value="DE-ESO:ne13" />
@@ -2265,7 +2250,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="normal,dwarf"
 					default=""
 					display_values="Mastbauform,Zwergsignal"
-					delete_if_empty="true" />
+					/>
 			</item>
 			<item name="Ankündigung Überwachungssignal Rückfallweiche (Ne 12)" icon="de/ne12-38.png" type="node">
 				<label text="Ankündigung Überwachungssignal Rückfallweiche (Ne 12)" />
@@ -2277,21 +2262,21 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
 					de.text="Signalstandort"
 					values="left,right"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:signal:direction"
 					text="Direction"
 					de.text="Anzeigerichtung"
 					values="forward,backward"
 					display_values="In Wegrichtung,Entgegen Wegrichtung"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<key key="railway:signal:resetting_switch_distant"
 					value="DE-ESO:ne12" />
@@ -2303,7 +2288,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="normal,dwarf"
 					default=""
 					display_values="Mastbauform,Zwergsignal"
-					delete_if_empty="true" />
+					/>
 			</item>
 			<separator />
 			<item name="Schachbretttafel (Ne 4)" icon="de/ne4-normal-32.png" type="node">
@@ -2316,28 +2301,27 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
 					de.text="Signalstandort"
 					values="left,right"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:signal:direction"
 					text="Direction"
 					de.text="Anzeigerichtung"
 					values="forward,backward"
 					display_values="In Wegrichtung,Entgegen Wegrichtung"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:signal:expected_position"
 					text="Side of track where the signal would be mounted usually"
 					de.text="Gleisseite, auf der man das Signal normalerweise erwarten würde"
 					values="left,right"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung"
 					default=""
-					delete_if_empty="true"
 					match="keyvalue!" />
 				<combo key="railway:signal:expected_position:height"
 					text="Signal height"
@@ -2345,7 +2329,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="normal,dwarf"
 					default=""
 					display_values="Mastbauform,Zwergsignal"
-					delete_if_empty="true" />
+					/>
 			</item>
 			<item name="Haltetafel (Ne 5)" icon="de/ne5-ds301-32.png" type="node">
 				<label text="Haltetafel (Ne 5)" />
@@ -2357,21 +2341,21 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
 					de.text="Signalstandort"
 					values="left,right"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:signal:direction"
 					text="Direction"
 					de.text="Anzeigerichtung"
 					values="forward,backward"
 					display_values="In Wegrichtung,Entgegen Wegrichtung"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<key key="railway:signal:stop"
 					value="DE-ESO:ne5" />
 				<key key="railway:signal:stop:form"
@@ -2382,12 +2366,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="normal,dwarf"
 					default=""
 					display_values="Mastbauform,Zwergsignal"
-					delete_if_empty="true" />
+					/>
 				<text key="railway:signal:stop:caption"
 					text="Description"
 					de.text="Zusatztext"
 					default=""
-					delete_if_empty="true" />
+					/>
 			</item>
 			<item name="Haltepunkttafel (Ne 6)" icon="de/ne6-32.png" type="node">
 				<label text="Haltepunkttafel (Ne 6)" />
@@ -2399,21 +2383,21 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
 					de.text="Signalstandort"
 					values="left,right"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:signal:direction"
 					text="Direction"
 					de.text="Anzeigerichtung"
 					values="forward,backward"
 					display_values="In Wegrichtung,Entgegen Wegrichtung"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<key key="railway:signal:station_distant"
 					value="DE-ESO:ne6" />
 				<key key="railway:signal:station_distant:form"
@@ -2429,21 +2413,21 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
 					de.text="Signalstandort"
 					values="left,right"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:signal:direction"
 					text="Direction"
 					de.text="Anzeigerichtung"
 					values="forward,backward"
 					display_values="In Wegrichtung,Entgegen Wegrichtung"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<key key="railway:signal:snowplow"
 					value="DE-ESO:ne7" />
 				<key key="railway:signal:snowplow:form"
@@ -2454,14 +2438,14 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="normal,dwarf"
 					default=""
 					display_values="Mastbauform,Zwergsignal"
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:signal:snowplow:type"
 					text="Order"
 					de.text="Anweisung"
 					values="up,down"
 					default=""
 					display_values="Heben,Senken"
-					delete_if_empty="true" />
+					/>
 			</item>
 			<item name="ETCS-Halt-Tafel (Ne 14, ETCS Stop Marker)" icon="etcs-stop-marker-arrow-left-32.png" type="node">
 				<label text="ETCS-Halt-Tafel (Ne 14), auch bekannt als ETCS Stop Marker" />
@@ -2473,31 +2457,31 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Signal ref"
 					de.text="Signalbezeichner"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<check key="railway:signal:train_protection:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
 					de.text="Signalstandort"
 					values="left,right,bridge,overhead"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke,Oberleitung"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:signal:direction"
 					text="Direction"
 					de.text="Anzeigerichtung"
 					values="forward,backward"
 					display_values="In Wegrichtung,Entgegen Wegrichtung"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<check key="railway:signal:catenary_mast"
 					text="On catenary mast"
 					de.text="Am Oberleitungsmast"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<key key="railway:signal:train_protection"
 					value="DE-ESO:ne14" /> 
 				<key key="railway:signal:train_protection:type"
@@ -2515,21 +2499,21 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
 					de.text="Signalstandort"
 					values="left,right,overhead"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung,Oberleitung"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:signal:direction"
 					text="Direction"
 					de.text="Anzeigerichtung"
 					values="forward,backward"
 					display_values="In Wegrichtung,Entgegen Wegrichtung"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<combo key="railway:signal:electricity"
 					text="Exact type"
@@ -2537,7 +2521,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="DE-ESO:el1v,DE-ESO:el1,DE-ESO:el2,DE-ESO:el3,DE-ESO:el4,DE-ESO:el5,DE-ESO:el6"
 					display_values="Ausschaltsignal erwarten (El 1v),Ausschaltsignal (El 1),Einschaltsignal (El 2),Bügel-ab-Signal erwarten (El 3),Bügel-ab-Signal (El 4),Bügel-an-Signal (El 5),Halt für Fahrzeuge mit gehobenem Stromabnehmer (El 6)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:signal:electricity:turn_direction"
 					text="Turn direction arrow – leave this key empty if there is no one."
 					de.text="Richtungspfeil – leer lassen, falls es keinen gibt."
@@ -2545,33 +2529,33 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					display_values="Left,Through,Right"
 					de.display_values="Links,Geradeaus,Rechts"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:signal:electricity:height"
 					text="Signal height"
 					de.text="Signalbauform"
 					values="normal,dwarf"
 					default=""
 					display_values="Mastbauform,Zwergsignal"
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:signal:electricity:type"
 					text="Meaning"
 					de.text="Bedeutung"
 					values="power_off_advance,power_off,power_on,pantograph_down_advance,pantograph_down,pantograph_up,end_of_catenary"
 					display_values="Ausschaltsignal erwarten (El 1v),Ausschaltsignal (El 1),Einschaltsignal (El 2),Bügel-ab-Signal erwarten (El 3),Bügel-ab-Signal (El 4),Bügel-an-Signal (El 5),Halt für Fahrzeuge mit gehobenem Stromabnehmer (El 6)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<key key="railway:signal:electricity:form"
 					value="sign" />
 				<text key="railway:signal:electricity:voltage"
 					text="Voltage (if mentioned)"
 					de.text="Spannung (falls angezeigt)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="railway:signal:electricity:frequency"
 					text="Frequency (if mentioned)"
 					de.text="Frequenz (falls angezeigt)"
 					default=""
-					delete_if_empty="true" />
+					/>
 			</item>
 			<separator />
 			<item name="Fahrtanzeiger" icon="de/fahrtanzeiger-32.png" type="node">
@@ -2584,26 +2568,26 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Signal ref"
 					de.text="Signalbezeichnung"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<check key="railway:signal:main_repeated:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
 					de.text="Signalstandort"
 					values="left,right,bridge"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:signal:direction"
 					text="Direction"
 					de.text="Anzeigerichtung"
 					values="forward,backward,both"
 					display_values="In Wegrichtung,Entgegen Wegrichtung,Beide Richtungen"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<key key="railway:signal:main_repeated"
 					value="DE-ESO:fahrtanzeiger" />
@@ -2620,21 +2604,21 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
 					de.text="Signalstandort"
 					values="left,right,bridge"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:signal:direction"
 					text="Direction"
 					de.text="Anzeigerichtung"
 					values="forward,backward,both"
 					display_values="In Wegrichtung,Entgegen Wegrichtung,Beide Richtungen"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<key key="railway:signal:departure"
 					value="DE-ESO:zp" />
 				<multiselect key="railway:signal:departure:states"
@@ -2643,7 +2627,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					delimiter=";"
 					values="DE-ESO:zp10;DE-ESO:zp9"
 					display_values="Türen schließen Zp 10;Abfahrtssignal Zp 9"
-					delete_if_empty="true" />
+					/>
 				<key key="railway:signal:departure:form"
 					value="light" />
 			</item>
@@ -2657,21 +2641,21 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
 					de.text="Signalstandort"
 					values="left,right,bridge"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:signal:direction"
 					text="Direction"
 					de.text="Anzeigerichtung"
 					values="forward,backward,both"
 					display_values="In Wegrichtung,Entgegen Wegrichtung,Beide Richtungen"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<key key="railway:signal:brake_test"
 					value="DE-ESO:zp" />
 				<key key="railway:signal:brake_test:form"
@@ -2693,31 +2677,31 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
 					de.text="Signalstandort"
 					values="left,right"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:signal:direction"
 					text="Direction"
 					de.text="Anzeigerichtung"
 					values="forward,backward"
 					display_values="In Wegrichtung,Entgegen Wegrichtung"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<check key="railway:signal:catenary_mast"
 					text="On catenary mast"
 					de.text="Am Oberleitungsmast"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<text key="ref"
 					text="Block reference"
 					de.text="Blockbezeichner"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<key key="railway:signal:train_protection"
 					value="DE-ESO:blockkennzeichen" /> 
 				<key key="railway:signal:train_protection:type"
@@ -2735,26 +2719,26 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
 					de.text="Signalstandort"
 					values="left,right"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:signal:direction"
 					text="Direction"
 					de.text="Anzeigerichtung"
 					values="forward,backward"
 					display_values="In Wegrichtung,Entgegen Wegrichtung"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<check key="railway:signal:catenary_mast"
 					text="On catenary mast"
 					de.text="Am Oberleitungsmast"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<key key="railway:signal:train_protection"
 					value="DE-ESO:lzb-bereichskennzeichen" />
 				<key key="railway:signal:train_protection:form"
@@ -2772,7 +2756,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="left,right"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<key key="railway:signal:radio"
 					value="DE-ESO:zugfunk-kanalhinweis" />
 				<key key="railway:signal:radio:form"
@@ -2781,7 +2765,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Frequency/Channel"
 					de.text="Kanal"
 					default=""
-					delete_if_empty="true" />
+					/>
 			</item>
 	</group>
 </presets>

--- a/josm-presets/de-signals-eso.xml
+++ b/josm-presets/de-signals-eso.xml
@@ -23,7 +23,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<text key="ref"
 						text="Signal ref"
 						de.text="Signalbezeichnung"
-						default=""
 						/>
 					<check key="railway:signal:distant:deactivated"
 						text="Out of order"
@@ -35,14 +34,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						de.text="Signalstandort"
 						values="left,right,bridge"
 						display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
-						default=""
 						/>
 					<combo key="railway:signal:direction"
 						text="Direction"
 						de.text="Anzeigerichtung"
 						values="forward,backward"
 						display_values="In Wegrichtung,Entgegen Wegrichtung"
-						default=""
 						/>
 					<space />
 					<key key="railway:signal:distant"
@@ -54,7 +51,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						de.text="Signalbauform"
 						values="normal,dwarf"
 						display_values="Mastbauform,Zwergsignal"
-						default=""
 						/>
 					<combo key="railway:signal:distant:states" default="DE-ESO:ks1;DE-ESO:ks2"
 						text="Signal states"
@@ -87,7 +83,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<text key="ref"
 						text="Signal ref"
 						de.text="Signalbezeichnung"
-						default=""
 						/>
 					<check key="railway:signal:combined:deactivated"
 						text="Out of order"
@@ -99,14 +94,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						de.text="Signalstandort"
 						values="left,right,bridge"
 						display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
-						default=""
 						/>
 					<combo key="railway:signal:direction"
 						text="Direction"
 						de.text="Anzeigerichtung"
 						values="forward,backward"
 						display_values="In Wegrichtung,Entgegen Wegrichtung"
-						default=""
 						/>
 					<space />
 					<key key="railway:signal:combined"
@@ -118,7 +111,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						de.text="Signalbauform"
 						values="normal,dwarf"
 						display_values="Mastbauform,Zwergsignal"
-						default=""
 						/>
 					<combo key="railway:signal:combined:states" default="DE-ESO:hp0;DE-ESO:ks1;DE-ESO:ks2"
 						text="Signal states"
@@ -137,7 +129,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						de.text="Signalaufgabe"
 						values="entry,exit,block,intermediate"
 						display_values="Einfahrsignal,Ausfahrsignal,Blocksignal,Zwischensignal"
-						default=""
 						/>
 					<multiselect key="railway:signal:combined:substitute_signal"
 						text="Substitute signal (multi-selection)"
@@ -166,7 +157,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<text key="ref"
 						text="Signal ref"
 						de.text="Signalbezeichnung"
-						default=""
 						/>
 					<check key="railway:signal:main:deactivated"
 						text="Out of order"
@@ -178,14 +168,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						de.text="Signalstandort"
 						values="left,right,bridge"
 						display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
-						default=""
 						/>
 					<combo key="railway:signal:direction"
 						text="Direction"
 						de.text="Anzeigerichtung"
 						values="forward,backward"
 						display_values="In Wegrichtung,Entgegen Wegrichtung"
-						default=""
 						/>
 					<space />
 					<key key="railway:signal:main"
@@ -197,9 +185,8 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						de.text="Signalbauform"
 						values="normal,dwarf"
 						display_values="Mastbauform,Zwergsignal"
-						default=""
 						/>
-					<combo key="railway:signal:main:states" default=""
+					<combo key="railway:signal:main:states"
 						text="Signal states"
 						de.text="Signalzustände"
 						delimiter="|"
@@ -211,7 +198,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						de.text="Signalaufgabe"
 						values="entry,exit,block,intermediate"
 						display_values="Einfahrsignal,Ausfahrsignal,Blocksignal,Zwischensignal"
-						default=""
 						/>
 					<multiselect key="railway:signal:main:substitute_signal"
 						text="Substitute signal (multi-selection)"
@@ -239,7 +225,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<text key="ref"
 					text="Signal ref"
 					de.text="Signalbezeichnung"
-					default=""
 					/>
 				<check key="railway:signal:combined:deactivated"
 					text="Out of order"
@@ -251,14 +236,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Signalstandort"
 					values="left,right,bridge"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
-					default=""
 					/>
 				<combo key="railway:signal:direction"
 					text="Direction"
 					de.text="Anzeigerichtung"
 					values="forward,backward"
 					display_values="In Wegrichtung,Entgegen Wegrichtung"
-					default=""
 					/>
 				<space />
 				<key key="railway:signal:combined"
@@ -270,7 +253,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Signalbauform"
 					values="normal,dwarf"
 					display_values="Mastbauform,Zwergsignal"
-					default=""
 					/>
 				<multiselect key="railway:signal:combined:states"
 					text="Signal states, Hamburg names (multi-selection)"
@@ -285,7 +267,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Signalaufgabe"
 					values="entry,exit,block,intermediate"
 					display_values="Einfahrsignal,Ausfahrsignal,Blocksignal,Zwischensignal"
-					default=""
 					/>
 				<multiselect key="railway:signal:combined:substitute_signal"
 					text="Substitute signal (multi-selection)"
@@ -320,7 +301,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<text key="ref"
 						text="Signal ref"
 						de.text="Signalbezeichnung"
-						default=""
 						/>
 					<check key="railway:signal:combined:deactivated"
 						text="Out of order"
@@ -332,14 +312,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						de.text="Signalstandort"
 						values="left,right,bridge"
 						display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
-						default=""
 						/>
 					<combo key="railway:signal:direction"
 						text="Direction"
 						de.text="Anzeigerichtung"
 						values="forward,backward"
 						display_values="In Wegrichtung,Entgegen Wegrichtung"
-						default=""
 						/>
 					<space />
 					<key key="railway:signal:combined"
@@ -351,7 +329,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						de.text="Signalbauform"
 						values="normal,dwarf"
 						display_values="Mastbauform,Zwergsignal"
-						default=""
 						/>
 					<multiselect key="railway:signal:combined:states"
 						text="Signal states (multi-selection)"
@@ -365,7 +342,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						de.text="Signalaufgabe"
 						values="entry,exit,block,intermediate"
 						display_values="Einfahrsignal,Ausfahrsignal,Blocksignal,Zwischensignal"
-						default=""
 						/>
 					<multiselect key="railway:signal:combined:substitute_signal"
 						text="Substitute signal (multi-selection)"
@@ -392,7 +368,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<text key="ref"
 						text="Signal ref"
 						de.text="Signalbezeichnung"
-						default=""
 						/>
 					<check key="railway:signal:main:deactivated"
 						text="Out of order"
@@ -404,14 +379,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						de.text="Signalstandort"
 						values="left,right,bridge"
 						display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
-						default=""
 						/>
 					<combo key="railway:signal:direction"
 						text="Direction"
 						de.text="Anzeigerichtung"
 						values="forward,backward"
 						display_values="In Wegrichtung,Entgegen Wegrichtung"
-						default=""
 						/>
 					<space />
 					<key key="railway:signal:main"
@@ -423,7 +396,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						de.text="Signalbauform"
 						values="normal,dwarf"
 						display_values="Mastbauform,Zwergsignal"
-						default=""
 						/>
 					<multiselect key="railway:signal:main:states"
 						text="Signal states (multi-selection)"
@@ -437,7 +409,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						de.text="Signalaufgabe"
 						values="entry,exit,block,intermediate"
 						display_values="Einfahrsignal,Ausfahrsignal,Blocksignal,Zwischensignal"
-						default=""
 						/>
 					<multiselect key="railway:signal:main:substitute_signal"
 						text="Substitute signal (multi-selection)"
@@ -464,7 +435,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<text key="ref"
 						text="Signal ref"
 						de.text="Signalbezeichnung"
-						default=""
 						/>
 					<check key="railway:signal:distant:deactivated"
 						text="Out of order"
@@ -476,14 +446,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						de.text="Signalstandort"
 						values="left,right,bridge"
 						display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
-						default=""
 						/>
 					<combo key="railway:signal:direction"
 						text="Direction"
 						de.text="Anzeigerichtung"
 						values="forward,backward"
 						display_values="In Wegrichtung,Entgegen Wegrichtung"
-						default=""
 						/>
 					<space />
 					<key key="railway:signal:distant"
@@ -520,7 +488,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<text key="ref"
 						text="Signal ref"
 						de.text="Signalbezeichnung"
-						default=""
 						/>
 					<check key="railway:signal:combined:deactivated"
 						text="Out of order"
@@ -532,14 +499,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						de.text="Signalstandort"
 						values="left,right,bridge"
 						display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
-						default=""
 						/>
 					<combo key="railway:signal:direction"
 						text="Direction"
 						de.text="Anzeigerichtung"
 						values="forward,backward"
 						display_values="In Wegrichtung,Entgegen Wegrichtung"
-						default=""
 						/>
 					<space />
 					<key key="railway:signal:combined"
@@ -551,7 +516,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						de.text="Signalbauform"
 						values="normal,dwarf"
 						display_values="Mastbauform,Zwergsignal"
-						default=""
 						/>
 					<combo key="railway:signal:combined:states" default="DE-ESO:hp0;DE-ESO:sk1;DE-ESO:sk2"
 						text="Signal states"
@@ -565,7 +529,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						de.text="Signalaufgabe"
 						values="entry,exit,block,intermediate"
 						display_values="Einfahrsignal,Ausfahrsignal,Blocksignal,Zwischensignal"
-						default=""
 						/>
 					<multiselect key="railway:signal:combined:substitute_signal"
 						text="Substitute signal (multi-selection)"
@@ -594,7 +557,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<text key="ref"
 						text="Signal ref"
 						de.text="Signalbezeichnung"
-						default=""
 						/>
 					<check key="railway:signal:main:deactivated"
 						text="Out of order"
@@ -606,14 +568,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						de.text="Signalstandort"
 						values="left,right,bridge"
 						display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
-						default=""
 						/>
 					<combo key="railway:signal:direction"
 						text="Direction"
 						de.text="Anzeigerichtung"
 						values="forward,backward"
 						display_values="In Wegrichtung,Entgegen Wegrichtung"
-						default=""
 						/>
 					<space />
 					<key key="railway:signal:main"
@@ -625,7 +585,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						de.text="Signalbauform"
 						values="normal,dwarf"
 						display_values="Mastbauform,Zwergsignal"
-						default=""
 						/>
 					<combo key="railway:signal:main:states" default="DE-ESO:hp0;DE-ESO:sk1"
 						text="Signal states"
@@ -639,7 +598,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						de.text="Signalaufgabe"
 						values="entry,exit,block,intermediate"
 						display_values="Einfahrsignal,Ausfahrsignal,Blocksignal,Zwischensignal"
-						default=""
 						/>
 					<multiselect key="railway:signal:main:substitute_signal"
 						text="Substitute signal (multi-selection)"
@@ -666,7 +624,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<text key="ref"
 						text="Signal ref"
 						de.text="Signalbezeichnung"
-						default=""
 						/>
 					<check key="railway:signal:distant:deactivated"
 						text="Out of order"
@@ -678,14 +635,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						de.text="Signalstandort"
 						values="left,right,bridge"
 						display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
-						default=""
 						/>
 					<combo key="railway:signal:direction"
 						text="Direction"
 						de.text="Anzeigerichtung"
 						values="forward,backward"
 						display_values="In Wegrichtung,Entgegen Wegrichtung"
-						default=""
 						/>
 					<space />
 					<key key="railway:signal:distant"
@@ -724,7 +679,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<text key="ref"
 						text="Signal ref"
 						de.text="Signalbezeichnung"
-						default=""
 						/>
 					<check key="railway:signal:main:deactivated"
 						text="Out of order"
@@ -736,14 +690,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						de.text="Signalstandort"
 						values="left,right,bridge"
 						display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
-						default=""
 						/>
 					<combo key="railway:signal:direction"
 						text="Direction"
 						de.text="Anzeigerichtung"
 						values="forward,backward"
 						display_values="In Wegrichtung,Entgegen Wegrichtung"
-						default=""
 						/>
 					<space />
 					<key key="railway:signal:main"
@@ -755,7 +707,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						de.text="Signalbauform"
 						values="normal,dwarf"
 						display_values="Mastbauform,Zwergsignal"
-						default=""
 						/>
 					<multiselect key="railway:signal:main:states"
 						text="Signal states (multi-selection)"
@@ -770,7 +721,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						de.text="Signalaufgabe"
 						values="entry,exit,block,intermediate"
 						display_values="Einfahrsignal,Ausfahrsignal,Blocksignal,Zwischensignal"
-						default=""
 						/>
 					<multiselect key="railway:signal:main:substitute_signal"
 						text="Substitute signal (multi-selection)"
@@ -795,7 +745,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<text key="ref"
 						text="Signal ref"
 						de.text="Signalbezeichnung"
-						default=""
 						/>
 					<check key="railway:signal:main:deactivated"
 						text="Out of order"
@@ -807,14 +756,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						de.text="Signalstandort"
 						values="left,right,bridge"
 						display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
-						default=""
 						/>
 					<combo key="railway:signal:direction"
 						text="Direction"
 						de.text="Anzeigerichtung"
 						values="forward,backward"
 						display_values="In Wegrichtung,Entgegen Wegrichtung"
-						default=""
 						/>
 					<space />
 					<key key="railway:signal:main"
@@ -826,7 +773,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						de.text="Signalbauform"
 						values="normal,dwarf"
 						display_values="Mastbauform,Zwergsignal"
-						default=""
 						/>
 					<multiselect key="railway:signal:main:states"
 						text="Signal states (multi-selection)"
@@ -841,7 +787,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						de.text="Signalaufgabe"
 						values="entry,exit,block,intermediate"
 						display_values="Einfahrsignal,Ausfahrsignal,Blocksignal,Zwischensignal"
-						default=""
 						/>
 					<multiselect key="railway:signal:main:substitute_signal"
 						text="Substitute signal (multi-selection)"
@@ -870,7 +815,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<text key="ref"
 						text="Signal ref"
 						de.text="Signalbezeichnung"
-						default=""
 						/>
 					<check key="railway:signal:distant:deactivated"
 						text="Out of order"
@@ -882,14 +826,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						de.text="Signalstandort"
 						values="left,right,bridge"
 						display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
-						default=""
 						/>
 					<combo key="railway:signal:direction"
 						text="Direction"
 						de.text="Anzeigerichtung"
 						values="forward,backward"
 						display_values="In Wegrichtung,Entgegen Wegrichtung"
-						default=""
 						/>
 					<space />
 					<key key="railway:signal:distant"
@@ -901,7 +843,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						de.text="Signalbauform"
 						values="normal,dwarf"
 						display_values="Mastbauform,Zwergsignal"
-						default=""
 						/>
 					<multiselect key="railway:signal:distant:states"
 						text="Signal states (multi-selection)"
@@ -915,7 +856,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						de.text="Verkürzter Bremsweg"
 						values="DE-ESO:db:ne2,DE-ESO:dr:so3c"
 						display_values="DB (weißes Dreieck),DR (Kreis)"
-						default=""
 						/>
 					<check key="railway:signal:distant:repeated"
 						text="Repeated Signal"
@@ -935,7 +875,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<text key="ref"
 						text="Signal ref"
 						de.text="Signalbezeichnung"
-						default=""
 						/>
 					<check key="railway:signal:distant:deactivated"
 						text="Out of order"
@@ -947,14 +886,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						de.text="Signalstandort"
 						values="left,right,bridge"
 						display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
-						default=""
 						/>
 					<combo key="railway:signal:direction"
 						text="Direction"
 						de.text="Anzeigerichtung"
 						values="forward,backward"
 						display_values="In Wegrichtung,Entgegen Wegrichtung"
-						default=""
 						/>
 					<space />
 					<key key="railway:signal:distant"
@@ -966,7 +903,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						de.text="Signalbauform"
 						values="normal,dwarf"
 						display_values="Mastbauform,Zwergsignal"
-						default=""
 						/>
 					<multiselect key="railway:signal:distant:states"
 						text="Signal states (multi-selection)"
@@ -1015,19 +951,16 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Signalstandort"
 					values="left,right,bridge"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
-					default=""
 					/>
 				<combo key="railway:signal:direction"
 					text="Direction"
 					de.text="Anzeigerichtung"
 					values="forward,backward"
 					display_values="In Wegrichtung,Entgegen Wegrichtung"
-					default=""
 					/>
 				<text key="railway:position:exact"
 					text="Exact position of wrong-line signals (e.g. '13.427')"
 					de.text="Standortangabe an Trapeztafeln im Gegengleis (z. B. '13.427')"
-					default=""
 					/>
 				<space />
 				<key key="railway:signal:main"
@@ -1039,7 +972,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Signalbauform"
 					values="normal,dwarf"
 					display_values="Normalhöhe,Zwergsignal"
-					default=""
 					/>
 				<key key="railway:signal:main:function"
 					value="entry" />
@@ -1060,14 +992,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Signalstandort"
 					values="left,right,bridge"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
-					default=""
 					/>
 				<combo key="railway:signal:direction"
 					text="Direction"
 					de.text="Anzeigerichtung"
 					values="forward,backward"
 					display_values="In Wegrichtung,Entgegen Wegrichtung"
-					default=""
 					/>
 				<space />
 				<combo key="railway:signal:distant"
@@ -1075,7 +1005,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Typ"
 					values="DE-ESO:db:ne2,DE-ESO:dr:so3,DE-ESO:dr:so3b"
 					display_values="Ne 2 ex-DB,So 3 ex-DR, So 3b ex-DR (mit schwarzem Punkt)"
-					default=""
 					match="keyvalue!" />
 				<key key="railway:signal:distant:form"
 					value="sign" />
@@ -1101,14 +1030,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Signalstandort"
 					values="left,right,bridge"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
-					default=""
 					/>
 				<combo key="railway:signal:direction"
 					text="Direction"
 					de.text="Anzeigerichtung"
 					values="forward,backward"
 					display_values="In Wegrichtung,Entgegen Wegrichtung"
-					default=""
 					/>
 				<space />
 				<key key="railway:signal:distant"
@@ -1134,14 +1061,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						de.text="Signalstandort"
 						values="left,right,bridge"
 						display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
-						default=""
 						/>
 					<combo key="railway:signal:direction"
 						text="Direction"
 						de.text="Anzeigerichtung"
 						values="forward,backward"
 						display_values="In Wegrichtung,Entgegen Wegrichtung"
-						default=""
 						/>
 					<space />
 					<combo key="railway:signal:crossing"
@@ -1149,14 +1074,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						de.text="Signaltyp"
 						values="DE-ESO:bü,DE-ESO:so16"
 						display_values="Bü (ex-DB),So 16 (ex-DR)"
-						default=""
 						match="keyvalue!" />
 					<combo key="railway:signal:crossing:states"
 						text="Signal states"
 						de.text="Signalzustände"
 						values="DE-ESO:bü0;DE-ESO:bü1,DE-ESO:so16a;DE-ESO:so16b"
 						display_values="Bü 0/1 (ex-DB),So 16a/b (ex-DR)"
-						default=""
 						/>
 					<key key="railway:signal:crossing:form"
 						value="light" />
@@ -1187,14 +1110,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						de.text="Signalstandort"
 						values="left,right,bridge"
 						display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
-						default=""
 						/>
 					<combo key="railway:signal:direction"
 						text="Direction"
 						de.text="Anzeigerichtung"
 						values="forward,backward"
 						display_values="In Wegrichtung,Entgegen Wegrichtung"
-						default=""
 						/>
 					<space />
 					<combo key="railway:signal:crossing_distant"
@@ -1202,7 +1123,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						de.text="Signaltyp"
 						values="DE-ESO:bü2,DE-ESO:so15"
 						display_values="Bü 2 'Rautentafel' ex-DB,So 15 ex-DR"
-						default=""
 						match="keyvalue!" />
 					<key key="railway:signal:crossing_distant:form"
 						value="sign" />
@@ -1238,14 +1158,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						de.text="Signalstandort"
 						values="left,right,bridge"
 						display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
-						default=""
 						/>
 					<combo key="railway:signal:direction"
 						text="Direction"
 						de.text="Anzeigerichtung"
 						values="forward,backward"
 						display_values="In Wegrichtung,Entgegen Wegrichtung"
-						default=""
 						/>
 					<key key="railway:signal:crossing_distant"
 						value="DE-ESO:bü3"
@@ -1274,7 +1192,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						de.text="Signalstandort"
 						values="left,right,bridge"
 						display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
-						default=""
 						/>
 					<key key="railway:signal:direction"
 						value="both" />
@@ -1300,14 +1217,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						de.text="Signalstandort"
 						values="left,right,bridge"
 						display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
-						default=""
 						/>
 					<combo key="railway:signal:direction"
 						text="Direction"
 						de.text="Anzeigerichtung"
 						values="forward,backward"
 						display_values="In Wegrichtung,Entgegen Wegrichtung"
-						default=""
 						/>
 					<space />
 					<combo key="railway:signal:whistle"
@@ -1315,7 +1230,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						de.text="Signaltyp"
 						values="DE-ESO:db:bü4,DE-ESO:dr:pf1,DE-ESO:dr:pf2"
 						display_values="Bü 4 (ex-DB),Pf 1 (einfache Pfeiftafel ex-DR),Pf 2 (doppelte Pfeiftafel ex-DR)"
-						default=""
 						/>
 					<key key="railway:signal:whistle:form"
 						value="sign" />
@@ -1346,14 +1260,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						de.text="Signalstandort"
 						values="left,right,bridge"
 						display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
-						default=""
 						/>
 					<combo key="railway:signal:direction"
 						text="Direction"
 						de.text="Anzeigerichtung"
 						values="forward,backward"
 						display_values="In Wegrichtung,Entgegen Wegrichtung"
-						default=""
 						/>
 					<key key="railway:signal:ring"
 						value="DE-ESO:bü5" />
@@ -1381,14 +1293,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						de.text="Signalstandort"
 						values="left,right"
 						display_values="Links von Wegrichtung,Rechts von Wegrichtung"
-						default=""
 						/>
 					<combo key="railway:signal:direction"
 						text="Direction"
 						de.text="Anzeigerichtung"
 						values="forward,backward"
 						display_values="In Wegrichtung,Entgegen Wegrichtung"
-						default=""
 						/>
 					<key key="railway:signal:crossing_info"
 						value="DE-ESO:bü-kennzeichentafel" />
@@ -1397,7 +1307,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<text key="railway:signal:crossing_info:caption"
 						text="Caption (e.g. 'Bü 123,4')"
 						de.text="Beschriftung (z. B. 'Bü 123,4')"
-						default=""
 						/>
 					<check key="railway:signal:crossing_info:repeated"
 						text="Repeated"
@@ -1408,7 +1317,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						text="Signal height"
 						de.text="Signalbauform"
 						values="normal,dwarf"
-						default=""
 						display_values="Mastbauform,Zwergsignal"
 						/>
 				</item>
@@ -1428,14 +1336,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						de.text="Signalstandort"
 						values="left,right"
 						display_values="Links von Wegrichtung,Rechts von Wegrichtung"
-						default=""
 						/>
 					<combo key="railway:signal:direction"
 						text="Direction"
 						de.text="Anzeigerichtung"
 						values="forward,backward"
 						display_values="In Wegrichtung,Entgegen Wegrichtung"
-						default=""
 						/>
 					<key key="railway:signal:crossing_hint"
 						value="DE-ESO:bü-ankündetafel" />
@@ -1444,7 +1350,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<text key="railway:signal:crossing_hint:caption"
 						text="Caption (e.g. 'Bü 123,4')"
 						de.text="Beschriftung (z. B. 'Bü 123,4')"
-						default=""
 						/>
 					<check key="railway:signal:crossing_hint:repeated"
 						text="Repeated"
@@ -1455,7 +1360,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						text="Signal height"
 						de.text="Signalbauform"
 						values="normal,dwarf"
-						default=""
 						display_values="Mastbauform,Zwergsignal"
 						/>
 				</item>
@@ -1470,7 +1374,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<text key="ref"
 						text="Signal ref"
 						de.text="Signalbezeichnung"
-						default=""
 						/>
 					<check key="railway:signal:minor:deactivated"
 						text="Out of order"
@@ -1482,14 +1385,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						de.text="Signalstandort"
 						values="left,right,bridge,in_track"
 						display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke,Gleismitte/am Prellbock"
-						default=""
 						/>
 					<combo key="railway:signal:direction"
 						text="Direction"
 						de.text="Anzeigerichtung"
 						values="forward,backward"
 						display_values="In Wegrichtung,Entgegen Wegrichtung"
-						default=""
 						/>
 					<space />
 					<key key="railway:signal:minor"
@@ -1499,21 +1400,18 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						de.text="Anzeigeart"
 						values="light,semaphore,sign"
 						display_values="Lichtsignal,Formsignal,Tafel"
-						default=""
 						/>
 					<combo key="railway:signal:minor:height"
 						text="Signal height"
 						de.text="Signalbauform"
 						values="normal,dwarf"
 						display_values="Mastbauform,Zwergsignal"
-						default=""
 						/>
 					<combo key="railway:signal:minor:states"
 						text="Displayed signals"
 						de.text="Angezeigte Signalbilder"
 						values="DE-ESO:hp0;DE-ESO:sh1,DE-ESO:sh0;DE-ESO:sh1,DE-ESO:hp0;DE-ESO:kennlicht"
 						display_values="Lichtsignal (Hp 0/Sh 1),Formsignal (Sh 0/Sh 1),Zugdeckungssignal (Hp 0/Kennlicht)"
-						default=""
 						/>
 					<space />
 					<label text="Signal Gsp 2 siehe 'Gleissperre'" />
@@ -1534,14 +1432,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						de.text="Signalstandort"
 						values="left,right,in_track"
 						display_values="Links von Wegrichtung,Rechts von Wegrichtung,Gleismitte/am Prellbock"
-						default=""
 						/>
 					<combo key="railway:signal:direction"
 						text="Direction"
 						de.text="Anzeigerichtung"
 						values="forward,backward,both"
 						display_values="In Wegrichtung,Entgegen Wegrichtung,Beide Richtungen"
-						default=""
 						/>
 					<space />
 					<key key="railway:signal:minor"
@@ -1560,7 +1456,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<text key="ref"
 						text="Signal ref"
 						de.text="Signalbezeichnung"
-						default=""
 						/>
 					<check key="railway:signal:minor_distant:deactivated"
 						text="Out of order"
@@ -1572,14 +1467,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						de.text="Signalstandort"
 						values="left,right,bridge"
 						display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
-						default=""
 						/>
 					<combo key="railway:signal:direction"
 						text="Direction"
 						de.text="Anzeigerichtung"
 						values="forward,backward"
 						display_values="In Wegrichtung,Entgegen Wegrichtung"
-						default=""
 						/>
 					<space />
 					<key key="railway:signal:minor_distant"
@@ -1591,7 +1484,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						de.text="Signalbauform"
 						values="normal,dwarf"
 						display_values="Mastbauform,Zwergsignal"
-						default=""
 						/>
 				</item>
 			</group>
@@ -1612,14 +1504,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						de.text="Signalstandort"
 						values="left,right"
 						display_values="Links von Wegrichtung,Rechts von Wegrichtung"
-						default=""
 						/>
 					<combo key="railway:signal:direction"
 						text="Direction"
 						de.text="Anzeigerichtung"
 						values="forward,backward"
 						display_values="In Wegrichtung,Entgegen Wegrichtung"
-						default=""
 						/>
 					<space />
 					<key key="railway:signal:shunting"
@@ -1631,7 +1521,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						de.text="Signalbauform"
 						values="normal,dwarf"
 						display_values="Mastbauform,Zwergsignal"
-						default=""
 						/>
 				</item>
 				<item name="Rangierhaltsignal" icon="de/ra11-sign-32.png" type="node">
@@ -1650,14 +1539,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						de.text="Signalstandort"
 						values="left,right"
 						display_values="Links von Wegrichtung,Rechts von Wegrichtung"
-						default=""
 						/>
 					<combo key="railway:signal:direction"
 						text="Direction"
 						de.text="Anzeigerichtung"
 						values="forward,backward"
 						display_values="In Wegrichtung,Entgegen Wegrichtung"
-						default=""
 						/>
 					<space />
 					<combo key="railway:signal:shunting"
@@ -1665,28 +1552,24 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						de.text="Signaltyp"
 						values="DE-ESO:ra11,DE-ESO:ra11b"
 						display_values="Ra 11 (gelb),Ra 11b (weiß)"
-						default=""
 						match="keyvalue!" />
 					<combo key="railway:signal:shunting:form"
 						text="Signal form"
 						de.text="Anzeigeart"
 						values="light,sign"
 						display_values="Lichtsignal mit Sh 1,Tafel"
-						default=""
 						/>
 					<combo key="railway:signal:shunting:states"
 						text="Signal states"
 						de.text="Signalzustände"
 						values="DE-ESO:ra11;DE-ESO:sh1, "
 						display_values="Ra 11 / Sh 1,-nur Tafel-"
-						default=""
 						/>
 					<combo key="railway:signal:shunting:height"
 						text="Signal height"
 						de.text="Signalbauform"
 						values="normal,dwarf"
 						display_values="Mastbauform,Zwergsignal"
-						default=""
 						/>
 				</item>
 				<item name="Abdrücksignal (Ra 6–Ra 9)" icon="de-humping.png" type="node">
@@ -1705,14 +1588,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						de.text="Signalstandort"
 						values="left,right"
 						display_values="Links von Wegrichtung,Rechts von Wegrichtung"
-						default=""
 						/>
 					<combo key="railway:signal:direction"
 						text="Direction"
 						de.text="Anzeigerichtung"
 						values="forward,backward"
 						display_values="In Wegrichtung,Entgegen Wegrichtung"
-						default=""
 						/>
 					<space />
 					<key key="railway:signal:humping"
@@ -1722,7 +1603,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						de.text="Anzeigeart"
 						values="light,semaphore"
 						display_values="Lichtsignal,Formsignal"
-						default=""
 						/>
 					<key key="railway:signal:humping:states"
 						value="DE-ESO:ra6;DE-ESO:ra7;DE-ESO:ra8;DE-ESO:ra9" />
@@ -1731,7 +1611,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						de.text="Signalbauform"
 						values="normal,dwarf"
 						display_values="Mastbauform,Zwergsignal"
-						default=""
 						/>
 				</item>
 				<item name="Grenzzeichen (Ra 12)" icon="de/ra12.png" type="node">
@@ -1745,7 +1624,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						de.text="Signalstandort"
 						values="left,right"
 						display_values="Links von Wegrichtung,Rechts von Wegrichtung"
-						default=""
 						/>
 					<key key="railway:signal:fouling_point"
 						value="DE-ESO:ra12" />
@@ -1768,14 +1646,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						de.text="Signalstandort"
 						values="left,right,bridge"
 						display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
-						default=""
 						/>
 					<combo key="railway:signal:direction"
 						text="Direction"
 						de.text="Anzeigerichtung"
 						values="forward,backward"
 						display_values="In Wegrichtung,Entgegen Wegrichtung"
-						default=""
 						/>
 					<space />
 					<key key="railway:signal:route"
@@ -1783,7 +1659,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<text key="railway:signal:route:states"
 						text="Signal states (separated by ';', use '?' if you don't know all possible values)"
 						de.text="Mögliche Anzeigewerte (getrennt durch ';', verwende '?', wenn du nicht alle Werte kennst)"
-						default=""
 						/>
 					<key key="railway:signal:route:form"
 						value="light" />
@@ -1804,14 +1679,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						de.text="Signalstandort"
 						values="left,right,bridge"
 						display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
-						default=""
 						/>
 					<combo key="railway:signal:direction"
 						text="Direction"
 						de.text="Anzeigerichtung"
 						values="forward,backward"
 						display_values="In Wegrichtung,Entgegen Wegrichtung"
-						default=""
 						/>
 					<space />
 					<key key="railway:signal:route_distant"
@@ -1819,7 +1692,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<text key="railway:signal:route_distant:states"
 						text="Signal states (separated by ';', use '?' if you don't know all possible values)"
 						de.text="Mögliche Anzeigewerte (getrennt durch ';', verwende '?', wenn du nicht alle Werte kennst)"
-						default=""
 						/>
 					<key key="railway:signal:route_distant:form"
 						value="light" />
@@ -1841,14 +1713,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						de.text="Signalstandort"
 						values="left,right,bridge"
 						display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
-						default=""
 						/>
 					<combo key="railway:signal:direction"
 						text="Direction"
 						de.text="Anzeigerichtung"
 						values="forward,backward"
 						display_values="In Wegrichtung,Entgegen Wegrichtung"
-						default=""
 						/>
 					<space />
 					<key key="railway:signal:speed_limit"
@@ -1870,7 +1740,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						text="Signal height"
 						de.text="Signalbauform"
 						values="normal,dwarf"
-						default=""
 						display_values="Mastbauform,Zwergsignal"
 						/>
 				</item>
@@ -1890,14 +1759,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						de.text="Signalstandort"
 						values="left,right,bridge"
 						display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
-						default=""
 						/>
 					<combo key="railway:signal:direction"
 						text="Direction"
 						de.text="Anzeigerichtung"
 						values="forward,backward"
 						display_values="In Wegrichtung,Entgegen Wegrichtung"
-						default=""
 						/>
 					<space />
 					<key key="railway:signal:speed_limit_distant"
@@ -1907,7 +1774,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						de.text="Anzeigeart"
 						values="light,sign"
 						display_values="Lichtsignal,Tafel"
-						default=""
 						/>
 					<multiselect key="railway:signal:speed_limit_distant:speed" 
 						text="Speed (km/h)"
@@ -1920,7 +1786,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						text="Signal height"
 						de.text="Signalbauform"
 						values="normal,dwarf"
-						default=""
 						display_values="Mastbauform,Zwergsignal"
 						/>
 				</item>
@@ -1940,14 +1805,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						de.text="Signalstandort"
 						values="left,right,bridge"
 						display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
-						default=""
 						/>
 					<combo key="railway:signal:direction"
 						text="Direction"
 						de.text="Anzeigerichtung"
 						values="forward,backward"
 						display_values="In Wegrichtung,Entgegen Wegrichtung"
-						default=""
 						/>
 					<space />
 					<key key="railway:signal:speed_limit"
@@ -1957,7 +1820,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						de.text="Anzeigeart"
 						values="light,sign"
 						display_values="Lichtsignal,Tafel"
-						default=""
 						/>
 					<key key="railway:signal:speed_limit:speed"
 						value="none" />
@@ -1965,7 +1827,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						text="Signal height"
 						de.text="Signalbauform"
 						values="normal,dwarf"
-						default=""
 						display_values="Mastbauform,Zwergsignal"
 						/>
 				</item>
@@ -1986,17 +1847,15 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						de.text="Signalstandort"
 						values="left,right,bridge"
 						display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
-						default=""
 						/>
 					<combo key="railway:signal:direction"
 						text="Direction"
 						de.text="Anzeigerichtung"
 						values="forward,backward"
 						display_values="In Wegrichtung,Entgegen Wegrichtung"
-						default=""
 						/>
 					<space />
-					<combo key="railway:signal:wrong_road" text="Type" de.text="Typ" default="" match="keyvalue!">
+					<combo key="railway:signal:wrong_road" text="Type" de.text="Typ" match="keyvalue!">
 		         	<list_entry value="DE-ESO:db:zs6" display_value="Zs 6 DB" short_description="Gegengleisanzeiger Zs 6 (ex-DB)" />
 		         	<list_entry value="DE-ESO:dr:zs7" display_value="Zs 7 DR" short_description="Gegengleisanzeiger Zs 7 (ex-DR)" />
 		         </combo>
@@ -2005,7 +1864,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						de.text="Anzeigeart"
 						values="sign,light"
 						display_values="Tafel,Leuchtanzeige"
-						default=""
 						/>
 				</item>
 				<item name="Gegengleisfahrt-Ersatzsignal (Zs 8)" icon="de-zs8.png" type="node">
@@ -2024,17 +1882,15 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						de.text="Signalstandort"
 						values="left,right,bridge"
 						display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
-						default=""
 						/>
 					<combo key="railway:signal:direction"
 						text="Direction"
 						de.text="Anzeigerichtung"
 						values="forward,backward"
 						display_values="In Wegrichtung,Entgegen Wegrichtung"
-						default=""
 						/>
 					<space />
-					<combo key="railway:signal:wrong_road" text="Type" de.text="Typ" default="" match="keyvalue!">
+					<combo key="railway:signal:wrong_road" text="Type" de.text="Typ" match="keyvalue!">
 						<list_entry value="DE-ESO:db:zs8" display_value="Zs 8 DB" short_description="Falschfahrt-Auftragssignal Zs 8 (ex-DB)" />
 						<list_entry value="DE-ESO:dr:zs8" display_value="Zs 8 DR" short_description="Linksfahrtersatzsignal Zs 8 (ex-DR)" />
 		            </combo>
@@ -2043,7 +1899,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						de.text="Anzeigeart"
 						values="sign,light"
 						display_values="Tafel,Leuchtanzeige"
-						default=""
 						/>
 				</item>
 				<separator />
@@ -2063,14 +1918,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						de.text="Signalstandort"
 						values="left,right,bridge"
 						display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
-						default=""
 						/>
 					<combo key="railway:signal:direction"
 						text="Direction"
 						de.text="Anzeigerichtung"
 						values="forward,backward"
 						display_values="In Wegrichtung,Entgegen Wegrichtung"
-						default=""
 						/>
 					<space />
 					<combo key="railway:signal:short_route"
@@ -2078,20 +1931,17 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						de.text="Signaltyp"
 						values="DE-ESO:zs13,DE-ESO:dr:zs6,DE-ESO:dr:zs106"
 						display_values="Zs 13,Zs 6 (Lichtsignal ex-DR),Zs 106 (Tafel ex-DR)"
-						default=""
 						match="keyvalue!" />
 					<combo key="railway:signal:short_route:form"
 						text="Signal form"
 						de.text="Anzeigeart"
 						values="light,sign"
 						display_values="Lichtsignal,Tafel"
-						default=""
 						/>
 					<combo key="railway:signal:short_route:height"
 						text="Signal height"
 						de.text="Signalbauform"
 						values="normal,dwarf"
-						default=""
 						display_values="Mastbauform,Zwergsignal"
 						/>
 				</item>
@@ -2113,17 +1963,15 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						de.text="Signalstandort"
 						values="left,right,bridge"
 						display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
-						default=""
 						/>
 					<combo key="railway:signal:direction"
 						text="Direction"
 						de.text="Anzeigerichtung"
 						values="forward,backward"
 						display_values="In Wegrichtung,Entgegen Wegrichtung"
-						default=""
 						/>
 					<space />
-					<combo key="railway:signal:speed_limit" text="Type of signal" de.text="Signaltyp" default="" match="keyvalue!">
+					<combo key="railway:signal:speed_limit" text="Type of signal" de.text="Signaltyp" match="keyvalue!">
 						<list_entry value="DE-ESO:lf7" display_value="Lf 7" short_description="Geschwindigkeitssignal Lf 7" />
 						<list_entry value="DE-ESO:dr:lf1/2" display_value="Lf 1/2" short_description="Langsamfahrbeginnscheibe Lf 1/2 (ex-DR)" />
 						<list_entry value="DE-ESO:lf2" display_value="Lf 2" short_description="Anfangsscheibe Lf 2" />
@@ -2133,7 +1981,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					</combo>
 					<key key="railway:signal:speed_limit:form"
 						value="sign" />
-					<combo key="railway:signal:speed_limit:speed" default=""
+					<combo key="railway:signal:speed_limit:speed"
 						text="Speed (km/h)"
 						de.text="Geschwindigkeit (km/h)"
 						values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,none"
@@ -2143,7 +1991,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						text="Signal height"
 						de.text="Signalbauform"
 						values="normal,dwarf"
-						default=""
 						display_values="Mastbauform,Zwergsignal"
 						/>
 					<combo key="railway:signal:speed_limit:turn_direction"
@@ -2152,7 +1999,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						values="left,through,right"
 						display_values="Left,Through,Right"
 						de.display_values="Links,Geradeaus,Rechts"
-						default=""
 						/>
 				</item>
 				<item name="Geschwindigkeits-Ankündesignal" icon="de/lf6-60-sign-down-32.png" type="node">
@@ -2171,17 +2017,15 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						de.text="Signalstandort"
 						values="left,right,bridge"
 						display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
-						default=""
 						/>
 					<combo key="railway:signal:direction"
 						text="Direction"
 						de.text="Anzeigerichtung"
 						values="forward,backward"
 						display_values="In Wegrichtung,Entgegen Wegrichtung"
-						default=""
 						/>
 					<space />
-					<combo key="railway:signal:speed_limit_distant" text="Type of signal" de.text="Signaltyp" default="" match="keyvalue!">
+					<combo key="railway:signal:speed_limit_distant" text="Type of signal" de.text="Signaltyp" match="keyvalue!">
 						<list_entry value="DE-ESO:lf6" display_value="Lf 6" short_description="Geschwindigkeits-Ankündesignal Lf 6" />
 						<list_entry value="DE-ESO:lf1" display_value="Lf 1" short_description="Langsamfahrscheibe Lf 1" />
 						<list_entry value="DE-ESO:db:lf4" display_value="Lf 4 DB" short_description="Geschwindigkeitstafel Lf 4 (ex-DB)" />
@@ -2189,7 +2033,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					</combo>
 					<key key="railway:signal:speed_limit_distant:form"
 						value="sign" />
-					<combo key="railway:signal:speed_limit_distant:speed" default=""
+					<combo key="railway:signal:speed_limit_distant:speed"
 						text="Speed (km/h)"
 						de.text="Geschwindigkeit (km/h)"
 						values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,off"
@@ -2199,7 +2043,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						text="Signal height"
 						de.text="Signalbauform"
 						values="normal,dwarf"
-						default=""
 						display_values="Mastbauform,Zwergsignal"
 						/>
 					<combo key="railway:signal:speed_limit_distant:turn_direction"
@@ -2208,7 +2051,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						values="left,through,right"
 						display_values="Left,Through,Right"
 						de.display_values="Links,Geradeaus,Rechts"
-						default=""
 						/>
 				</item>
 			</group>
@@ -2228,14 +2070,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Signalstandort"
 					values="left,right"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung"
-					default=""
 					/>
 				<combo key="railway:signal:direction"
 					text="Direction"
 					de.text="Anzeigerichtung"
 					values="forward,backward"
 					display_values="In Wegrichtung,Entgegen Wegrichtung"
-					default=""
 					/>
 				<space />
 				<key key="railway:signal:resetting_switch"
@@ -2248,7 +2088,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Signal height"
 					de.text="Signalbauform"
 					values="normal,dwarf"
-					default=""
 					display_values="Mastbauform,Zwergsignal"
 					/>
 			</item>
@@ -2268,14 +2107,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Signalstandort"
 					values="left,right"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung"
-					default=""
 					/>
 				<combo key="railway:signal:direction"
 					text="Direction"
 					de.text="Anzeigerichtung"
 					values="forward,backward"
 					display_values="In Wegrichtung,Entgegen Wegrichtung"
-					default=""
 					/>
 				<space />
 				<key key="railway:signal:resetting_switch_distant"
@@ -2286,7 +2123,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Signal height"
 					de.text="Signalbauform"
 					values="normal,dwarf"
-					default=""
 					display_values="Mastbauform,Zwergsignal"
 					/>
 			</item>
@@ -2307,27 +2143,23 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Signalstandort"
 					values="left,right"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung"
-					default=""
 					/>
 				<combo key="railway:signal:direction"
 					text="Direction"
 					de.text="Anzeigerichtung"
 					values="forward,backward"
 					display_values="In Wegrichtung,Entgegen Wegrichtung"
-					default=""
 					/>
 				<combo key="railway:signal:expected_position"
 					text="Side of track where the signal would be mounted usually"
 					de.text="Gleisseite, auf der man das Signal normalerweise erwarten würde"
 					values="left,right"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung"
-					default=""
 					match="keyvalue!" />
 				<combo key="railway:signal:expected_position:height"
 					text="Signal height"
 					de.text="Signalbauform"
 					values="normal,dwarf"
-					default=""
 					display_values="Mastbauform,Zwergsignal"
 					/>
 			</item>
@@ -2347,14 +2179,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Signalstandort"
 					values="left,right"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung"
-					default=""
 					/>
 				<combo key="railway:signal:direction"
 					text="Direction"
 					de.text="Anzeigerichtung"
 					values="forward,backward"
 					display_values="In Wegrichtung,Entgegen Wegrichtung"
-					default=""
 					/>
 				<key key="railway:signal:stop"
 					value="DE-ESO:ne5" />
@@ -2364,13 +2194,11 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Signal height"
 					de.text="Signalbauform"
 					values="normal,dwarf"
-					default=""
 					display_values="Mastbauform,Zwergsignal"
 					/>
 				<text key="railway:signal:stop:caption"
 					text="Description"
 					de.text="Zusatztext"
-					default=""
 					/>
 			</item>
 			<item name="Haltepunkttafel (Ne 6)" icon="de/ne6-32.png" type="node">
@@ -2389,14 +2217,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Signalstandort"
 					values="left,right"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung"
-					default=""
 					/>
 				<combo key="railway:signal:direction"
 					text="Direction"
 					de.text="Anzeigerichtung"
 					values="forward,backward"
 					display_values="In Wegrichtung,Entgegen Wegrichtung"
-					default=""
 					/>
 				<key key="railway:signal:station_distant"
 					value="DE-ESO:ne6" />
@@ -2419,14 +2245,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Signalstandort"
 					values="left,right"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung"
-					default=""
 					/>
 				<combo key="railway:signal:direction"
 					text="Direction"
 					de.text="Anzeigerichtung"
 					values="forward,backward"
 					display_values="In Wegrichtung,Entgegen Wegrichtung"
-					default=""
 					/>
 				<key key="railway:signal:snowplow"
 					value="DE-ESO:ne7" />
@@ -2436,14 +2260,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Signal height"
 					de.text="Signalbauform"
 					values="normal,dwarf"
-					default=""
 					display_values="Mastbauform,Zwergsignal"
 					/>
 				<combo key="railway:signal:snowplow:type"
 					text="Order"
 					de.text="Anweisung"
 					values="up,down"
-					default=""
 					display_values="Heben,Senken"
 					/>
 			</item>
@@ -2456,7 +2278,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<text key="ref"
 					text="Signal ref"
 					de.text="Signalbezeichner"
-					default=""
 					/>
 				<check key="railway:signal:train_protection:deactivated"
 					text="Out of order"
@@ -2468,14 +2289,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Signalstandort"
 					values="left,right,bridge,overhead"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke,Oberleitung"
-					default=""
 					/>
 				<combo key="railway:signal:direction"
 					text="Direction"
 					de.text="Anzeigerichtung"
 					values="forward,backward"
 					display_values="In Wegrichtung,Entgegen Wegrichtung"
-					default=""
 					/>
 				<check key="railway:signal:catenary_mast"
 					text="On catenary mast"
@@ -2505,14 +2324,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Signalstandort"
 					values="left,right,overhead"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung,Oberleitung"
-					default=""
 					/>
 				<combo key="railway:signal:direction"
 					text="Direction"
 					de.text="Anzeigerichtung"
 					values="forward,backward"
 					display_values="In Wegrichtung,Entgegen Wegrichtung"
-					default=""
 					/>
 				<space />
 				<combo key="railway:signal:electricity"
@@ -2520,7 +2337,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Signaltyp"
 					values="DE-ESO:el1v,DE-ESO:el1,DE-ESO:el2,DE-ESO:el3,DE-ESO:el4,DE-ESO:el5,DE-ESO:el6"
 					display_values="Ausschaltsignal erwarten (El 1v),Ausschaltsignal (El 1),Einschaltsignal (El 2),Bügel-ab-Signal erwarten (El 3),Bügel-ab-Signal (El 4),Bügel-an-Signal (El 5),Halt für Fahrzeuge mit gehobenem Stromabnehmer (El 6)"
-					default=""
 					/>
 				<combo key="railway:signal:electricity:turn_direction"
 					text="Turn direction arrow – leave this key empty if there is no one."
@@ -2528,13 +2344,11 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="left,through,right"
 					display_values="Left,Through,Right"
 					de.display_values="Links,Geradeaus,Rechts"
-					default=""
 					/>
 				<combo key="railway:signal:electricity:height"
 					text="Signal height"
 					de.text="Signalbauform"
 					values="normal,dwarf"
-					default=""
 					display_values="Mastbauform,Zwergsignal"
 					/>
 				<combo key="railway:signal:electricity:type"
@@ -2542,19 +2356,16 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Bedeutung"
 					values="power_off_advance,power_off,power_on,pantograph_down_advance,pantograph_down,pantograph_up,end_of_catenary"
 					display_values="Ausschaltsignal erwarten (El 1v),Ausschaltsignal (El 1),Einschaltsignal (El 2),Bügel-ab-Signal erwarten (El 3),Bügel-ab-Signal (El 4),Bügel-an-Signal (El 5),Halt für Fahrzeuge mit gehobenem Stromabnehmer (El 6)"
-					default=""
 					/>
 				<key key="railway:signal:electricity:form"
 					value="sign" />
 				<text key="railway:signal:electricity:voltage"
 					text="Voltage (if mentioned)"
 					de.text="Spannung (falls angezeigt)"
-					default=""
 					/>
 				<text key="railway:signal:electricity:frequency"
 					text="Frequency (if mentioned)"
 					de.text="Frequenz (falls angezeigt)"
-					default=""
 					/>
 			</item>
 			<separator />
@@ -2567,7 +2378,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<text key="ref"
 					text="Signal ref"
 					de.text="Signalbezeichnung"
-					default=""
 					/>
 				<check key="railway:signal:main_repeated:deactivated"
 					text="Out of order"
@@ -2579,14 +2389,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Signalstandort"
 					values="left,right,bridge"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
-					default=""
 					/>
 				<combo key="railway:signal:direction"
 					text="Direction"
 					de.text="Anzeigerichtung"
 					values="forward,backward,both"
 					display_values="In Wegrichtung,Entgegen Wegrichtung,Beide Richtungen"
-					default=""
 					/>
 				<space />
 				<key key="railway:signal:main_repeated"
@@ -2610,14 +2418,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Signalstandort"
 					values="left,right,bridge"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
-					default=""
 					/>
 				<combo key="railway:signal:direction"
 					text="Direction"
 					de.text="Anzeigerichtung"
 					values="forward,backward,both"
 					display_values="In Wegrichtung,Entgegen Wegrichtung,Beide Richtungen"
-					default=""
 					/>
 				<key key="railway:signal:departure"
 					value="DE-ESO:zp" />
@@ -2647,14 +2453,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Signalstandort"
 					values="left,right,bridge"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
-					default=""
 					/>
 				<combo key="railway:signal:direction"
 					text="Direction"
 					de.text="Anzeigerichtung"
 					values="forward,backward,both"
 					display_values="In Wegrichtung,Entgegen Wegrichtung,Beide Richtungen"
-					default=""
 					/>
 				<key key="railway:signal:brake_test"
 					value="DE-ESO:zp" />
@@ -2683,14 +2487,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Signalstandort"
 					values="left,right"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung"
-					default=""
 					/>
 				<combo key="railway:signal:direction"
 					text="Direction"
 					de.text="Anzeigerichtung"
 					values="forward,backward"
 					display_values="In Wegrichtung,Entgegen Wegrichtung"
-					default=""
 					/>
 				<check key="railway:signal:catenary_mast"
 					text="On catenary mast"
@@ -2700,7 +2502,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<text key="ref"
 					text="Block reference"
 					de.text="Blockbezeichner"
-					default=""
 					/>
 				<key key="railway:signal:train_protection"
 					value="DE-ESO:blockkennzeichen" /> 
@@ -2725,14 +2526,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Signalstandort"
 					values="left,right"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung"
-					default=""
 					/>
 				<combo key="railway:signal:direction"
 					text="Direction"
 					de.text="Anzeigerichtung"
 					values="forward,backward"
 					display_values="In Wegrichtung,Entgegen Wegrichtung"
-					default=""
 					/>
 				<check key="railway:signal:catenary_mast"
 					text="On catenary mast"
@@ -2755,7 +2554,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Signalstandort"
 					values="left,right"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung"
-					default=""
 					/>
 				<key key="railway:signal:radio"
 					value="DE-ESO:zugfunk-kanalhinweis" />
@@ -2764,7 +2562,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<text key="railway:signal:radio:frequency"
 					text="Frequency/Channel"
 					de.text="Kanal"
-					default=""
 					/>
 			</item>
 	</group>

--- a/josm-presets/de.xml
+++ b/josm-presets/de.xml
@@ -22,20 +22,17 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<text key="ref"
 					text="Line reference (VzG number, e.g. '2379')"
 					de.text="Streckennummer (VzG-Nummer, z. B. '2379')"
-					default=""
 					/>
 				<text key="railway:track_ref"
 					text="Track ref (inside station)"
 					de.text="Gleisnummer (im Bahnhof)"
-					default=""
 					/>
 				<text key="name"
 					text="Railway name"
 					de.text="Streckenname"
-					default=""
 					/>
 				<space />	
-				<combo key="usage" text="Usage" de.text="Nutzung" default="">
+				<combo key="usage" text="Usage" de.text="Nutzung">
 					<list_entry value="main" de.display_value="Hauptbahn" display_value="main line" de.short_description="Strecke mit übergeordneter Bedeutung; meist zweigleisig, meist elektrifiziert, in der Regel zumindest abschnittsweise mit mehr als 100 km/h befahrbar" short_description="An important line; often double tracks, electrified; usually more than 100 km/h" />
 					<list_entry value="branch" de.display_value="Nebenbahn" display_value="branch line" de.short_description="Strecke mit untergeordneter Bedeutung; oft nicht elektrifiziert, oft eingleisig. Keinesfalls mit mehr als 100 km/h befahrbar." short_description="less important line; often single-tracked; not electrified; less than 100 km/h" />
 					<list_entry value="industrial" de.display_value="Industriebahn" display_value="industrial/mine railway" de.short_description="Eine Strecke, die ausschließlich dem Güterverkehr dient und in der Regel Eigentum eines Industrieunternehmens ist. Meist nur innerhalb von Hafengebieten, Industrieanlagen, Tagebauen." short_description="A line only used for freight trains inside industrial areas or mines." />
@@ -48,7 +45,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Verkehrsart"
 					values="mixed,passenger,freight"
 					de.display_values="Gemischt,Personenverkehr,Güterverkehr" display_values="mixed,passenger,freight"
-					default=""
 					/>
 				<check key="highspeed"
 					text="High-speed line (~ >200 km/h)"
@@ -81,14 +77,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Geschwindigkeitsüberwachung Neigetechnik"
 					values="yes,no,zub122,zub262"
 					display_values="Ja,Nein,ZUB122,ZUB262"
-					default=""
 					/>
 				<combo key="railway:etcs"
 					text="ETCS"
 					de.text="ETCS"
 					values="yes,no,0,1,2,3"
 					display_values="Ja,Nein,Level 0,Level 1,Level 2,Level 3"
-					default=""
 					/>
 				<combo key="railway:radio"
 					text="Radio"
@@ -96,26 +90,25 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="analogue,gsm-r"
 					display_values="analogue,GSM-R"
 					de.display_values="Analog,GSM-R"
-					default=""
 					/>
-				<combo key="railway:preferred_direction" text="Direction of use (depends on direction of OSM way)" de.text="Regelfahrtrichtung (abhängig von Richtung des OSM-Ways)" default="">
+				<combo key="railway:preferred_direction" text="Direction of use (depends on direction of OSM way)" de.text="Regelfahrtrichtung (abhängig von Richtung des OSM-Ways)">
 					<list_entry value="forward" display_value="forward (in the same direction as the OSM way)" de.display_value="In Wegrichtung" short_description="Das Gleis wird üblicherweise in die Richtung befahren, in die der OSM-Way führt. Nur für mehrgleisige Strecken." />
 					<list_entry value="backward"  display_value="backward (in the other direction than the OSM way)" de.display_value="Entgegen Wegrichtung" short_description="Das Gleis wird üblicherweise entgegen der Richtung befahren, in die der OSM-Way führt. Nur für mehrgleisige Strecken." />
 					<list_entry value="both" display_value="both" de.display_value="Beide Richtungen" short_description="Es gibt keine Richtung, in die die Züge üblicherweise fahren bzw. nicht fahren. Nur für eingleisige Strecken." />
 				</combo>
-				<combo key="railway:bidirectional" text="Bidirectional traffic (depends on direction of OSM way)" de.text="Gleiswechselbetrieb (abhängig von Richtung des OSM-Ways)" default="">
+				<combo key="railway:bidirectional" text="Bidirectional traffic (depends on direction of OSM way)" de.text="Gleiswechselbetrieb (abhängig von Richtung des OSM-Ways)">
 					<list_entry value="regular" de.display_value="Gleiswechselbetrieb" short_description="Das Gleis ist für beide Fahrtrichtungen mit Signalen ausgestattet und kann daher regulär entgegen der üblichen Fahrtrichtung befahren werden." />
 					<list_entry value="signals" de.display_value="Signalisierter Falschfahrbetrieb" short_description="Das Gleis ist signaltechnisch nur für eine Fahrtrichtung ausgelegt, sodass weiterhin Falschfahrten notwendig sind, diese sind aber durch Signale geregelt." />
 					<list_entry value="possible" de.display_value="Falschfahrt möglich" short_description="Signaltechnisch besteht keine Möglichkeit einer Befahrung des Gegengleises. Es ist ein schriftlicher Befehl notwendig." />
 				</combo>
 				<space />
-				<combo key="maxspeed" default=""
+				<combo key="maxspeed"
 					text="Maxspeed (km/h)"
 					de.text="Höchstgeschwindigkeit (km/h)"
 					values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,none"
 					display_values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,keine" />
 				<label text="Different speed limits depending on direction can be tagged manually using maxspeed:forward= and maxspeed:backward=*." de.text="Unterschiedliche Geschwindigkeiten je Richtung können manuell mit maxspeed:forward=* bzw. maxspeed:backward=* getaggt werden." />
-				<combo key="maxspeed:tilting" default=""
+				<combo key="maxspeed:tilting"
 					text="Maxspeed of Used by tilting trains (km/h)"
 					de.text="Höchstgeschwindigkeit von Neigetechnikzügen (km/h)"
 					values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,none"
@@ -126,7 +119,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Elektrifizierung"
 					values="yes,no,contact_line,rail"
 					display_values="Ja,Nein,Ja (mit Oberleitung),Ja (mit Stromschiene)"
-					default=""
 					/>
 				<combo key="voltage"
 					text="Voltage"
@@ -134,7 +126,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="15000,600,750,1200,1500,2400,3000,6600,25000"
 					display_values="15 kV (default in Germany),600 V,750 V,1200 V,1500 V,2400 V,3000 V,6600 V,25 kV"
 					de.display_values="15 kV (Standard in Deutschland),600 V,750 V,1200 V,1500 V,2400 V,3000 V,6600 V,25 kV"
-					default=""
 					/>
 				<combo key="frequency"
 					text="Frequency"
@@ -142,7 +133,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="16.7,0,16.67,50,60,25"					
 					de.display_values="16.7 Hz (Standard in Deutschland),Gleichspannung,16 2/3 Hz (in Teilen Deutschlands),50 Hz,60 Hz,25 Hz"
 					display_values="16.7 Hz (default in Germany),DC,16 2/3 Hz (in parts of Germany),50 Hz,60 Hz,25 Hz"
-					default=""
 					/>
 				<combo key="gauge"
 					text="Gauge"
@@ -161,23 +151,19 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Zahnstange"
 					values="yes,no,riggenbach,strub,abt,locher,riggenbach-klose,marsh,von_roll"
 					display_values="Ja,Nein,System Riggenbach,System Strub,System Abt,System Locher,System Riggenbach-Klose,System Marsh,System Von Roll"
-					default=""
 					/>
 				<text key="incline"
 					text="Incline (e.g.. '3%')"
 					de.text="Steigung (z. B. '3%')"
-					default=""
 					/>
 				<space />
 				<text key="start_date"
 					text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
-					default=""
 					/>
 				<text key="operator"
 					text="Operator (e.g. 'DB Netz AG')"
 					de.text="Betreiber (z. B. 'DB Netz AG')"
-					default=""
 					/>
 				<space />
 				<check key="embankment"
@@ -201,7 +187,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<text key="railway:track_ref"
 					text="Track ref (inside station)"
 					de.text="Gleisnummer (im Bahnhof)"
-					default=""
 					/>
 				<space />
 				<combo key="railway:traffic_mode"
@@ -209,7 +194,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Verkehrsart"
 					values="mixed,passenger,freight"
 					de.display_values="Gemischt,Personenverkehr,Güterverkehr" display_values="mixed,passenger,freight"
-					default=""
 					/>
 				<check key="highspeed"
 					text="High-speed line (~ >200 km/h)"
@@ -237,7 +221,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="ETCS"
 					values="yes,no,0,1,2,3"
 					display_values="Ja,Nein,Level 0,Level 1,Level 2,Level 3"
-					default=""
 					/>
 				<combo key="railway:radio"
 					text="Radio"
@@ -245,9 +228,8 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="analogue,gsm-r"
 					display_values="analogue,GSM-R"
 					de.display_values="Analog,GSM-R"
-					default=""
 					/>
-				<combo key="maxspeed" default=""
+				<combo key="maxspeed"
 					text="Maxspeed (km/h)"
 					de.text="Höchstgeschwindigkeit (km/h)"
 					values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,none"
@@ -259,7 +241,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Elektrifizierung"
 					values="yes,no,contact_line,rail"
 					display_values="Ja,Nein,Oberleitung,Stromschiene"
-					default=""
 					/>
 				<combo key="voltage"
 					text="Voltage"
@@ -267,7 +248,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="15000,600,750,1200,1500,2400,3000,6600,25000"
 					display_values="15 kV (default in Germany),600 V,750 V,1200 V,1500 V,2400 V,3000 V,6600 V,25 kV"
 					de.display_values="15 kV (Standard in Deutschland),600 V,750 V,1200 V,1500 V,2400 V,3000 V,6600 V,25 kV"
-					default=""
 					/>
 				<combo key="frequency"
 					text="Frequency"
@@ -275,7 +255,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="16.7,0,16.67,50,60,25"
 					de.display_values="16.7 Hz (Standard in Deutschland),Gleichspannung,16 2/3 Hz (in Teilen Deutschlands),50 Hz,60 Hz,25 Hz"
 					display_values="16.7 Hz (default in Germany),DC,16 2/3 Hz (in parts of Germany),50 Hz,60 Hz,25 Hz"
-					default=""
 					/>
 				<combo key="gauge"
 					text="Gauge"
@@ -294,23 +273,19 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Zahnstange"
 					values="yes,no,riggenbach,strub,abt,locher,riggenbach-klose,marsh,von_roll"
 					display_values="Ja,Nein,System Riggenbach,System Strub,System Abt,System Locher,System Riggenbach-Klose,System Marsh,System Von Roll"
-					default=""
 					/>
 				<text key="incline"
 					text="Incline (e.g.. '3%')"
 					de.text="Steigung (z. B. '3%')"
-					default=""
 					/>
 				<space />
 				<text key="start_date"
 					text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
-					default=""
 					/>
 				<text key="operator"
 					text="Operator (e.g. 'DB Netz AG')"
 					de.text="Betreiber (z. B. 'DB Netz AG')"
-					default=""
 					/>
 				<space />
 				<check key="embankment"
@@ -334,7 +309,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<text key="railway:track_ref"
 					text="Track ref (inside station)"
 					de.text="Gleisnummer (im Bahnhof)"
-					default=""
 					/>
 				<space />
 				<combo key="railway:traffic_mode"
@@ -342,7 +316,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Verkehrsart"
 					values="mixed,passenger,freight"
 					de.display_values="Gemischt,Personenverkehr,Güterverkehr" display_values="mixed,passenger,freight"
-					default=""
 					/>
 				<space />
 				<check key="lit"
@@ -360,7 +333,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="ETCS"
 					values="yes,no,0,1,2,3"
 					display_values="Ja,Nein,Level 0,Level 1,Level 2,Level 3"
-					default=""
 					/>
 				<combo key="railway:radio"
 					text="Radio"
@@ -368,9 +340,8 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="analogue,gsm-r"
 					display_values="analogue,GSM-R"
 					de.display_values="Analog,GSM-R"
-					default=""
 					/>
-				<combo key="maxspeed" default=""
+				<combo key="maxspeed"
 					text="Maxspeed (km/h)"
 					de.text="Höchstgeschwindigkeit (km/h)"
 					values="10,20,30,40,50,60,70,80,90,100,none"
@@ -382,7 +353,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Elektrifizierung"
 					values="yes,no,contact_line,rail"
 					display_values="Ja,Nein,Oberleitung,Stromschiene"
-					default=""
 					/>
 				<combo key="voltage"
 					text="Voltage"
@@ -390,7 +360,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="15000,600,750,1200,1500,2400,3000,6600,25000"
 					display_values="15 kV (default in Germany),600 V,750 V,1200 V,1500 V,2400 V,3000 V,6600 V,25 kV"
 					de.display_values="15 kV (Standard in Deutschland),600 V,750 V,1200 V,1500 V,2400 V,3000 V,6600 V,25 kV"
-					default=""
 					/>
 				<combo key="frequency"
 					text="Frequency"
@@ -398,7 +367,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="16.7,0,16.67,50,60,25"
 					de.display_values="16.7 Hz (Standard in Deutschland),Gleichspannung,16 2/3 Hz (in Teilen Deutschlands),50 Hz,60 Hz,25 Hz"
 					display_values="16.7 Hz (default in Germany),DC,16 2/3 Hz (in parts of Germany),50 Hz,60 Hz,25 Hz"
-					default=""
 					/>
 				<combo key="gauge"
 					text="Gauge"
@@ -417,23 +385,19 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Zahnstange"
 					values="yes,no,riggenbach,strub,abt,locher,riggenbach-klose,marsh,von_roll"
 					display_values="Ja,Nein,System Riggenbach,System Strub,System Abt,System Locher,System Riggenbach-Klose,System Marsh,System Von Roll"
-					default=""
 					/>
 				<text key="incline"
 					text="Incline (e.g.. '3%')"
 					de.text="Steigung (z. B. '3%')"
-					default=""
 					/>
 				<space />
 				<text key="start_date"
 					text="Year of opening"
 					de.text="Zeitpunkt der Inbetriebnahme"
-					default=""
 					/>
 				<text key="operator"
 					text="Operator (e.g. 'DB Netz AG')"
 					de.text="Betreiber (z. B. 'DB Netz AG')"
-					default=""
 					/>
 				<space />
 				<check key="embankment"
@@ -478,7 +442,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="ETCS"
 					values="yes,no,0,1,2,3"
 					display_values="Ja,Nein,Level 0,Level 1,Level 2,Level 3"
-					default=""
 					/>
 				<combo key="railway:radio"
 					text="Radio"
@@ -486,9 +449,8 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="analogue,gsm-r"
 					display_values="analogue,GSM-R"
 					de.display_values="Analog,GSM-R"
-					default=""
 					/>
-				<combo key="maxspeed" default=""
+				<combo key="maxspeed"
 					text="Maxspeed (km/h)"
 					de.text="Höchstgeschwindigkeit (km/h)"
 					values="10,20,30,40,50,60,70,80,90,100,none"
@@ -500,7 +462,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Elektrifizierung"
 					values="yes,no,contact_line,rail"
 					display_values="Ja,Nein,Oberleitung,Stromschiene"
-					default=""
 					/>
 				<combo key="voltage"
 					text="Voltage"
@@ -508,7 +469,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="15000,600,750,1200,1500,2400,3000,6600,25000"
 					display_values="15 kV (default in Germany),600 V,750 V,1200 V,1500 V,2400 V,3000 V,6600 V,25 kV"
 					de.display_values="15 kV (Standard in Deutschland),600 V,750 V,1200 V,1500 V,2400 V,3000 V,6600 V,25 kV"
-					default=""
 					/>
 				<combo key="frequency"
 					text="Frequency"
@@ -516,7 +476,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="16.7,16.67,50,60,25,0"
 					display_values="16.7 Hz (default in Germany),16 2/3 Hz (in parts of Germany),50 Hz,60 Hz,25 Hz,DC"
 					de.display_values="16.7 Hz (Standard in Deutschland),16 2/3 Hz (in Teilen Deutschlands),50 Hz,60 Hz,25 Hz,Gleichspannung"
-					default=""
 					/>
 				<combo key="gauge"
 					text="Gauge"
@@ -535,23 +494,19 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Zahnstange"
 					values="yes,no,riggenbach,strub,abt,locher,riggenbach-klose,marsh,von_roll"
 					display_values="Ja,Nein,System Riggenbach,System Strub,System Abt,System Locher,System Riggenbach-Klose,System Marsh,System Von Roll"
-					default=""
 					/>
 				<text key="incline"
 					text="Incline (e.g.. '3%')"
 					de.text="Steigung (z. B. '3%')"
-					default=""
 					/>
 				<space />
 				<text key="start_date"
 					text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
-					default=""
 					/>
 				<text key="operator"
 					text="Operator (e.g. 'DB Netz AG')"
 					de.text="Betreiber (z. B. 'DB Netz AG')"
-					default=""
 					/>
 				<space />
 				<check key="embankment"
@@ -578,7 +533,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Verkehrsart"
 					values="mixed,passenger,freight"
 					de.display_values="Gemischt,Personenverkehr,Güterverkehr" display_values="mixed,passenger,freight"
-					default=""
 					/>
 				<check key="highspeed"
 					text="High-speed line (~ >200 km/h)"
@@ -611,14 +565,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Geschwindigkeitsüberwachung Neigetechnik"
 					values="yes,no,zub122,zub262"
 					display_values="Ja,Nein,ZUB122,ZUB262"
-					default=""
 					/>
 				<combo key="railway:etcs"
 					text="ETCS"
 					de.text="ETCS"
 					values="yes,no,0,1,2,3"
 					display_values="Ja,Nein,Level 0,Level 1,Level 2,Level 3"
-					default=""
 					/>
 				<combo key="railway:radio"
 					text="Radio"
@@ -626,16 +578,15 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="analogue,gsm-r"
 					display_values="analogue,GSM-R"
 					de.display_values="Analog,GSM-R"
-					default=""
 					/>
 				<space />
-				<combo key="maxspeed" default=""
+				<combo key="maxspeed"
 					text="Maxspeed (km/h)"
 					de.text="Höchstgeschwindigkeit (km/h)"
 					values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,none"
 					display_values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,keine" />
 				<label text="Different speed limits depending on direction can be tagged manually using maxspeed:forward= and maxspeed:backward=*." de.text="Unterschiedliche Geschwindigkeiten je Richtung können manuell mit maxspeed:forward=* bzw. maxspeed:backward=* getaggt werden." />
-				<combo key="maxspeed:tilting" default=""
+				<combo key="maxspeed:tilting"
 					text="Maxspeed of Used by tilting trains (km/h)"
 					de.text="Höchstgeschwindigkeit von Neigetechnikzügen (km/h)"
 					values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,none"
@@ -646,7 +597,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Elektrifizierung"
 					values="yes,no,contact_line,rail"
 					display_values="Ja,Nein,Oberleitung,Stromschiene"
-					default=""
 					/>
 				<combo key="voltage"
 					text="Voltage"
@@ -654,7 +604,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="15000,600,750,1200,1500,2400,3000,6600,25000"
 					display_values="15 kV (default in Germany),600 V,750 V,1200 V,1500 V,2400 V,3000 V,6600 V,25 kV"
 					de.display_values="15 kV (Standard in Deutschland),600 V,750 V,1200 V,1500 V,2400 V,3000 V,6600 V,25 kV"
-					default=""
 					/>
 				<combo key="frequency"
 					text="Frequency"
@@ -662,7 +611,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="16.7,0,16.67,50,60,25"
 					display_values="16.7 Hz (default in Germany),DC,16 2/3 Hz (in large parts of Germany),50 Hz,60 Hz,25 Hz"
 					de.display_values="16.7 Hz (Standard in Deutschland),Gleichspannung,16 2/3 Hz (in Teilen Deutschlands),50 Hz,60 Hz,25 Hz"
-					default=""
 					/>
 				<combo key="gauge"
 					text="Gauge"
@@ -681,23 +629,19 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Zahnstange"
 					values="yes,no,riggenbach,strub,abt,locher,riggenbach-klose,marsh,von_roll"
 					display_values="Ja,Nein,System Riggenbach,System Strub,System Abt,System Locher,System Riggenbach-Klose,System Marsh,System Von Roll"
-					default=""
 					/>
 				<text key="incline"
 					text="Incline (e.g.. '3%')"
 					de.text="Steigung (z. B. '3%')"
-					default=""
 					/>
 				<space />
 				<text key="start_date"
 					text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
-					default=""
 					/>
 				<text key="operator"
 					text="Operator (e.g. 'DB Netz AG')"
 					de.text="Betreiber (z. B. 'DB Netz AG')"
-					default=""
 					/>
 				<space />
 				<check key="embankment"
@@ -720,20 +664,17 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<text key="ref"
 					text="Line ref (VzG number, e.g. '2379')"
 					de.text="Streckennummer (VzG-Nummer, z. B. '2379')"
-					default=""
 					/>
 				<text key="railway:track_ref"
 					text="Track ref (inside station)"
 					de.text="Gleisnummer (im Bahnhof)"
-					default=""
 					/>
 				<text key="name"
 					text="Railway name"
 					de.text="Streckenname"
-					default=""
 					/>
 				<space />
-				<combo key="usage" text="Usage (leave empty if main track or line)" de.text="Nutzung (leer lassen bei Strecken- und Hauptgleisen)" default="">
+				<combo key="usage" text="Usage (leave empty if main track or line)" de.text="Nutzung (leer lassen bei Strecken- und Hauptgleisen)">
 					<list_entry value="branch" display_value="Reguläre Strecke" de.display_value="regular line" short_description="Eine Schmalspurbahn, auf der regulärer Personen- und/oder Güterverkehr stattfindet." />
 					<list_entry value="industrial" display_value="Industriebahn" de.display_value="industrial/mine railway" short_description="Eine Strecke, die ausschließlich dem Güterverkehr dient und in der Regel Eigentum eines Industrieunternehmens ist. Meist nur innerhalb von Hafengebieten, Industrieanlagen, Tagebauen." />
 					<list_entry value="military" de.display_value="Militärbahn" display_value="military railway" short_description="Eine Strecke, die ausschließlich dem Militärverkehr dient. Meistens Strecken zwischen normalen Bahnstrecken und Munitionsdepots oder Truppenübungsplätzen." />
@@ -745,9 +686,8 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Verkehrsart"
 					values="mixed,passenger,freight"
 					de.display_values="Gemischt,Personenverkehr,Güterverkehr" display_values="mixed,passenger,freight"
-					default=""
 					/>
-				<combo key="service" text="Track service" de.text="Gleisfunktion" default="">
+				<combo key="service" text="Track service" de.text="Gleisfunktion">
 				  <list_entry value="siding" display_value="Nebengleis" short_description="Gleise in Bahnhöfen, die parallel zum durchgehenden Hauptgleis verlaufen und zum Überholen und Halten von Zügen dienen" /><!-- FIXME: Abgrenzung zwischen (nicht durchgehenden) Hauptgleisen und (planmäßig nicht von Zügen befahrenen) Nebengleisen herausstellen -->
 					<list_entry value="yard" display_value="Abstellgleis" short_description="Gleise in Rangier-, Güter- oder Betriebsbahnhöfen, die zum Rangieren, Zusammenstellen von Zügen und Abstellen von Wagen dienen" />
 					<list_entry value="crossover" display_value="Überleitgleis" short_description="Kurze Gleise, die das Wechseln zwischen zwei Gleisen ermöglichen" />
@@ -775,7 +715,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="ETCS"
 					values="yes,no,0,1,2,3"
 					display_values="Ja,Nein,Level 0,Level 1,Level 2,Level 3"
-					default=""
 					/>
 				<combo key="railway:radio"
 					text="Radio"
@@ -783,19 +722,18 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="analogue,gsm-r"
 					display_values="analogue,GSM-R"
 					de.display_values="Analog,GSM-R"
-					default=""
 					/>
-				<combo key="railway:preferred_direction" text="Direction of use (depends on direction of OSM way)" de.text="Regelfahrtrichtung (abhängig von Richtung des OSM-Ways)" default="">
+				<combo key="railway:preferred_direction" text="Direction of use (depends on direction of OSM way)" de.text="Regelfahrtrichtung (abhängig von Richtung des OSM-Ways)">
 					<list_entry value="forward" display_value="forward (in the same direction as the OSM way)" de.display_value="In Wegrichtung" short_description="Das Gleis wird üblicherweise in die Richtung befahren, in die der OSM-Way führt. Nur für mehrgleisige Strecken." />
 					<list_entry value="backward"  display_value="backward (in the other direction than the OSM way)" de.display_value="Entgegen Wegrichtung" short_description="Das Gleis wird üblicherweise entgegen der Richtung befahren, in die der OSM-Way führt. Nur für mehrgleisige Strecken." />
 					<list_entry value="both" display_value="both" de.display_value="Beide Richtungen" short_description="Es gibt keine Richtung, in die die Züge üblicherweise fahren bzw. nicht fahren. Nur für eingleisige Strecken." />
 				</combo>
-				<combo key="railway:bidirectional" text="Bidirectional traffic (depends on direction of OSM way)" de.text="Gleiswechselbetrieb (abhängig von Richtung des OSM-Ways)" default="">
+				<combo key="railway:bidirectional" text="Bidirectional traffic (depends on direction of OSM way)" de.text="Gleiswechselbetrieb (abhängig von Richtung des OSM-Ways)">
 					<list_entry value="regular" de.display_value="Gleiswechselbetrieb" short_description="Das Gleis ist für beide Fahrtrichtungen mit Signalen ausgestattet und kann daher regulär entgegen der üblichen Fahrtrichtung befahren werden." />
 					<list_entry value="signals" de.display_value="Signalisierter Falschfahrbetrieb" short_description="Das Gleis ist signaltechnisch nur für eine Fahrtrichtung ausgelegt, sodass weiterhin Falschfahrten notwendig sind, diese sind aber durch Signale geregelt." />
 					<list_entry value="possible" de.display_value="Falschfahrt möglich" short_description="Signaltechnisch besteht keine Möglichkeit einer Befahrung des Gegengleises. Es ist ein schriftlicher Befehl notwendig." />
 				</combo>
-				<combo key="maxspeed" default=""
+				<combo key="maxspeed"
 					text="Maxspeed (km/h)"
 					de.text="Höchstgeschwindigkeit (km/h)"
 					values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,none"
@@ -807,7 +745,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Elektrifizierung"
 					values="yes,no,contact_line,rail"
 					display_values="Ja,Nein,Oberleitung,Stromschiene"
-					default=""
 					/>
 				<combo key="voltage"
 					text="Voltage"
@@ -815,7 +752,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="15000,400,600,750,1200,1500,2400,3000,6600"
 					display_values="15 kV (default in Germany),400 V,600 V,750 V,1200 V,1500 V,2400 V,3000 V,6600 V"
 					de.display_values="15 kV (Standard in Deutschland),400 V,600 V,750 V,1200 V,1500 V,2400 V,3000 V,6600 V"
-					default=""
 					/>
 				<combo key="frequency"
 					text="Frequency"
@@ -823,14 +759,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="16.7,0,16.67,50,60,25"
 					display_values="16.7 Hz (default in Germany),DC,16 2/3 Hz (in large parts of Germany),50 Hz,60 Hz,25 Hz"
 					de.display_values="16.7 Hz (Standard in Deutschland),Gleichspannung,16 2/3 Hz (in Teilen Deutschlands),50 Hz,60 Hz,25 Hz"
-					default=""
 					/>
 				<combo key="gauge"
 					text="Gauge"
 					de.text="Spurweite"
 					values="1100,1000,900,889,880,860,800,775,750,660,655,630,600,575,560,550,500"
 					display_values="1100 mm,1000 mm (Meterspur),900 mm,889 mm,880 mm,860 mm,800 mm,775 mm,750 mm,660 mm,655 mm,630 mm,600 mm,575 mm,560 mm,550 mm,500 mm"
-					default=""
 					/>
 				<check key="railway:ballastless"
 					text="Ballastless"
@@ -842,23 +776,19 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Zahnstange"
 					values="yes,no,riggenbach,strub,abt,locher,riggenbach-klose,marsh,von_roll"
 					display_values="Ja,Nein,System Riggenbach,System Strub,System Abt,System Locher,System Riggenbach-Klose,System Marsh,System Von Roll"
-					default=""
 					/>
 				<text key="incline"
 					text="Incline (e.g.. '3%')"
 					de.text="Steigung (z. B. '3%')"
-					default=""
 					/>
 				<space />
 				<text key="start_date"
 					text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
-					default=""
 					/>
 				<text key="operator"
 					text="Operator (e.g. 'DB Netz AG')"
 					de.text="Betreiber (z. B. 'DB Netz AG')"
-					default=""
 					/>
 				<space />
 				<check key="embankment"
@@ -880,17 +810,14 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<text key="ref"
 					text="Line ref (VzG number, e.g. '2379')"
 					de.text="Streckennummer (VzG-Nummer, z. B. '2379')"
-					default=""
 					/>
 				<text key="railway:track_ref"
 					text="Track ref (inside station)"
 					de.text="Gleisnummer (im Bahnhof)"
-					default=""
 					/>
 				<text key="name"
 					text="Railway name"
 					de.text="Streckenname"
-					default=""
 					/>
 				<space />
 				<combo key="railway:traffic_mode"
@@ -898,9 +825,8 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Verkehrsart"
 					values="mixed,passenger,freight"
 					de.display_values="Gemischt,Personenverkehr,Güterverkehr" display_values="mixed,passenger,freight"
-					default=""
 					/>
-				<combo key="service" text="Track service" de.text="Gleisfunktion" default="">
+				<combo key="service" text="Track service" de.text="Gleisfunktion">
 					<list_entry value="siding" display_value="Nebengleis" short_description="Gleise in Bahnhöfen, die parallel zum durchgehenden Hauptgleis verlaufen und zum Überholen und Halten von Zügen dienen" />
 					<list_entry value="yard" display_value="Abstellgleis" short_description="Gleise in Rangier-, Güter- oder Betriebsbahnhöfen, die zum Rangieren, Zusammenstellen von Zügen und Abstellen von Wagen dienen" />
 					<list_entry value="crossover" display_value="Überleitgleis" short_description="Kurze Gleise, die das Wechseln zwischen zwei Gleisen ermöglichen" />
@@ -924,19 +850,18 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="analogue,gsm-r"
 					display_values="analogue,GSM-R"
 					de.display_values="Analog,GSM-R"
-					default=""
 					/>
-				<combo key="railway:preferred_direction" text="Direction of use (depends on direction of OSM way)" de.text="Regelfahrtrichtung (abhängig von Richtung des OSM-Ways)" default="">
+				<combo key="railway:preferred_direction" text="Direction of use (depends on direction of OSM way)" de.text="Regelfahrtrichtung (abhängig von Richtung des OSM-Ways)">
 					<list_entry value="forward" display_value="forward (in the same direction as the OSM way)" de.display_value="In Wegrichtung" short_description="Das Gleis wird üblicherweise in die Richtung befahren, in die der OSM-Way führt. Nur für mehrgleisige Strecken." />
 					<list_entry value="backward"  display_value="backward (in the other direction than the OSM way)" de.display_value="Entgegen Wegrichtung" short_description="Das Gleis wird üblicherweise entgegen der Richtung befahren, in die der OSM-Way führt. Nur für mehrgleisige Strecken." />
 					<list_entry value="both" display_value="both" de.display_value="Beide Richtungen" short_description="Es gibt keine Richtung, in die die Züge üblicherweise fahren bzw. nicht fahren. Nur für eingleisige Strecken." />
 				</combo>
-				<combo key="railway:bidirectional" text="Bidirectional traffic (depends on direction of OSM way)" de.text="Gleiswechselbetrieb (abhängig von Richtung des OSM-Ways)" default="">
+				<combo key="railway:bidirectional" text="Bidirectional traffic (depends on direction of OSM way)" de.text="Gleiswechselbetrieb (abhängig von Richtung des OSM-Ways)">
 					<list_entry value="regular" de.display_value="Gleiswechselbetrieb" short_description="Das Gleis ist für beide Fahrtrichtungen mit Signalen ausgestattet und kann daher regulär entgegen der üblichen Fahrtrichtung befahren werden." />
 					<list_entry value="signals" de.display_value="Signalisierter Falschfahrbetrieb" short_description="Das Gleis ist signaltechnisch nur für eine Fahrtrichtung ausgelegt, sodass weiterhin Falschfahrten notwendig sind, diese sind aber durch Signale geregelt." />
 					<list_entry value="possible" de.display_value="Falschfahrt möglich" short_description="Signaltechnisch besteht keine Möglichkeit einer Befahrung des Gegengleises. Es ist ein schriftlicher Befehl notwendig." />
 				</combo>
-				<combo key="maxspeed" default=""
+				<combo key="maxspeed"
 					text="Maxspeed (km/h)"
 					de.text="Höchstgeschwindigkeit (km/h)"
 					values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,none"
@@ -948,7 +873,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Elektrifizierung"
 					values="yes,no,contact_line,rail"
 					display_values="Ja,Nein,Oberleitung,Stromschiene"
-					default=""
 					/>
 				<combo key="voltage"
 					text="Voltage"
@@ -956,7 +880,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="15000,400,600,750,1200,1500,2400,3000,6600,25000"
 					display_values="15 kV (default in Germany),400 V,600 V,750 V,1200 V,1500 V,2400 V,3000 V,6600 V,25 kV"
 					de.display_values="15 kV (Standard in Deutschland),400 V,600 V,750 V,1200 V,1500 V,2400 V,3000 V,6600 V,25 kV"
-					default=""
 					/>
 				<combo key="frequency"
 					text="Frequency"
@@ -964,7 +887,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="16.7,0,16.67,50,60,25"
 					display_values="16.7 Hz (default in Germany),DC,16 2/3 Hz (in large parts of Germany),50 Hz,60 Hz,25 Hz"
 					dedisplay_values="16.7 Hz (Standard in Deutschland),Gleichspannung,16 2/3 Hz (in Teilen Deutschlands),50 Hz,60 Hz,25 Hz"
-					default=""
 					/>
 				<combo key="gauge"
 					text="Gauge"
@@ -983,23 +905,19 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Zahnstange"
 					values="yes,no,riggenbach,strub,abt,locher,riggenbach-klose,marsh,von_roll"
 					display_values="Ja,Nein,System Riggenbach,System Strub,System Abt,System Locher,System Riggenbach-Klose,System Marsh,System Von Roll"
-					default=""
 					/>
 				<text key="incline"
 					text="Incline (e.g.. '3%')"
 					de.text="Steigung (z. B. '3%')"
-					default=""
 					/>
 				<space />
 				<text key="start_date"
 					text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
-					default=""
 					/>
 				<text key="operator"
 					text="Operator (e.g. 'DB Netz AG')"
 					de.text="Betreiber (z. B. 'DB Netz AG')"
-					default=""
 					/>
 				<space />
 				<check key="embankment"
@@ -1021,15 +939,13 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<text key="railway:track_ref"
 					text="Track ref (inside station)"
 					de.text="Gleisnummer (im Bahnhof)"
-					default=""
 					/>
 				<text key="name"
 					text="Railway name"
 					de.text="Streckenname"
-					default=""
 					/>
 				<space />
-				<combo key="usage" text="Usage (leave empty if main track or line)" de.text="Nutzung (leer lassen bei Strecken- und Hauptgleisen)" default="">
+				<combo key="usage" text="Usage (leave empty if main track or line)" de.text="Nutzung (leer lassen bei Strecken- und Hauptgleisen)">
 					<list_entry value="branch" display_value="Reguläre Strecke" de.display_value="regular line" short_description="Eine Schmalspurbahn, auf der regulärer Personen- und/oder Güterverkehr stattfindet." />
 					<list_entry value="industrial" display_value="Industriebahn" de.display_value="industrial/mine railway" short_description="Eine Strecke, die ausschließlich dem Güterverkehr dient und in der Regel Eigentum eines Industrieunternehmens ist. Meist nur innerhalb von Hafengebieten, Industrieanlagen, Tagebauen." />
 					<list_entry value="tourism" de.display_value="Tourismusbahn" display_value="tourism" short_description="Eine Strecke, die ausschließlich touristischen Zwecken dient, z. B. Museumsstrecken oder Draisinenbahnen." />
@@ -1039,9 +955,8 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Verkehrsart"
 					values="mixed,passenger,freight"
 					de.display_values="Gemischt,Personenverkehr,Güterverkehr" display_values="mixed,passenger,freight"
-					default=""
 					/>
-				<combo key="service" text="Track service" de.text="Gleisfunktion" default="">
+				<combo key="service" text="Track service" de.text="Gleisfunktion">
 					<list_entry value="siding" display_value="Nebengleis" short_description="Gleise in Bahnhöfen, die parallel zum durchgehenden Hauptgleis verlaufen und zum Überholen und Halten von Zügen dienen" />
 					<list_entry value="yard" display_value="Abstellgleis" short_description="Gleise in Rangier-, Güter- oder Betriebsbahnhöfen, die zum Rangieren, Zusammenstellen von Zügen und Abstellen von Wagen dienen" />
 					<list_entry value="crossover" display_value="Überleitgleis" short_description="Kurze Gleise, die das Wechseln zwischen zwei Gleisen ermöglichen" />
@@ -1060,9 +975,8 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="analogue,gsm-r"
 					display_values="analogue,GSM-R"
 					de.display_values="Analog,GSM-R"
-					default=""
 					/>
-				<combo key="maxspeed" default=""
+				<combo key="maxspeed"
 					text="Maxspeed (km/h)"
 					de.text="Höchstgeschwindigkeit (km/h)"
 					values="10,20,30,40,50,60,70,80,90,100,none"
@@ -1074,14 +988,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Elektrifizierung"
 					values="yes,no,contact_line,rail"
 					display_values="Ja,Nein,Oberleitung,Stromschiene"
-					default=""
 					/>
 				<combo key="voltage"
 					text="Voltage"
 					de.text="Spannung"
 					values="45,220,400,600,750,1200,1500,6600"
 					display_values="45 V,220 V,400 V,600 V,750 V,1200 V,1500 V,6600 V"
-					default=""
 					/>
 				<combo key="frequency"
 					text="Frequency"
@@ -1089,14 +1001,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="16.7,0,16.67,50,60,25"
 					display_values="16.7 Hz (default in Germany),DC,16 2/3 Hz (in large parts of Germany),50 Hz,60 Hz,25 Hz"
 					de.display_values="16.7 Hz (Standard in Deutschland),Gleichspannung,16 2/3 Hz (in Teilen Deutschlands),50 Hz,60 Hz,25 Hz"
-					default=""
 					/>
 				<combo key="gauge"
 					text="Gauge"
 					de.text="Spurweite"
 					values="381,320,184,144,127,89"
 					display_values="381 mm,320 mm,184 mm,144 mm,127 mm,89 mm"
-					default=""
 					/>
 				<check key="railway:ballastless"
 					text="Ballastless"
@@ -1108,23 +1018,19 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Zahnstange"
 					values="yes,no,riggenbach,strub,abt,locher,riggenbach-klose,marsh,von_roll"
 					display_values="Ja,Nein,System Riggenbach,System Strub,System Abt,System Locher,System Riggenbach-Klose,System Marsh,System Von Roll"
-					default=""
 					/>
 				<text key="incline"
 					text="Incline (e.g.. '3%')"
 					de.text="Steigung (z. B. '3%')"
-					default=""
 					/>
 				<space />
 				<text key="start_date"
 					text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
-					default=""
 					/>
 				<text key="operator"
 					text="Operator (e.g. 'DB Netz AG')"
 					de.text="Betreiber (z. B. 'DB Netz AG')"
-					default=""
 					/>
 				<space />
 				<check key="embankment"
@@ -1147,17 +1053,14 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<text key="ref"
 					text="Line ref"
 					de.text="Streckennummer"
-					default=""
 					/>
 				<text key="railway:track_ref"
 					text="Track ref (inside station)"
 					de.text="Gleisnummer (im Bahnhof)"
-					default=""
 					/>
 				<text key="name"
 					text="Railway name"
 					de.text="Streckenname"
-					default=""
 					/>
 				<space />
 				<combo key="railway:traffic_mode"
@@ -1167,7 +1070,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.display_values="Gemischt,Güterverkehr,Personenverkehr" display_values="mixed,freight,passenger"
 					default="passenger"
 					/>
-				<combo key="service" text="Track service" de.text="Gleisfunktion" default="">
+				<combo key="service" text="Track service" de.text="Gleisfunktion">
 					<list_entry value="siding" display_value="Nebengleis" short_description="Gleise in Bahnhöfen, die parallel zum durchgehenden Hauptgleis verlaufen und zum Überholen und Halten von Zügen dienen" />
 					<list_entry value="yard" display_value="Abstellgleis" short_description="Gleise in Rangier-, Güter- oder Betriebsbahnhöfen, die zum Rangieren, Zusammenstellen von Zügen und Abstellen von Wagen dienen" />
 					<list_entry value="crossover" display_value="Überleitgleis" short_description="Kurze Gleise, die das Wechseln zwischen zwei Gleisen ermöglichen" />
@@ -1194,19 +1097,18 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="ETCS"
 					values="yes,no,0,1,2,3"
 					display_values="Ja,Nein,Level 0,Level 1,Level 2,Level 3"
-					default=""
 					/>
-				<combo key="railway:preferred_direction" text="Direction of use (depends on direction of OSM way)" de.text="Regelfahrtrichtung (abhängig von Richtung des OSM-Ways)" default="">
+				<combo key="railway:preferred_direction" text="Direction of use (depends on direction of OSM way)" de.text="Regelfahrtrichtung (abhängig von Richtung des OSM-Ways)">
 					<list_entry value="forward" display_value="forward (in the same direction as the OSM way)" de.display_value="In Wegrichtung" short_description="Das Gleis wird üblicherweise in die Richtung befahren, in die der OSM-Way führt. Nur für mehrgleisige Strecken." />
 					<list_entry value="backward"  display_value="backward (in the other direction than the OSM way)" de.display_value="Entgegen Wegrichtung" short_description="Das Gleis wird üblicherweise entgegen der Richtung befahren, in die der OSM-Way führt. Nur für mehrgleisige Strecken." />
 					<list_entry value="both" display_value="both" de.display_value="Beide Richtungen" short_description="Es gibt keine Richtung, in die die Züge üblicherweise fahren bzw. nicht fahren. Nur für eingleisige Strecken." />
 				</combo>
-				<combo key="railway:bidirectional" text="Bidirectional traffic (depends on direction of OSM way)" de.text="Gleiswechselbetrieb (abhängig von Richtung des OSM-Ways)" default="">
+				<combo key="railway:bidirectional" text="Bidirectional traffic (depends on direction of OSM way)" de.text="Gleiswechselbetrieb (abhängig von Richtung des OSM-Ways)">
 					<list_entry value="regular" de.display_value="Gleiswechselbetrieb" short_description="Das Gleis ist für beide Fahrtrichtungen mit Signalen ausgestattet und kann daher regulär entgegen der üblichen Fahrtrichtung befahren werden." />
 					<list_entry value="signals" de.display_value="Signalisierter Falschfahrbetrieb" short_description="Das Gleis ist signaltechnisch nur für eine Fahrtrichtung ausgelegt, sodass weiterhin Falschfahrten notwendig sind, diese sind aber durch Signale geregelt." />
 					<list_entry value="possible" de.display_value="Falschfahrt möglich" short_description="Signaltechnisch besteht keine Möglichkeit einer Befahrung des Gegengleises. Es ist ein schriftlicher Befehl notwendig." />
 				</combo>
-				<combo key="maxspeed" default=""
+				<combo key="maxspeed"
 					text="Maxspeed (km/h)"
 					de.text="Höchstgeschwindigkeit (km/h)"
 					values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,none"
@@ -1218,7 +1120,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Elektrifizierung"
 					values="yes,no,contact_line,rail"
 					display_values="Ja,Nein,Oberleitung,Stromschiene"
-					default=""
 					/>
 				<combo key="voltage"
 					text="Voltage"
@@ -1226,7 +1127,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="15000,500,550,600,750,850,1000,1200,1500,2400,3000,6500,6600,11000,25000"
 					display_values="15 kV (default in Germany),500 V,550 V,600 V,750 V,850 V,1000 V,1200 V,1500 V,2400 V,3000 V,6500 V,6600 V,11 kV,25 kV"
 					de.display_values="15 kV (Standard in Deutschland),500 V,550 V,600 V,750 V,850 V,1000 V,1200 V,1500 V,2400 V,3000 V,6500 V,6600 V,11 kV,25 kV"
-					default=""
 					/>
 				<combo key="frequency"
 					text="Frequency"
@@ -1234,7 +1134,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="0,16.7,16.67,50,60,25"
 					de.display_values="Gleichspannung,16.7 Hz, 16 2/3 Hz, 50 Hz, 60 Hz, 25 Hz"
 					display_values="DC,16.7 Hz,16 2/3 Hz,50 Hz,60 Hz,25 Hz"
-					default=""
 					/>
 				<combo key="gauge"
 					text="Gauge"
@@ -1251,18 +1150,15 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<text key="incline"
 					text="Incline (e.g.. '3%')"
 					de.text="Steigung (z. B. '3%')"
-					default=""
 					/>
 				<space />
 				<text key="start_date"
 					text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
-					default=""
 					/>
 				<text key="operator"
 					text="Operator (e.g. 'Rheinbahn')"
 					de.text="Betreiber (z. B. 'Rheinbahn')"
-					default=""
 					/>
 				<space />
 				<check key="embankment"
@@ -1284,20 +1180,17 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<text key="ref"
 					text="Line ref"
 					de.text="Streckennummer"
-					default=""
 					/>
 				<text key="railway:track_ref"
 					text="Track ref (inside station)"
 					de.text="Gleisnummer (im Bahnhof)"
-					default=""
 					/>
 				<text key="name"
 					text="Railway name"
 					de.text="Streckenname"
-					default=""
 					/>
 				<space />
-				<combo key="service" text="Track service" de.text="Gleisfunktion" default="">
+				<combo key="service" text="Track service" de.text="Gleisfunktion">
 					<list_entry value="siding" display_value="Nebengleis" short_description="Gleise in Bahnhöfen, die parallel zum durchgehenden Hauptgleis verlaufen und zum Überholen und Halten von Zügen dienen" />
 					<list_entry value="yard" display_value="Abstellgleis" short_description="Gleise in Rangier-, Güter- oder Betriebsbahnhöfen, die zum Rangieren, Zusammenstellen von Zügen und Abstellen von Wagen dienen" />
 					<list_entry value="crossover" display_value="Überleitgleis" short_description="Kurze Gleise, die das Wechseln zwischen zwei Gleisen ermöglichen" />
@@ -1323,19 +1216,18 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="ETCS"
 					values="yes,no,0,1,2,3"
 					display_values="Ja,Nein,Level 0,Level 1,Level 2,Level 3"
-					default=""
 					/>
-				<combo key="railway:preferred_direction" text="Direction of use (depends on direction of OSM way)" de.text="Regelfahrtrichtung (abhängig von Richtung des OSM-Ways)" default="">
+				<combo key="railway:preferred_direction" text="Direction of use (depends on direction of OSM way)" de.text="Regelfahrtrichtung (abhängig von Richtung des OSM-Ways)">
 					<list_entry value="forward" display_value="forward (in the same direction as the OSM way)" de.display_value="In Wegrichtung" short_description="Das Gleis wird üblicherweise in die Richtung befahren, in die der OSM-Way führt. Nur für mehrgleisige Strecken." />
 					<list_entry value="backward"  display_value="backward (in the other direction than the OSM way)" de.display_value="Entgegen Wegrichtung" short_description="Das Gleis wird üblicherweise entgegen der Richtung befahren, in die der OSM-Way führt. Nur für mehrgleisige Strecken." />
 					<list_entry value="both" display_value="both" de.display_value="Beide Richtungen" short_description="Es gibt keine Richtung, in die die Züge üblicherweise fahren bzw. nicht fahren. Nur für eingleisige Strecken." />
 				</combo>
-				<combo key="railway:bidirectional" text="Bidirectional traffic (depends on direction of OSM way)" de.text="Gleiswechselbetrieb (abhängig von Richtung des OSM-Ways)" default="">
+				<combo key="railway:bidirectional" text="Bidirectional traffic (depends on direction of OSM way)" de.text="Gleiswechselbetrieb (abhängig von Richtung des OSM-Ways)">
 					<list_entry value="regular" de.display_value="Gleiswechselbetrieb" short_description="Das Gleis ist für beide Fahrtrichtungen mit Signalen ausgestattet und kann daher regulär entgegen der üblichen Fahrtrichtung befahren werden." />
 					<list_entry value="signals" de.display_value="Signalisierter Falschfahrbetrieb" short_description="Das Gleis ist signaltechnisch nur für eine Fahrtrichtung ausgelegt, sodass weiterhin Falschfahrten notwendig sind, diese sind aber durch Signale geregelt." />
 					<list_entry value="possible" de.display_value="Falschfahrt möglich" short_description="Signaltechnisch besteht keine Möglichkeit einer Befahrung des Gegengleises. Es ist ein schriftlicher Befehl notwendig." />
 				</combo>
-				<combo key="maxspeed" default=""
+				<combo key="maxspeed"
 					text="Maxspeed (km/h)"
 					de.text="Höchstgeschwindigkeit (km/h)"
 					values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,none"
@@ -1347,7 +1239,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Elektrifizierung"
 					values="yes,no,contact_line,rail"
 					display_values="Ja,Nein,Oberleitung,Stromschiene"
-					default=""
 					/>
 				<combo key="voltage"
 					text="Voltage"
@@ -1355,7 +1246,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="15000,500,550,600,750,850,1000,1200,1500,2400,3000,6500,6600,11000,25000"
 					display_values="15 kV (default in Germany),500 V,550 V,600 V,750 V,850 V,1000 V,1200 V,1500 V,2400 V,3000 V,6500 V,6600 V,11 kV,25 kV"
 					de.display_values="15 kV (Standard in Deutschland),500 V,550 V,600 V,750 V,850 V,1000 V,1200 V,1500 V,2400 V,3000 V,6500 V,6600 V,11 kV,25 kV"
-					default=""
 					/>
 				<combo key="frequency"
 					text="Frequency"
@@ -1363,7 +1253,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="0,16.7,16.67,50,60,25"
 					de.display_values="Gleichspannung,16.7 Hz, 16 2/3 Hz, 50 Hz, 60 Hz, 25 Hz"
 					display_values="DC,16.7 Hz,16 2/3 Hz,50 Hz,60 Hz,25 Hz"
-					default=""
 					/>
 				<combo key="gauge"
 					text="Gauge"
@@ -1380,18 +1269,15 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<text key="incline"
 					text="Incline (e.g.. '3%')"
 					de.text="Steigung (z. B. '3%')"
-					default=""
 					/>
 				<space />
 				<text key="start_date"
 					text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
-					default=""
 					/>
 				<text key="operator"
 					text="Operator (e.g. 'Rheinbahn')"
 					de.text="Betreiber (z. B. 'Rheinbahn')"
-					default=""
 					/>
 			</item>
 			<item de.name="Stadt-/Schnellbahngleis" name="Light Rail" icon="light-rail.png" type="way">
@@ -1402,22 +1288,19 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<text key="ref"
 					text="Line ref"
 					de.text="Streckennummer"
-					default=""
 					/>
 				<text key="railway:track_ref"
 					text="Track ref (inside station)"
 					de.text="Gleisnummer (im Bahnhof)"
-					default=""
 					/>
 				<text key="name"
 					text="Railway name"
 					de.text="Streckenname"
-					default=""
 					/>
 				<space />
 				<key key="railway:traffic_mode"
 					value="passenger" />
-				<combo key="service" text="Track service" de.text="Gleisfunktion" default="">
+				<combo key="service" text="Track service" de.text="Gleisfunktion">
 					<list_entry value="siding" display_value="Nebengleis" short_description="Gleise in Bahnhöfen, die parallel zum durchgehenden Hauptgleis verlaufen und zum Überholen und Halten von Zügen dienen" />
 					<list_entry value="yard" display_value="Abstellgleis" short_description="Gleise in Rangier-, Güter- oder Betriebsbahnhöfen, die zum Rangieren, Zusammenstellen von Zügen und Abstellen von Wagen dienen" />
 					<list_entry value="crossover" display_value="Überleitgleis" short_description="Kurze Gleise, die das Wechseln zwischen zwei Gleisen ermöglichen" />
@@ -1444,19 +1327,18 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="ETCS"
 					values="yes,no,0,1,2,3"
 					display_values="Ja,Nein,Level 0,Level 1,Level 2,Level 3"
-					default=""
 					/>
-				<combo key="railway:preferred_direction" text="Direction of use (depends on direction of OSM way)" de.text="Regelfahrtrichtung (abhängig von Richtung des OSM-Ways)" default="">
+				<combo key="railway:preferred_direction" text="Direction of use (depends on direction of OSM way)" de.text="Regelfahrtrichtung (abhängig von Richtung des OSM-Ways)">
 					<list_entry value="forward" display_value="forward (in the same direction as the OSM way)" de.display_value="In Wegrichtung" short_description="Das Gleis wird üblicherweise in die Richtung befahren, in die der OSM-Way führt. Nur für mehrgleisige Strecken." />
 					<list_entry value="backward"  display_value="backward (in the other direction than the OSM way)" de.display_value="Entgegen Wegrichtung" short_description="Das Gleis wird üblicherweise entgegen der Richtung befahren, in die der OSM-Way führt. Nur für mehrgleisige Strecken." />
 					<list_entry value="both" display_value="both" de.display_value="Beide Richtungen" short_description="Es gibt keine Richtung, in die die Züge üblicherweise fahren bzw. nicht fahren. Nur für eingleisige Strecken." />
 				</combo>
-				<combo key="railway:bidirectional" text="Bidirectional traffic (depends on direction of OSM way)" de.text="Gleiswechselbetrieb (abhängig von Richtung des OSM-Ways)" default="">
+				<combo key="railway:bidirectional" text="Bidirectional traffic (depends on direction of OSM way)" de.text="Gleiswechselbetrieb (abhängig von Richtung des OSM-Ways)">
 					<list_entry value="regular" de.display_value="Gleiswechselbetrieb" short_description="Das Gleis ist für beide Fahrtrichtungen mit Signalen ausgestattet und kann daher regulär entgegen der üblichen Fahrtrichtung befahren werden." />
 					<list_entry value="signals" de.display_value="Signalisierter Falschfahrbetrieb" short_description="Das Gleis ist signaltechnisch nur für eine Fahrtrichtung ausgelegt, sodass weiterhin Falschfahrten notwendig sind, diese sind aber durch Signale geregelt." />
 					<list_entry value="possible" de.display_value="Falschfahrt möglich" short_description="Signaltechnisch besteht keine Möglichkeit einer Befahrung des Gegengleises. Es ist ein schriftlicher Befehl notwendig." />
 				</combo>
-				<combo key="maxspeed" default=""
+				<combo key="maxspeed"
 					text="Maxspeed (km/h)"
 					de.text="Höchstgeschwindigkeit (km/h)"
 					values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,none"
@@ -1468,7 +1350,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Elektrifizierung"
 					values="yes,no,contact_line,rail"
 					display_values="Ja,Nein,Oberleitung,Stromschiene"
-					default=""
 					/>
 				<combo key="voltage"
 					text="Voltage"
@@ -1476,7 +1357,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="15000,500,550,600,750,850,1000,1200,1500,2400,3000,6500,6600,11000,25000"
 					display_values="15 kV (default in Germany),500 V,550 V,600 V,750 V,850 V,1000 V,1200 V,1500 V,2400 V,3000 V,6500 V,6600 V,11 kV,25 kV"
 					de.display_values="15 kV (Standard in Deutschland),500 V,550 V,600 V,750 V,850 V,1000 V,1200 V,1500 V,2400 V,3000 V,6500 V,6600 V,11 kV,25 kV"
-					default=""
 					/>
 				<combo key="frequency"
 					text="Frequency"
@@ -1484,7 +1364,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="0,16.7,16.67,50,60,25"
 					de.display_values="Gleichspannung,16.7 Hz, 16 2/3 Hz, 50 Hz, 60 Hz, 25 Hz"
 					display_values="DC,16.7 Hz,16 2/3 Hz,50 Hz,60 Hz,25 Hz"
-					default=""
 					/>
 				<combo key="gauge"
 					text="Gauge"
@@ -1501,18 +1380,15 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<text key="incline"
 					text="Incline (e.g.. '3%')"
 					de.text="Steigung (z. B. '3%')"
-					default=""
 					/>
 				<space />
 				<text key="start_date"
 					text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
-					default=""
 					/>
 				<text key="operator"
 					text="Operator (e.g. 'Rheinbahn')"
 					de.text="Betreiber (z. B. 'Rheinbahn')"
-					default=""
 					/>
 				<space />
 				<check key="embankment"
@@ -1535,20 +1411,17 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<text key="ref"
 					text="Line ref (VzG number, e.g. '2379')"
 					de.text="Streckennummer (VzG-Nummer, z. B. '2379')"
-					default=""
 					/>
 				<text key="railway:track_ref"
 					text="Track ref (inside station)"
 					de.text="Gleisnummer (im Bahnhof)"
-					default=""
 					/>
 				<text key="name"
 					text="Railway name"
 					de.text="Streckenname"
-					default=""
 					/>
 				<space />
-				<combo key="usage" text="Usage" de.text="Nutzung" default="">
+				<combo key="usage" text="Usage" de.text="Nutzung">
 					<list_entry value="main" de.display_value="Hauptbahn" display_value="main line" short_description="Strecke mit übergeordneter Bedeutung; meist zweigleisig, meist elektrifiziert, zumindest abschnittsweise mit mehr als 100 km/h befahrbar" />
 					<list_entry value="branch" de.display_value="Nebenbahn" display_value="branch line" short_description="Strecke mit untergeordneter Bedeutung; oft nicht elektrifiziert, oft eingleisig. Keinesfalls mit mehr als 100 km/h befahrbar." />
 					<list_entry value="industrial" display_value="Industriebahn" de.display_value="industrial/mine railway" short_description="Eine Strecke, die ausschließlich dem Güterverkehr dient und in der Regel Eigentum eines Industrieunternehmens ist. Meist nur innerhalb von Hafengebieten, Industrieanlagen, Tagebauen." />
@@ -1561,7 +1434,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Verkehrsart"
 					values="mixed,passenger,freight"
 					de.display_values="Gemischt,Personenverkehr,Güterverkehr" display_values="mixed,passenger,freight"
-					default=""
 					/>
 				<check key="highspeed"
 					text="Highspeed traffic (~ >200 km/h)"
@@ -1589,14 +1461,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Geschwindigkeitsüberwachung Neigetechnik"
 					values="yes,no,zub122,zub262"
 					display_values="Ja,Nein,ZUB122,ZUB262"
-					default=""
 					/>
 				<combo key="railway:etcs"
 					text="ETCS"
 					de.text="ETCS"
 					values="yes,no,0,1,2,3"
 					display_values="Ja,Nein,Level 0,Level 1,Level 2,Level 3"
-					default=""
 					/>
 				<combo key="railway:radio"
 					text="Radio"
@@ -1604,26 +1474,25 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="analogue,gsm-r"
 					display_values="analogue,GSM-R"
 					de.display_values="Analog,GSM-R"
-					default=""
 					/>
-				<combo key="railway:preferred_direction" text="Direction of use (depends on direction of OSM way)" de.text="Regelfahrtrichtung (abhängig von Richtung des OSM-Ways)" default="">
+				<combo key="railway:preferred_direction" text="Direction of use (depends on direction of OSM way)" de.text="Regelfahrtrichtung (abhängig von Richtung des OSM-Ways)">
 					<list_entry value="forward" display_value="forward (in the same direction as the OSM way)" de.display_value="In Wegrichtung" short_description="Das Gleis wird üblicherweise in die Richtung befahren, in die der OSM-Way führt. Nur für mehrgleisige Strecken." />
 					<list_entry value="backward"  display_value="backward (in the other direction than the OSM way)" de.display_value="Entgegen Wegrichtung" short_description="Das Gleis wird üblicherweise entgegen der Richtung befahren, in die der OSM-Way führt. Nur für mehrgleisige Strecken." />
 					<list_entry value="both" display_value="both" de.display_value="Beide Richtungen" short_description="Es gibt keine Richtung, in die die Züge üblicherweise fahren bzw. nicht fahren. Nur für eingleisige Strecken." />
 				</combo>
-				<combo key="railway:bidirectional" text="Bidirectional traffic (depends on direction of OSM way)" de.text="Gleiswechselbetrieb (abhängig von Richtung des OSM-Ways)" default="">
+				<combo key="railway:bidirectional" text="Bidirectional traffic (depends on direction of OSM way)" de.text="Gleiswechselbetrieb (abhängig von Richtung des OSM-Ways)">
 					<list_entry value="regular" de.display_value="Gleiswechselbetrieb" short_description="Das Gleis ist für beide Fahrtrichtungen mit Signalen ausgestattet und kann daher regulär entgegen der üblichen Fahrtrichtung befahren werden." />
 					<list_entry value="signals" de.display_value="Signalisierter Falschfahrbetrieb" short_description="Das Gleis ist signaltechnisch nur für eine Fahrtrichtung ausgelegt, sodass weiterhin Falschfahrten notwendig sind, diese sind aber durch Signale geregelt." />
 					<list_entry value="possible" de.display_value="Falschfahrt möglich" short_description="Signaltechnisch besteht keine Möglichkeit einer Befahrung des Gegengleises. Es ist ein schriftlicher Befehl notwendig." />
 				</combo>
 				<space />
-				<combo key="maxspeed" default=""
+				<combo key="maxspeed"
 					text="Maxspeed (km/h)"
 					de.text="Höchstgeschwindigkeit (km/h)"
 					values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,none"
 					display_values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,keine" />
 				<label text="Different speed limits depending on direction can be tagged manually using maxspeed:forward= and maxspeed:backward=*." de.text="Unterschiedliche Geschwindigkeiten je Richtung können manuell mit maxspeed:forward=* bzw. maxspeed:backward=* getaggt werden." />
-				<combo key="maxspeed:tilting" default=""
+				<combo key="maxspeed:tilting"
 					text="Maxspeed of Used by tilting trains (km/h)"
 					de.text="Höchstgeschwindigkeit von Neigetechnikzügen (km/h)"
 					values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,none"
@@ -1634,7 +1503,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Elektrifizierung"
 					values="yes,no,contact_line,rail"
 					display_values="Ja,Nein,Oberleitung,Stromschiene"
-					default=""
 					/>
 				<combo key="voltage"
 					text="Voltage"
@@ -1642,7 +1510,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="15000,400,600,750,1200,1500,2400,3000,6600,25000"
 					display_values="15 kV (default in Germany),400 V,600 V,750 V,1200 V,1500 V,2400 V,3000 V,6600 V,25 kV"
 					de.display_values="15 kV (Standard in Deutschland),400 V,600 V,750 V,1200 V,1500 V,2400 V,3000 V,6600 V,25 kV"
-					default=""
 					/>
 				<combo key="frequency"
 					text="Frequency"
@@ -1650,7 +1517,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="16.7,0,16.67,50,60,25"					
 					display_values="16.7 Hz (default in Germany),DC,16 2/3 Hz (in parts of Germany),50 Hz,60 Hz,25 Hz"
 					de.display_values="16.7 Hz (Standard in Deutschland),Gleichspannung,16 2/3 Hz (in Teilen Deutschlands),50 Hz,60 Hz,25 Hz"
-					default=""
 					/>
 				<combo key="gauge"
 					text="Gauge"
@@ -1669,23 +1535,19 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Zahnstange"
 					values="yes,no,riggenbach,strub,abt,locher,riggenbach-klose,marsh,von_roll"
 					display_values="Ja,Nein,System Riggenbach,System Strub,System Abt,System Locher,System Riggenbach-Klose,System Marsh,System Von Roll"
-					default=""
 					/>
 				<text key="incline"
 					text="Incline (e.g.. '3%')"
 					de.text="Steigung (z. B. '3%')"
-					default=""
 					/>
 				<space />
 				<text key="start_date"
 					text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
-					default=""
 					/>
 				<text key="operator"
 					text="Operator (e.g. 'DB Netz AG')"
 					de.text="Betreiber (z. B. 'DB Netz AG')"
-					default=""
 					/>
 				<space />
 				<check key="embankment"
@@ -1707,20 +1569,17 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<text key="ref"
 					text="Line ref (VzG number, e.g. '2379')"
 					de.text="Streckennummer (VzG-Nummer, z. B. '2379')"
-					default=""
 					/>
 				<text key="railway:track_ref"
 					text="Track ref (inside station)"
 					de.text="Gleisnummer (im Bahnhof)"
-					default=""
 					/>
 				<text key="name"
 					text="Railway name"
 					de.text="Streckenname"
-					default=""
 					/>
 				<space />
-				<combo key="usage" text="Usage" de.text="Nutzung" default="">
+				<combo key="usage" text="Usage" de.text="Nutzung">
 					<list_entry value="main" de.display_value="Hauptbahn" display_value="main line" short_description="Strecke mit übergeordneter Bedeutung; meist zweigleisig, meist elektrifiziert, zumindest abschnittsweise mit mehr als 100 km/h befahrbar" />
 					<list_entry value="branch" de.display_value="Nebenbahn" display_value="branch line" short_description="Strecke mit untergeordneter Bedeutung; oft nicht elektrifiziert, oft eingleisig. Keinesfalls mit mehr als 100 km/h befahrbar." />
 					<list_entry value="industrial" display_value="Industriebahn" de.display_value="industrial/mine railway" short_description="Eine Strecke, die ausschließlich dem Güterverkehr dient und in der Regel Eigentum eines Industrieunternehmens ist. Meist nur innerhalb von Hafengebieten, Industrieanlagen, Tagebauen." />
@@ -1733,7 +1592,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Verkehrsart"
 					values="mixed,passenger,freight"
 					de.display_values="Gemischt,Personenverkehr,Güterverkehr" display_values="mixed,passenger,freight"
-					default=""
 					/>
 				<check key="highspeed"
 					text="Highspeed traffic (~ >200 km/h)"
@@ -1761,14 +1619,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Geschwindigkeitsüberwachung Neigetechnik"
 					values="yes,no,zub122,zub262"
 					display_values="Ja,Nein,ZUB122,ZUB262"
-					default=""
 					/>
 				<combo key="railway:etcs"
 					text="ETCS"
 					de.text="ETCS"
 					values="yes,no,0,1,2,3"
 					display_values="Ja,Nein,Level 0,Level 1,Level 2,Level 3"
-					default=""
 					/>
 				<combo key="railway:radio"
 					text="Radio"
@@ -1776,26 +1632,25 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="analogue,gsm-r"
 					display_values="analogue,GSM-R"
 					de.display_values="Analog,GSM-R"
-					default=""
 					/>
-				<combo key="railway:preferred_direction" text="Direction of use (depends on direction of OSM way)" de.text="Regelfahrtrichtung (abhängig von Richtung des OSM-Ways)" default="">
+				<combo key="railway:preferred_direction" text="Direction of use (depends on direction of OSM way)" de.text="Regelfahrtrichtung (abhängig von Richtung des OSM-Ways)">
 					<list_entry value="forward" display_value="forward (in the same direction as the OSM way)" de.display_value="In Wegrichtung" short_description="Das Gleis wird üblicherweise in die Richtung befahren, in die der OSM-Way führt. Nur für mehrgleisige Strecken." />
 					<list_entry value="backward"  display_value="backward (in the other direction than the OSM way)" de.display_value="Entgegen Wegrichtung" short_description="Das Gleis wird üblicherweise entgegen der Richtung befahren, in die der OSM-Way führt. Nur für mehrgleisige Strecken." />
 					<list_entry value="both" display_value="both" de.display_value="Beide Richtungen" short_description="Es gibt keine Richtung, in die die Züge üblicherweise fahren bzw. nicht fahren. Nur für eingleisige Strecken." />
 				</combo>
-				<combo key="railway:bidirectional" text="Bidirectional traffic (depends on direction of OSM way)" de.text="Gleiswechselbetrieb (abhängig von Richtung des OSM-Ways)" default="">
+				<combo key="railway:bidirectional" text="Bidirectional traffic (depends on direction of OSM way)" de.text="Gleiswechselbetrieb (abhängig von Richtung des OSM-Ways)">
 					<list_entry value="regular" de.display_value="Gleiswechselbetrieb" short_description="Das Gleis ist für beide Fahrtrichtungen mit Signalen ausgestattet und kann daher regulär entgegen der üblichen Fahrtrichtung befahren werden." />
 					<list_entry value="signals" de.display_value="Signalisierter Falschfahrbetrieb" short_description="Das Gleis ist signaltechnisch nur für eine Fahrtrichtung ausgelegt, sodass weiterhin Falschfahrten notwendig sind, diese sind aber durch Signale geregelt." />
 					<list_entry value="possible" de.display_value="Falschfahrt möglich" short_description="Signaltechnisch besteht keine Möglichkeit einer Befahrung des Gegengleises. Es ist ein schriftlicher Befehl notwendig." />
 				</combo>
 				<space />
-				<combo key="maxspeed" default=""
+				<combo key="maxspeed"
 					text="Maxspeed (km/h)"
 					de.text="Höchstgeschwindigkeit (km/h)"
 					values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,none"
 					display_values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,keine" />
 				<label text="Different speed limits depending on direction can be tagged manually using maxspeed:forward= and maxspeed:backward=*." de.text="Unterschiedliche Geschwindigkeiten je Richtung können manuell mit maxspeed:forward=* bzw. maxspeed:backward=* getaggt werden." />
-				<combo key="maxspeed:tilting" default=""
+				<combo key="maxspeed:tilting"
 					text="Maxspeed of Used by tilting trains (km/h)"
 					de.text="Höchstgeschwindigkeit von Neigetechnikzügen (km/h)"
 					values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,none"
@@ -1806,7 +1661,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Elektrifizierung"
 					values="yes,no,contact_line,rail"
 					display_values="Ja,Nein,Oberleitung,Stromschiene"
-					default=""
 					/>
 				<combo key="voltage"
 					text="Voltage"
@@ -1814,7 +1668,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="15000,400,600,750,1200,1500,2400,3000,6600,25000"
 					display_values="15 kV (default in Germany),400 V,600 V,750 V,1200 V,1500 V,2400 V,3000 V,6600 V,25 kV"
 					de.display_values="15 kV (Standard in Deutschland),400 V,600 V,750 V,1200 V,1500 V,2400 V,3000 V,6600 V,25 kV"
-					default=""
 					/>
 				<combo key="frequency"
 					text="Frequency"
@@ -1822,7 +1675,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="16.7,0,16.67,50,60,25"					
 					display_values="16.7 Hz (default in Germany),DC,16 2/3 Hz (in parts of Germany),50 Hz,60 Hz,25 Hz"
 					de.display_values="16.7 Hz (Standard in Deutschland),Gleichspannung,16 2/3 Hz (in Teilen Deutschlands),50 Hz,60 Hz,25 Hz"
-					default=""
 					/>
 				<combo key="gauge"
 					text="Gauge"
@@ -1841,23 +1693,19 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Zahnstange"
 					values="yes,no,riggenbach,strub,abt,locher,riggenbach-klose,marsh,von_roll"
 					display_values="Ja,Nein,System Riggenbach,System Strub,System Abt,System Locher,System Riggenbach-Klose,System Marsh,System Von Roll"
-					default=""
 					/>
 				<text key="incline"
 					text="Incline (e.g.. '3%')"
 					de.text="Steigung (z. B. '3%')"
-					default=""
 					/>
 				<space />
 				<text key="start_date"
 					text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
-					default=""
 					/>
 				<text key="operator"
 					text="Operator (e.g. 'DB Netz AG')"
 					de.text="Betreiber (z. B. 'DB Netz AG')"
-					default=""
 					/>
 				<space />
 				<check key="embankment"
@@ -1879,20 +1727,17 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<text key="ref"
 					text="Line ref (VzG number, e.g. '2379')"
 					de.text="Streckennummer (VzG-Nummer, z. B. '2379')"
-					default=""
 					/>
 				<text key="railway:track_ref"
 					text="Track ref (inside station)"
 					de.text="Gleisnummer (im Bahnhof)"
-					default=""
 					/>
 				<text key="name"
 					text="Railway name"
 					de.text="Streckenname"
-					default=""
 					/>
 				<space />
-				<combo key="usage" text="Usage" de.text="Nutzung" default="">
+				<combo key="usage" text="Usage" de.text="Nutzung">
 					<list_entry value="main" de.display_value="Hauptbahn" display_value="main line" short_description="Strecke mit übergeordneter Bedeutung; meist zweigleisig, meist elektrifiziert, zumindest abschnittsweise mit mehr als 100 km/h befahrbar" />
 					<list_entry value="branch" de.display_value="Nebenbahn" display_value="branch line" short_description="Strecke mit untergeordneter Bedeutung; oft nicht elektrifiziert, oft eingleisig. Keinesfalls mit mehr als 100 km/h befahrbar." />
 					<list_entry value="industrial" display_value="Industriebahn" de.display_value="industrial/mine railway" short_description="Eine Strecke, die ausschließlich dem Güterverkehr dient und in der Regel Eigentum eines Industrieunternehmens ist. Meist nur innerhalb von Hafengebieten, Industrieanlagen, Tagebauen." />
@@ -1906,7 +1751,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="mixed,passenger,freight"
 					de.display_values="Gemischt,Personenverkehr,Güterverkehr" 
 					display_values="mixed,passenger,freight"
-					default=""
 					/>
 				<check key="highspeed"
 					text="Highspeed traffic (~ >200 km/h)"
@@ -1929,7 +1773,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="ETCS"
 					values="yes,no,0,1,2,3"
 					display_values="Ja,Nein,Level 0,Level 1,Level 2,Level 3"
-					default=""
 					/>
 				<combo key="railway:radio"
 					text="Radio"
@@ -1937,19 +1780,18 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="analogue,gsm-r"
 					display_values="analogue,GSM-R"
 					de.display_values="Analog,GSM-R"
-					default=""
 					/>
-				<combo key="railway:preferred_direction" text="Direction of use (depends on direction of OSM way)" de.text="Regelfahrtrichtung (abhängig von Richtung des OSM-Ways)" default="">
+				<combo key="railway:preferred_direction" text="Direction of use (depends on direction of OSM way)" de.text="Regelfahrtrichtung (abhängig von Richtung des OSM-Ways)">
 					<list_entry value="forward" display_value="forward (in the same direction as the OSM way)" de.display_value="In Wegrichtung" short_description="Das Gleis wird üblicherweise in die Richtung befahren, in die der OSM-Way führt. Nur für mehrgleisige Strecken." />
 					<list_entry value="backward"  display_value="backward (in the other direction than the OSM way)" de.display_value="Entgegen Wegrichtung" short_description="Das Gleis wird üblicherweise entgegen der Richtung befahren, in die der OSM-Way führt. Nur für mehrgleisige Strecken." />
 					<list_entry value="both" display_value="both" de.display_value="Beide Richtungen" short_description="Es gibt keine Richtung, in die die Züge üblicherweise fahren bzw. nicht fahren. Nur für eingleisige Strecken." />
 				</combo>
-				<combo key="railway:bidirectional" text="Bidirectional traffic (depends on direction of OSM way)" de.text="Gleiswechselbetrieb (abhängig von Richtung des OSM-Ways)" default="">
+				<combo key="railway:bidirectional" text="Bidirectional traffic (depends on direction of OSM way)" de.text="Gleiswechselbetrieb (abhängig von Richtung des OSM-Ways)">
 					<list_entry value="regular" de.display_value="Gleiswechselbetrieb" short_description="Das Gleis ist für beide Fahrtrichtungen mit Signalen ausgestattet und kann daher regulär entgegen der üblichen Fahrtrichtung befahren werden." />
 					<list_entry value="signals" de.display_value="Signalisierter Falschfahrbetrieb" short_description="Das Gleis ist signaltechnisch nur für eine Fahrtrichtung ausgelegt, sodass weiterhin Falschfahrten notwendig sind, diese sind aber durch Signale geregelt." />
 					<list_entry value="possible" de.display_value="Falschfahrt möglich" short_description="Signaltechnisch besteht keine Möglichkeit einer Befahrung des Gegengleises. Es ist ein schriftlicher Befehl notwendig." />
 				</combo>
-				<combo key="maxspeed" default=""
+				<combo key="maxspeed"
 					text="Maxspeed (km/h)"
 					de.text="Höchstgeschwindigkeit (km/h)"
 					values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,none"
@@ -1961,7 +1803,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Elektrifizierung"
 					values="yes,no,contact_line,rail"
 					display_values="Ja,Nein,Oberleitung,Stromschiene"
-					default=""
 					/>
 				<combo key="voltage"
 					text="Voltage"
@@ -1969,7 +1810,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="15000,180,220,400,600,650,750,800,1100,1200,1500,2400,3000,5000,5500,6300,6600,8000,10000,20000,25000"
 					display_values="15 kV (default in Germany),45 V,220 V,400 V,600 V,650 V,750 V,800 V,1100 V,1200 V,1500 V,2400 V,3000 V,5000 V,5500 V,6300 V,6600 V,8000 V,10 kV,20 kV,25 kV"
 					de.display_values="15 kV (Standard in Deutschland),45 V,220 V,400 V,600 V,650 V,750 V,800 V,1100 V,1200 V,1500 V,2400 V,3000 V,5000 V,5500 V,6300 V,6600 V,8000 V,10 kV,20 kV,25 kV"
-					default=""
 					/>
 				<combo key="frequency"
 					text="Frequency"
@@ -1977,7 +1817,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="16.7,0,16.67,50,60,25"					
 					de.display_values="16.7 Hz (Standard in Deutschland),Gleichspannung,16 2/3 Hz (in Teilen Deutschlands),50 Hz,60 Hz,25 Hz"
 					display_values="16.7 Hz (default in Germany),DC,16 2/3 Hz (in parts of Germany),50 Hz,60 Hz,25 Hz"
-					default=""
 					/>
 				<combo key="gauge"
 					text="Gauge"
@@ -1996,28 +1835,23 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Zahnstange"
 					values="yes,no,riggenbach,strub,abt,locher,riggenbach-klose,marsh,von_roll"
 					display_values="Ja,Nein,System Riggenbach,System Strub,System Abt,System Locher,System Riggenbach-Klose,System Marsh,System Von Roll"
-					default=""
 					/>
 				<text key="incline"
 					text="Incline (e.g.. '3%')"
 					de.text="Steigung (z. B. '3%')"
-					default=""
 					/>
 				<space />
 				<text key="start_date"
 					text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
-					default=""
 					/>
 				<text key="end_date"
 					text="Closed at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Stilllegung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
-					default=""
 					/>
 				<text key="operator"
 					text="Operator (e.g. 'DB Netz AG')"
 					de.text="Betreiber (z. B. 'DB Netz AG')"
-					default=""
 					/>
 				<space />
 				<check key="embankment"
@@ -2039,20 +1873,17 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<text key="ref"
 					text="Line ref (VzG number, e.g. '2379')"
 					de.text="Streckennummer (VzG-Nummer, z. B. '2379')"
-					default=""
 					/>
 				<text key="railway:track_ref"
 					text="Track ref (inside station)"
 					de.text="Gleisnummer (im Bahnhof)"
-					default=""
 					/>
 				<text key="name"
 					text="Railway name"
 					de.text="Streckenname"
-					default=""
 					/>
 				<space />
-				<combo key="usage" text="Usage" de.text="Nutzung" default="">
+				<combo key="usage" text="Usage" de.text="Nutzung">
 					<list_entry value="main" de.display_value="Hauptbahn" display_value="main line" short_description="Strecke mit übergeordneter Bedeutung; meist zweigleisig, meist elektrifiziert, zumindest abschnittsweise mit mehr als 100 km/h befahrbar" />
 					<list_entry value="branch" de.display_value="Nebenbahn" display_value="branch line" short_description="Strecke mit untergeordneter Bedeutung; oft nicht elektrifiziert, oft eingleisig. Keinesfalls mit mehr als 100 km/h befahrbar." />
 					<list_entry value="industrial" display_value="Industriebahn" de.display_value="industrial/mine railway" short_description="Eine Strecke, die ausschließlich dem Güterverkehr dient und in der Regel Eigentum eines Industrieunternehmens ist. Meist nur innerhalb von Hafengebieten, Industrieanlagen, Tagebauen." />
@@ -2066,7 +1897,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="mixed,passenger,freight"
 					de.display_values="Gemischt,Personenverkehr,Güterverkehr" 
 					display_values="mixed,passenger,freight"
-					default=""
 					/>
 				<check key="highspeed"
 					text="Highspeed traffic (~ >200 km/h)"
@@ -2089,7 +1919,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="ETCS"
 					values="yes,no,0,1,2,3"
 					display_values="Ja,Nein,Level 0,Level 1,Level 2,Level 3"
-					default=""
 					/>
 				<combo key="railway:radio"
 					text="Radio"
@@ -2097,19 +1926,18 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="analogue,gsm-r"
 					display_values="analogue,GSM-R"
 					de.display_values="Analog,GSM-R"
-					default=""
 					/>
-				<combo key="railway:preferred_direction" text="Direction of use (depends on direction of OSM way)" de.text="Regelfahrtrichtung (abhängig von Richtung des OSM-Ways)" default="">
+				<combo key="railway:preferred_direction" text="Direction of use (depends on direction of OSM way)" de.text="Regelfahrtrichtung (abhängig von Richtung des OSM-Ways)">
 					<list_entry value="forward" display_value="forward (in the same direction as the OSM way)" de.display_value="In Wegrichtung" short_description="Das Gleis wird üblicherweise in die Richtung befahren, in die der OSM-Way führt. Nur für mehrgleisige Strecken." />
 					<list_entry value="backward"  display_value="backward (in the other direction than the OSM way)" de.display_value="Entgegen Wegrichtung" short_description="Das Gleis wird üblicherweise entgegen der Richtung befahren, in die der OSM-Way führt. Nur für mehrgleisige Strecken." />
 					<list_entry value="both" display_value="both" de.display_value="Beide Richtungen" short_description="Es gibt keine Richtung, in die die Züge üblicherweise fahren bzw. nicht fahren. Nur für eingleisige Strecken." />
 				</combo>
-				<combo key="railway:bidirectional" text="Bidirectional traffic (depends on direction of OSM way)" de.text="Gleiswechselbetrieb (abhängig von Richtung des OSM-Ways)" default="">
+				<combo key="railway:bidirectional" text="Bidirectional traffic (depends on direction of OSM way)" de.text="Gleiswechselbetrieb (abhängig von Richtung des OSM-Ways)">
 					<list_entry value="regular" de.display_value="Gleiswechselbetrieb" short_description="Das Gleis ist für beide Fahrtrichtungen mit Signalen ausgestattet und kann daher regulär entgegen der üblichen Fahrtrichtung befahren werden." />
 					<list_entry value="signals" de.display_value="Signalisierter Falschfahrbetrieb" short_description="Das Gleis ist signaltechnisch nur für eine Fahrtrichtung ausgelegt, sodass weiterhin Falschfahrten notwendig sind, diese sind aber durch Signale geregelt." />
 					<list_entry value="possible" de.display_value="Falschfahrt möglich" short_description="Signaltechnisch besteht keine Möglichkeit einer Befahrung des Gegengleises. Es ist ein schriftlicher Befehl notwendig." />
 				</combo>
-				<combo key="maxspeed" default=""
+				<combo key="maxspeed"
 					text="Maxspeed (km/h)"
 					de.text="Höchstgeschwindigkeit (km/h)"
 					values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,none"
@@ -2121,7 +1949,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Elektrifizierung"
 					values="yes,no,contact_line,rail"
 					display_values="Ja,Nein,Oberleitung,Stromschiene"
-					default=""
 					/>
 				<combo key="voltage"
 					text="Voltage"
@@ -2129,7 +1956,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="15000,180,220,400,600,650,750,800,1100,1200,1500,2400,3000,5000,5500,6300,6600,8000,10000,20000,25000"
 					display_values="15 kV (default in Germany),45 V,220 V,400 V,600 V,650 V,750 V,800 V,1100 V,1200 V,1500 V,2400 V,3000 V,5000 V,5500 V,6300 V,6600 V,8000 V,10 kV,20 kV,25 kV"
 					de.display_values="15 kV (Standard in Deutschland),45 V,220 V,400 V,600 V,650 V,750 V,800 V,1100 V,1200 V,1500 V,2400 V,3000 V,5000 V,5500 V,6300 V,6600 V,8000 V,10 kV,20 kV,25 kV"
-					default=""
 					/>
 				<combo key="frequency"
 					text="Frequency"
@@ -2137,7 +1963,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="16.7,0,16.67,50,60,25"					
 					de.display_values="16.7 Hz (Standard in Deutschland),Gleichspannung,16 2/3 Hz (in Teilen Deutschlands),50 Hz,60 Hz,25 Hz"
 					display_values="16.7 Hz (default in Germany),DC,16 2/3 Hz (in parts of Germany),50 Hz,60 Hz,25 Hz"
-					default=""
 					/>
 				<combo key="gauge"
 					text="Gauge"
@@ -2156,28 +1981,23 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Zahnstange"
 					values="yes,no,riggenbach,strub,abt,locher,riggenbach-klose,marsh,von_roll"
 					display_values="Ja,Nein,System Riggenbach,System Strub,System Abt,System Locher,System Riggenbach-Klose,System Marsh,System Von Roll"
-					default=""
 					/>
 				<text key="incline"
 					text="Incline (e.g.. '3%')"
 					de.text="Steigung (z. B. '3%')"
-					default=""
 					/>
 				<space />
 				<text key="start_date"
 					text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
-					default=""
 					/>
 				<text key="end_date"
 					text="Closed at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Stilllegung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
-					default=""
 					/>
 				<text key="operator"
 					text="Operator (e.g. 'DB Netz AG')"
 					de.text="Betreiber (z. B. 'DB Netz AG')"
-					default=""
 					/>
 				<space />
 				<check key="embankment"
@@ -2199,20 +2019,17 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<text key="ref"
 					text="Line ref (VzG number, e.g. '2379')"
 					de.text="Streckennummer (VzG-Nummer, z. B. '2379')"
-					default=""
 					/>
 				<text key="railway:track_ref"
 					text="Track ref (inside station)"
 					de.text="Gleisnummer (im Bahnhof)"
-					default=""
 					/>
 				<text key="name"
 					text="Railway name"
 					de.text="Streckenname"
-					default=""
 					/>
 				<space />
-				<combo key="usage" text="Usage" de.text="Nutzung" default="">
+				<combo key="usage" text="Usage" de.text="Nutzung">
 					<list_entry value="main" de.display_value="Hauptbahn" display_value="main line" short_description="Strecke mit übergeordneter Bedeutung; meist zweigleisig, meist elektrifiziert, zumindest abschnittsweise mit mehr als 100 km/h befahrbar" />
 					<list_entry value="branch" de.display_value="Nebenbahn" display_value="branch line" short_description="Strecke mit untergeordneter Bedeutung; oft nicht elektrifiziert, oft eingleisig. Keinesfalls mit mehr als 100 km/h befahrbar." />
 					<list_entry value="industrial" display_value="Industriebahn" de.display_value="industrial/mine railway" short_description="Eine Strecke, die ausschließlich dem Güterverkehr dient und in der Regel Eigentum eines Industrieunternehmens ist. Meist nur innerhalb von Hafengebieten, Industrieanlagen, Tagebauen." />
@@ -2226,7 +2043,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="mixed,passenger,freight"
 					de.display_values="Gemischt,Personenverkehr,Güterverkehr"
 					display_values="mixed,passenger only,freight only"
-					default=""
 					/>
 				<check key="highspeed"
 					text="Highspeed traffic (~ >200 km/h)"
@@ -2250,7 +2066,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="yes,no,0,1,2,3"
 					display_values="Yes,No,Level 0,Level 1,Level 2,Level 3"
 					de.display_values="Ja,Nein,Level 0,Level 1,Level 2,Level 3"
-					default=""
 					/>
 				<combo key="railway:radio"
 					text="Radio"
@@ -2258,19 +2073,18 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="analogue,gsm-r"
 					display_values="analogue,GSM-R"
 					de.display_values="Analog,GSM-R"
-					default=""
 					/>
-				<combo key="railway:preferred_direction" text="Direction of use (depends on direction of OSM way)" de.text="Regelfahrtrichtung (abhängig von Richtung des OSM-Ways)" default="">
+				<combo key="railway:preferred_direction" text="Direction of use (depends on direction of OSM way)" de.text="Regelfahrtrichtung (abhängig von Richtung des OSM-Ways)">
 					<list_entry value="forward" display_value="forward (in the same direction as the OSM way)" de.display_value="In Wegrichtung" short_description="Das Gleis wird üblicherweise in die Richtung befahren, in die der OSM-Way führt. Nur für mehrgleisige Strecken." />
 					<list_entry value="backward"  display_value="backward (in the other direction than the OSM way)" de.display_value="Entgegen Wegrichtung" short_description="Das Gleis wird üblicherweise entgegen der Richtung befahren, in die der OSM-Way führt. Nur für mehrgleisige Strecken." />
 					<list_entry value="both" display_value="both" de.display_value="Beide Richtungen" short_description="Es gibt keine Richtung, in die die Züge üblicherweise fahren bzw. nicht fahren. Nur für eingleisige Strecken." />
 				</combo>
-				<combo key="railway:bidirectional" text="Bidirectional traffic (depends on direction of OSM way)" de.text="Gleiswechselbetrieb (abhängig von Richtung des OSM-Ways)" default="">
+				<combo key="railway:bidirectional" text="Bidirectional traffic (depends on direction of OSM way)" de.text="Gleiswechselbetrieb (abhängig von Richtung des OSM-Ways)">
 					<list_entry value="regular" de.display_value="Gleiswechselbetrieb" short_description="Das Gleis ist für beide Fahrtrichtungen mit Signalen ausgestattet und kann daher regulär entgegen der üblichen Fahrtrichtung befahren werden." />
 					<list_entry value="signals" de.display_value="Signalisierter Falschfahrbetrieb" short_description="Das Gleis ist signaltechnisch nur für eine Fahrtrichtung ausgelegt, sodass weiterhin Falschfahrten notwendig sind, diese sind aber durch Signale geregelt." />
 					<list_entry value="possible" de.display_value="Falschfahrt möglich" short_description="Signaltechnisch besteht keine Möglichkeit einer Befahrung des Gegengleises. Es ist ein schriftlicher Befehl notwendig." />
 				</combo>
-				<combo key="maxspeed" default=""
+				<combo key="maxspeed"
 					text="Maxspeed (km/h)"
 					de.text="Höchstgeschwindigkeit (km/h)"
 					values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,none"
@@ -2282,7 +2096,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Elektrifizierung"
 					values="yes,no,contact_line,rail"
 					display_values="Ja,Nein,Oberleitung,Stromschiene"
-					default=""
 					/>
 				<combo key="voltage"
 					text="Voltage"
@@ -2290,7 +2103,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="15000,180,220,400,600,650,750,800,1100,1200,1500,2400,3000,5000,5500,6300,6600,8000,10000,20000,25000"
 					de.display_values="15 kV (Standard in Deutschland),45 V,220 V,400 V,600 V,650 V,750 V,800 V,1100 V,1200 V,1500 V,2400 V,3000 V,5000 V,5500 V,6300 V,6600 V,8000 V,10 kV,20 kV,25 kV"
 					display_values="15 kV (default in Germany),45 V,220 V,400 V,600 V,650 V,750 V,800 V,1100 V,1200 V,1500 V,2400 V,3000 V,5000 V,5500 V,6300 V,6600 V,8000 V,10 kV,20 kV,25 kV"
-					default=""
 					/>
 				<combo key="frequency"
 					text="Frequency"
@@ -2298,7 +2110,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="16.7,0,16.67,50,60,25"					
 					de.display_values="16.7 Hz (Standard in Deutschland),Gleichspannung,16 2/3 Hz (in Teilen Deutschlands),50 Hz,60 Hz,25 Hz"
 					display_values="16.7 Hz (default in Germany),DC,16 2/3 Hz (in parts of Germany),50 Hz,60 Hz,25 Hz"
-					default=""
 					/>
 				<combo key="gauge"
 					text="Gauge"
@@ -2317,28 +2128,23 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Zahnstange"
 					values="yes,no,riggenbach,strub,abt,locher,riggenbach-klose,marsh,von_roll"
 					display_values="Ja,Nein,System Riggenbach,System Strub,System Abt,System Locher,System Riggenbach-Klose,System Marsh,System Von Roll"
-					default=""
 					/>
 				<text key="incline"
 					text="Incline (e.g.. '3%')"
 					de.text="Steigung (z. B. '3%')"
-					default=""
 					/>
 				<space />
 				<text key="start_date"
 					text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
-					default=""
 					/>
 				<text key="end_date"
 					text="Closed at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Stilllegung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
-					default=""
 					/>
 				<text key="operator"
 					text="Operator (e.g. 'DB Netz AG')"
 					de.text="Betreiber (z. B. 'DB Netz AG')"
-					default=""
 					/>
 				<space />
 				<check key="embankment"
@@ -2361,17 +2167,14 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<text key="bridge:name"
 					text="Bridge name"
 					de.text="Name der Brücke"
-					default=""
 					/>
 				<text key="image"
 					text="Image URL"
 					de.text="URL eines Bildes"
-					default=""
 					/>
 				<text key="wikipedia"
 					text="Wikipedia article in the format (Language):(Article)"
 					de.text="Wikipediaartikel in der Form (Sprachkürzel):(Artikelname)"
-					default=""
 					/>
 			</item>
 			<item de.name="Tunnel" name="Tunnel" icon="tunnel-32.png" type="way">
@@ -2382,17 +2185,14 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<text key="tunnel:name"
 					text="Tunnel name"
 					de.text="Name des Tunnels"
-					default=""
 					/>
 				<text key="image"
 					text="Image URL"
 					de.text="URL eines Bildes"
-					default=""
 					/>
 				<text key="wikipedia"
 					text="Wikipedia article in the format (Language):(Article)"
 					de.text="Wikipediaartikel in der Form (Sprachkürzel):(Artikelname)"
-					default=""
 					/>
 			</item>
 			<separator />
@@ -2407,14 +2207,13 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="forward,backward"
 					de.display_values="In Wegrichtung,Entgegen Wegrichtung"
 					display_values="forward,backward"
-					default=""
 					/>
 				<combo key="railway:signal:minor"
 					text="Exact type of signal"
 					de.text="Signaltyp"
 					values="DE-ESO:sh0,DE-ESO:sh2"
 					display_values="Sh 0-Tafel,Sh 2-Tafel"
-					default="" />
+					/>
 				<key key="railway:signal:minor:form"
 					value="sign" />
 			</item>
@@ -2426,7 +2225,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<text key="ref"
 					text="Switch reference"
 					de.text="Weichennummer"
-					default=""
 					/>
 				<check key="railway:local_operated"
 					text="Local operated"
@@ -2454,7 +2252,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="default,three_way,single_slip,double_slip,wye,abt"
 					display_values="default switch,three way switch,single slip switch,double slip switch,wye switch,abt switch"
 					de.display_values="Einfache Weiche,Dreiwegweiche,einfache Kreuzungsweiche,Doppelkreuzungsweiche,Y-Weiche,Abtsche Weiche"
-					default=""
 					/>
 				<combo key="railway:turnout_side"
 					text="Turnout side (only default and resetting switches)"
@@ -2462,30 +2259,25 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="left,right"
 					display_values="Left,Right"
 					de.display_values="Links,Rechts"
-					default=""
 					/>
 				<combo key="railway:radius"
 					text="Switch radius (m)"
 					de.text="Radius der Weichengrundform (m)"
 					values="190,300,500,760,1200,2500"
-					default=""
 					/>
 				<text key="railway:maxspeed:straight"
 					text="Maxspeed in straight direction (km/h)"
 					de.text="Geschwindigkeit auf dem geraden Zweig (km/h)"
-					default=""
 					/>
 				<text key="railway:maxspeed:diverging"
 					text="Maxspeed in diverging direction (km/h)"
 					de.text="Geschwindigkeit auf dem Abzweig (km/h)"
-					default=""
 					/>
 				<combo key="railway:switch:configuration"
 					text="Configuration"
 					de.text="Bauform (bei Doppelkreuzungsweichen)"
 					values="inside,outside"
 					display_values="Innenliegende Zungen (Engländer),Außenliegende Zungen (Baeseler)"
-					default=""
 					/>
 				<check key="railway:switch:movable_frog"
 					text="Movable frog"
@@ -2501,7 +2293,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<text key="ref"
 					text="Ref"
 					de.text="Bezeichnung/Nummer"
-					default=""
 					/>
 			</item>
 			<item name="Derailer" de.name="Gleissperre" icon="derail.png" type="node">
@@ -2514,7 +2305,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<text key="ref"
 					text="Ref"
 					de.text="Bezeichnung/Nummer"
-					default=""
 					/>
 				<check key="railway:local_operated"
 					text="Local operated"
@@ -2533,7 +2323,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Signalzustände"
 					values="DE-ESO:sh0;DE-ESO:sh1,DE-ESO:sh0;DE-ESO:wn7"
 					display_values="Sh 0 / Sh 1,Sh 0 / Wn 7 (vormals Gsp 2)"
-					default=""
 					/>
 				<key key="railway:signal:minor:form"
 					value="semaphore" />
@@ -2551,7 +2340,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="insulated_rail_joint,axle_counter"
 					display_values="insulated_rail_joint,axle_counter"
 					de.display_values="Isolierstoß,Achszähler"
-					default=""
 					/>
 			</item>
 		</group>
@@ -2563,39 +2351,32 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<text key="name"
 				text="Name"
 				de.text="Name (z. B. 'Neuss Ngf', 'Riesa B8' 'Holzheim ESTW-A')"
-				default=""
 				/>
 			<text key="railway:ref"
 				text="Short name"
 				de.text="Abkürzung (z. B. 'Ngf' oder 'B8')"
-				default=""
 				/>
 			<combo key="railway:signal_box"
 				text="Signal box type"
 				de.text="Stellwerkstechnik"
 				values="mechanical,electric,track_diagram,electronic"
 				display_values="Mechanisches Stellwerk,Elektrisches/Elektromechanisches Stellwerk,Gleisbildstellwerk,Elektronisches Stellwerk (ESTW)"
-				default=""
 				/>
 			<text key="start_date"
 				text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 				de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
-				default=""
 				/>
 			<text key="railway:position"
 				text="Distance indication (rounded, e.g. '12.3'; km)"
 				de.text="Hektometerwert (z. B. '12.3')"
-				default=""
 				/>
 			<text key="railway:position:exact"
 				text="Exact distance indication (exact, e.g. '12.345'; km)"
 				de.text="Metergenauer Wert (genau, z. B: '12.345'; km)"
-				default=""
 				/>
 			<text key="image"
 				text="Image URL"
 				de.text="URL eines Bildes"
-				default=""
 				/>
 			<check key="railway:local_operated"
 				text="Local operated"
@@ -2626,63 +2407,51 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="station, "
 					de.display_values="ja,nein"
 					display_values="yes,no"
-					default=""
 					/>
 				<text key="name" text="Name"
 					de.text="Name"
-					default=""
 					/>
 				<text key="railway:ref"
 					text="Short name (DS100)"
 					de.text="Abkürzung (nach DS100, z. B. 'ABC')"
-					default=""
 					/>
 				<text key="uic_ref"
 					text="UIC-ID"
 					de.text="UIC-Bahnhofsnummer"
-					default=""
 					/>
 				<text key="uic_name"
 					text="UIC name"
 					de.text="UIC-Bahnhofsname"
-					default=""
 					/>
 				<combo key="railway:station_category"
 					text="Station category"
 					de.text="Bahnhofskategorie"
 					values="1,2,3,4,5,6,7"
 					display_values="1,2,3,4,5,6,7"
-					default=""
 					/>
 				<text key="operator"
 					text="Operator (e.g. 'DB Station&amp;Service AG')"
 					de.text="Betreiber (z. B. 'DB Station&amp;Service AG')"
-					default=""
 					/>
 				<text key="network"
 					text="Network"
 					de.text="Verkehrsverbund"
-					default=""
 					/>
 				<text key="start_date"
 					text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
-					default=""
 					/>
 				<text key="image"
 					text="Image URL"
 					de.text="URL eines Bildes"
-					default=""
 					/>
 				<text key="wikipedia"
 					text="Wikipedia article in the format (Language):(Article)"
 					de.text="Wikipediaartikel in der Form (Sprachkürzel):(Artikelname)"
-					default=""
 					/>
 				<text key="ele"
 					text="Height above sea level (m)"
 					de.text="Höhe über Meeresspiegel (m)"
-					default=""
 					/>
 			</item>
 			<item name="Halt" de.name="Haltepunkt/Haltestelle" icon="halt.png" type="node">
@@ -2697,63 +2466,51 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="station, "
 					de.display_values="ja,nein"
 					display_values="yes,no"
-					default=""
 					/>
 				<text key="name" text="Name"
 					de.text="Name"
-					default=""
 					/>
 				<text key="railway:ref"
 					text="Short name (DS100)"
 					de.text="Abkürzung (DS100, z. B. 'ABC')"
-					default=""
 					/>
 				<text key="uic_ref"
 					text="UIC-ID"
 					de.text="UIC-Bahnhofsnummer"
-					default=""
 					/>
 				<text key="uic_name"
 					text="UIC name"
 					de.text="UIC-Bahnhofsname"
-					default=""
 					/>
 				<combo key="railway:station_category"
 					text="Station category"
 					de.text="Bahnhofskategorie"
 					values="1,2,3,4,5,6,7"
 					display_values="1,2,3,4,5,6,7"
-					default=""
 					/>
 				<text key="operator"
 					text="Operator (e.g. 'DB Station&amp;Service AG')"
 					de.text="Betreiber (z. B. 'DB Station&amp;Service AG')"
-					default=""
 					/>
 				<text key="network"
 					text="Network"
 					de.text="Verkehrsverbund"
-					default=""
 					/>
 				<text key="start_date"
 					text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
-					default=""
 					/>
 				<text key="image"
 					text="Image URL"
 					de.text="URL eines Bildes"
-					default=""
 					/>
 				<text key="wikipedia"
 					text="Wikipedia article in the format (Language):(Article)"
 					de.text="Wikipediaartikel in der Form (Sprachkürzel):(Artikelname)"
-					default=""
 					/>
 				<text key="ele"
 					text="Height above sea level (m)"
 					de.text="Höhe über Meeresspiegel (m)"
-					default=""
 					/>
 			</item>
 			<item name="Tram Stop" de.name="Straßenbahnhaltestelle" icon="tramstop.png" type="node">
@@ -2768,46 +2525,37 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="station, "
 					de.display_values="ja,nein"
 					display_values="yes,no"
-					default=""
 					/>
 				<text key="name" text="Name"
 					de.text="Name"
-					default=""
 					/>
 				<text key="railway:ref"
 					text="Short name"
 					de.text="Abkürzung"
-					default=""
 					/>
 				<text key="uic_ref"
 					text="UIC-ID"
 					de.text="UIC-Bahnhofsnummer"
-					default=""
 					/>
 				<text key="uic_name"
 					text="UIC name"
 					de.text="UIC-Bahnhofsname"
-					default=""
 					/>
 				<text key="operator"
 					text="Operator (e.g. 'Rheinbahn')"
 					de.text="Betreiber (z. B. 'Rheinbahn')"
-					default=""
 					/>
 				<text key="network"
 					text="Network"
 					de.text="Verkehrsverbund"
-					default=""
 					/>
 				<text key="start_date"
 					text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
-					default=""
 					/>
 				<text key="ele"
 					text="Height above sea level (m)"
 					de.text="Höhe über Meeresspiegel (m)"
-					default=""
 					/>
 			</item>
 			<item name="Freight Station" de.name="Güterbahnhof/Rangierbahnhof" icon="yard-32.png" type="node">
@@ -2818,37 +2566,30 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					value="yard" />
 				<text key="name" text="Name"
 					de.text="Name"
-					default=""
 					/>
 				<text key="railway:ref"
 					text="Short name (DS100)"
 					de.text="Abkürzung (nach DS100, z. B. 'ABC')"
-					default=""
 					/>
 				<text key="operator"
 					text="Operator (e.g. 'DB Netz AG')"
 					de.text="Betreiber (z. B. 'DB Netz AG')"
-					default=""
 					/>
 				<text key="start_date"
 					text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
-					default=""
 					/>
 				<text key="image"
 					text="Image URL"
 					de.text="URL eines Bildes"
-					default=""
 					/>
 				<text key="wikipedia"
 					text="Wikipedia article in the format (Language):(Article)"
 					de.text="Wikipediaartikel in der Form (Sprachkürzel):(Artikelname)"
-					default=""
 					/>
 				<text key="ele"
 					text="Height above sea level (m)"
 					de.text="Höhe über Meeresspiegel (m)"
-					default=""
 					/>
 			</item>
 			<item name="Service Station" de.name="Betriebsbahnhof" icon="service-station.png" type="node">
@@ -2859,37 +2600,30 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					value="service_station" />
 				<text key="name" text="Name"
 					de.text="Name"
-					default=""
 					/>
 				<text key="railway:ref"
 					text="Short name (DS100)"
 					de.text="Abkürzung (nach DS100, z. B. 'ABC')"
-					default=""
 					/>
 				<text key="operator"
 					text="Operator (e.g. 'DB Netz AG')"
 					de.text="Betreiber (z. B. 'DB Netz AG')"
-					default=""
 					/>
 				<text key="start_date"
 					text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
-					default=""
 					/>
 				<text key="image"
 					text="Image URL"
 					de.text="URL eines Bildes"
-					default=""
 					/>
 				<text key="wikipedia"
 					text="Wikipedia article in the format (Language):(Article)"
 					de.text="Wikipediaartikel in der Form (Sprachkürzel):(Artikelname)"
-					default=""
 					/>
 				<text key="ele"
 					text="Height above sea level (m)"
 					de.text="Höhe über Meeresspiegel (m)"
-					default=""
 					/>
 			</item>
 			<item name="Juction" de.name="Abzweig" icon="junction-25.png" type="node">
@@ -2901,37 +2635,30 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<text key="name"
 					text="Name"
 					de.text="Name"
-					default=""
 					/>
 				<text key="railway:ref"
 					text="Short name (DS100, such as 'NAN')"
 					de.text="Abkürzung (nach DS100, z. B. 'NAN')"
-					default=""
 					/>
 				<text key="operator"
 					text="Operator (e.g. 'DB Netz AG')"
 					de.text="Betreiber (z. B. 'DB Netz AG')"
-					default=""
 					/>
 				<text key="start_date"
 					text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
-					default=""
 					/>
 				<text key="image"
 					text="Image URL"
 					de.text="URL eines Bildes"
-					default=""
 					/>
 				<text key="wikipedia"
 					text="Wikipedia article in the format (Language):(Article)"
 					de.text="Wikipediaartikel in der Form (Sprachkürzel):(Artikelname)"
-					default=""
 					/>
 				<text key="ele"
 					text="Height above sea level (m)"
 					de.text="Höhe über Meeresspiegel (m)"
-					default=""
 					/>
 			</item>
 			<item name="Spur juction" de.name="Anst / Awanst" icon="junction-25.png" type="node">
@@ -2943,37 +2670,30 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<text key="name"
 					text="Name"
 					de.text="Name"
-					default=""
 					/>
 				<text key="railway:ref"
 					text="Short name (DS100, such as 'NAN')"
 					de.text="Abkürzung (nach DS100, z. B. 'NAN')"
-					default=""
 					/>
 				<text key="operator"
 					text="Operator (e.g. 'DB Netz AG')"
 					de.text="Betreiber (z. B. 'DB Netz AG')"
-					default=""
 					/>
 				<text key="start_date"
 					text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
-					default=""
 					/>
 				<text key="image"
 					text="Image URL"
 					de.text="URL eines Bildes"
-					default=""
 					/>
 				<text key="wikipedia"
 					text="Wikipedia article in the format (Language):(Article)"
 					de.text="Wikipediaartikel in der Form (Sprachkürzel):(Artikelname)"
-					default=""
 					/>
 				<text key="ele"
 					text="Height above sea level (m)"
 					de.text="Höhe über Meeresspiegel (m)"
-					default=""
 					/>
 			</item>
 			<item name="Crossover" de.name="Überleitstelle" icon="crossover-28.png" type="node">
@@ -2985,37 +2705,30 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<text key="name"
 					text="Name"
 					de.text="Name"
-					default=""
 					/>
 				<text key="railway:ref"
 					text="Short name (DS100)"
 					de.text="Abkürzung (nach DS100, z. B. 'ABC')"
-					default=""
 					/>
 				<text key="operator"
 					text="Operator (e.g. 'DB Netz AG')"
 					de.text="Betreiber (z. B. 'DB Netz AG')"
-					default=""
 					/>
 				<text key="start_date"
 					text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
-					default=""
 					/>
 				<text key="image"
 					text="Image URL"
 					de.text="URL eines Bildes"
-					default=""
 					/>
 				<text key="wikipedia"
 					text="Wikipedia article in the format (Language):(Article)"
 					de.text="Wikipediaartikel in der Form (Sprachkürzel):(Artikelname)"
-					default=""
 					/>
 				<text key="ele"
 					text="Height above sea level (m)"
 					de.text="Höhe über Meeresspiegel (m)"
-					default=""
 					/>
 			</item>
 			<item name="Station Part or Blockpost" de.name="Bahnhofsteil, Blockstelle, Deckungsstelle" icon="site.png" type="node">
@@ -3027,37 +2740,30 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<text key="name"
 					text="Name"
 					de.text="Name"
-					default=""
 					/>
 				<text key="railway:ref"
 					text="Short name (DS100)"
 					de.text="Abkürzung (nach DS100, z. B. 'ABC')"
-					default=""
 					/>
 				<text key="operator"
 					text="Operator (e.g. 'DB Netz AG')"
 					de.text="Betreiber (z. B. 'DB Netz AG')"
-					default=""
 					/>
 				<text key="start_date"
 					text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
-					default=""
 					/>
 				<text key="image"
 					text="Image URL"
 					de.text="URL eines Bildes"
-					default=""
 					/>
 				<text key="wikipedia"
 					text="Wikipedia article in the format (Language):(Article)"
 					de.text="Wikipediaartikel in der Form (Sprachkürzel):(Artikelname)"
-					default=""
 					/>
 				<text key="ele"
 					text="Height above sea level (m)"
 					de.text="Höhe über Meeresspiegel (m)"
-					default=""
 					/>
 			</item>
 			<separator />
@@ -3071,34 +2777,28 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="stop_position, "
 					de.display_values="ja,nein"
 					display_values="yes,no"
-					default=""
 					/>
 				<key key="railway"
 					value="stop" />
 				<text key="name"
 					text="Name"
 					de.text="Name"
-					default=""
 					/>
 				<text key="railway:ref"
 					text="Short name (DS100)"
 					de.text="Abkürzung (nach DS100, z. B. 'ABC')"
-					default=""
 					/>
 				<text key="uic_ref"
 					text="UIC-ID"
 					de.text="UIC-Bahnhofsnummer"
-					default=""
 					/>
 				<text key="uic_name"
 					text="UIC name"
 					de.text="UIC-Bahnhofsname"
-					default=""
 					/>
 				<text key="local_ref"
 					text="track number (e.g. 5 or 5a)"
 					de.text="Gleisnummer (z.B. 5 oder 5a)"
-					default=""
 					/>
 				<check key="train"
 					text="Railway traffic?"
@@ -3123,27 +2823,22 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<text key="operator"
 					text="Operator (e.g. 'DB Netz AG' or 'DB Station&amp;Service AG')"
 					de.text="Betreiber (z. B. 'DB Netz AG' oder 'DB Station&amp;Service AG')"
-					default=""
 					/>
 				<text key="network"
 					text="Network"
 					de.text="Verkehrsverbund"
-					default=""
 					/>
 				<text key="ele"
 					text="Height above sea level (m)"
 					de.text="Höhe über Meeresspiegel (m)"
-					default=""
 					/>
 				<text key="railway:position"
 					text="Distance indication (rounded, e.g. '12.3'; km)"
 					de.text="Entfernungsangabe (gerundet, z. B. '12.3'; km)"
-					default=""
 					/>
 				<text key="railway:position:exact"
 					text="Exact distance indication (exact, e.g. '12.345'; km)"
 					de.text="Exakte Entfernungsangabe (genau, z.B: '12.345'; km)"
-					default=""
 					/>
 			</item>
 			<item name="Railway Landuse Area" de.name="Bahngelände" icon="landuse.png" type="closedway">
@@ -3162,7 +2857,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="public_transport, "
 					de.display_values="ja,nein"
 					display_values="yes,no"
-					default=""
 					/>
 				<combo key="public_transport"
 					text="Public transport?"
@@ -3170,32 +2864,26 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="stop_area, "
 					de.display_values="ja,nein"
 					display_values="yes,no"
-					default=""
 					/>
 				<text key="name"
 					text="Name"
 					de.text="Name"
-					default=""
 					/>
 				<text key="uic_ref"
 					text="UIC-ID"
 					de.text="UIC-Bahnhofsnummer"
-					default=""
 					/>
 				<text key="uic_name"
 					text="UIC name"
 					de.text="UIC-Bahnhofsname"
-					default=""
 					/>
 				<text key="railway:ref"
 					text="Short name (DS100)"
 					de.text="Abkürzung (nach DS100, z. B. 'ABC')"
-					default=""
 					/>
 				<text key="operator"
 					text="Operator (e.g. 'DB Netz AG' or 'DB Station&amp;Service AG')"
 					de.text="Betreiber (z. B. 'DB Netz AG' oder 'DB Station&amp;Service AG')"
-					default=""
 					/>
 				<check key="train"
 					text="Railway traffic?"
@@ -3263,32 +2951,26 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<text key="name"
 				text="Name of track (e.g. '1234 Eifelquerbahn Gerolstein - Kaisersesch')"
 				de.text="Streckenname (z. B. '1234 Eifelquerbahn Gerolstein – Kaisersesch')"
-				default=""
 				/>
 			<text key="ref"
 				text="Line ref (VzG number, e.g. '2379')"
 				de.text="Streckennummer (VzG-Nummer, z. B. '2379')"
-				default=""
 				/>
 			<text key="from"
 				text="Initial station"
 				de.text="Streckenanfang"
-				default=""
 				/>
 			<text key="to"
 				text="Terminus station"
 				de.text="Streckenende"
-				default=""
 				/>
 			<text key="operator"
 				text="Operator (e.g. 'DB Netz AG')"
 				de.text="Betreiber (z. B. 'DB Netz AG')"
-				default=""
 				/>
 			<text key="wikipedia"
 				text="Wikipedia article in the format (Language):(Article)"
 				de.text="Wikipediaartikel in der Form (Sprachkürzel):(Artikelname)"
-				default=""
 				/>
 			<roles>
 				<role key=""
@@ -3308,27 +2990,22 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<text key="name"
 				text="Name of route (e.g. 'KBS 123 Voreifelbahn')"
 				de.text="Name der Kursbuchstrecke (z. B. 'KBS 123 Voreifelbahn')"
-				default=""
 				/>
 			<text key="ref"
 				text="Line ref (KBS number, e.g. '123')"
 				de.text="Streckennummer (KBS-Nummer, z. B. '123')"
-				default=""
 				/>
 			<text key="from"
 				text="Initial station"
 				de.text="Streckenanfang"
-				default=""
 				/>
 			<text key="to"
 				text="Terminus station"
 				de.text="Streckenende"
-				default=""
 				/>
 			<text key="wikipedia"
 				text="Wikipedia article in the format (Language):(Article)"
 				de.text="Wikipediaartikel in der Form (Sprachkürzel):(Artikelname)"
-				default=""
 				/>
 			<roles>
 				<role key=""
@@ -3349,9 +3026,8 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				values="train,light_rail,tram,subway"
 				de.display_values="Zug,Stadt-/Schnellbahn,Straßenbahn,U-Bahn"
 				display_values="train,light rail,tram,subway"
-				default=""
 				/>
-			<combo key="service" text="Zuggattung" default="">
+			<combo key="service" text="Zuggattung">
 				<list_entry value="high_speed" de.display_value="Hochgeschwindigkeitszug" display_value="high speed train" short_description="ICE, Thalys, TGV, Railjet" />
 				<list_entry value="long_distance" de.display_value="Reisezug" display_value="long distance train" short_description="Eurocity, Intercity, D-Zug" />
 				<list_entry value="regional" de.display_value="Regionalzug" display_value="regional train" short_description="Regionalbahn, Regionalexpress" />
@@ -3364,32 +3040,26 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<text key="name"
 				text="Name of line (e.g. 'RE 7 Krefeld Rhein-Münsterland-Express')"
 				de.text="Name der Linie (z. B. 'RE 7 Krefeld Rhein-Münsterland-Express')"
-				default=""
 				/>
 			<text key="operator"
 				text="Operator"
 				de.text="Betreiber"
-				default=""
 				/>
 			<text key="ref"
 				text="Line or train ref (e.g. 'RE 7')"
 				de.text="Linien- bzw. Zugnummer (z. B. 'RE 7')"
-				default=""
 				/>
 			<text key="from"
 				text="Initial station"
 				de.text="Streckenanfang"
-				default=""
 				/>
 			<text key="to"
 				text="Terminus station"
 				de.text="Streckenende"
-				default=""
 				/>
 			<text key="wikipedia"
 				text="Wikipedia article in the format (Language):(Article)"
 				de.text="Wikipediaartikel in der Form (Sprachkürzel):(Artikelname)"
-				default=""
 				/>
 			<roles>
 				<role key=""
@@ -3446,9 +3116,8 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				values="train,light_rail,tram,subway"
 				de.display_values="Zug,Stadt-/Schnellbahn,Straßenbahn,U-Bahn"
 				display_values="train,light rail,tram,subway"
-				default=""
 				/>
-			<combo key="service" text="Zuggattung" default="">
+			<combo key="service" text="Zuggattung">
 				<list_entry value="high_speed" de.display_value="Hochgeschwindigkeitszug" display_value="high speed train" short_description="ICE, Thalys, TGV, Railjet" />
 				<list_entry value="long_distance" de.display_value="Reisezug" display_value="long distance train" short_description="Eurocity, Intercity, D-Zug" />
 				<list_entry value="regional" de.display_value="Regionalzug" display_value="regional train" short_description="Regionalbahn, Regionalexpress" />
@@ -3461,32 +3130,26 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<text key="name"
 				text="Name of line (e.g. 'RE 7 Krefeld Rhein-Münsterland-Express')"
 				de.text="Name der Linie (z. B. 'RE 7 Krefeld Rhein-Münsterland-Express')"
-				default=""
 				/>
 			<text key="operator"
 				text="Operator"
 				de.text="Betreiber"
-				default=""
 				/>
 			<text key="ref"
 				text="Line or train ref (e.g. 'RE 7')"
 				de.text="Linien- bzw. Zugnummer (z. B. 'RE 7')"
-				default=""
 				/>
 			<text key="from"
 				text="Initial station"
 				de.text="Streckenanfang"
-				default=""
 				/>
 			<text key="to"
 				text="Terminus station"
 				de.text="Streckenende"
-				default=""
 				/>
 			<text key="wikipedia"
 				text="Wikipedia article in the format (Language):(Article)"
 				de.text="Wikipediaartikel in der Form (Sprachkürzel):(Artikelname)"
-				default=""
 				/>
 			<roles>
 				<role key=""
@@ -3541,17 +3204,14 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<text key="railway:ref"
 				text="Name (no position)"
 				de.text="Name (keine Kilometerangabe oder kreuzende Straße)"
-				default=""
 				/>
 			<text key="railway:position"
 				text="Position (rounded, e.g. '12.3'; km)"
 				de.text="Hektometerwert (z. B. '12.3')"
-				default=""
 				/>
 			<text key="railway:position:exact"
 				text="Position (exact, e.g. '12.345'; km)"
 				de.text="Metergenauer Wert (z. B. '12.345'; km)"
-				default=""
 				/>
 			<space />
 			<combo key="crossing:barrier"
@@ -3559,7 +3219,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				values="half,double_half,full,gates,yes,no"
 				de.display_values="Halbschranke,Vollabschluss ('doppelte Halbschranke'),Vollschranke,Tore (England),Beschrankt,Unbeschrankt"
 				display_values="half boom gate,double half boom gate,full boom gate,gates (turnable),yes,no"
-				default=""
 				/>
 			<check key="crossing:light"
 				text="Lights"
@@ -3587,19 +3246,16 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				values="no,camera,attendant,automatic,phone"
 				display_values="no,camera,attendant,automatic,phone"
 				de.display_values="keine Überwachung,Kamera,Schrankenwärter/Fahrdienstleiter/Posten,Gefahrenraum-Freimeldeanlage,Telefon (Anrufschranken)"
-				default=""
 				/>
 			<combo key="crossing:activation"
 				text="Activation" de.text="Einschaltung"
 				values="automatic,remote,local"
 				display_values="automatic (contacts),remote (signal box), local (attendant/train staff)"
 				de.display_values="Einschaltkontakte, fahrdienstleitergesteuert, vor Ort (Schrankenwärter/Zugpersonal)"
-				default=""
 				/>
 			<text key="railway:level_crossing:closure:average"
 				text="average clousure duration (minutes)"
 				de.text="durchschnittliche Schließdauer (in Minuten)"
-				default=""
 				/>
 			<check key="crossing:on_demand"
 				text="On demand"
@@ -3615,17 +3271,14 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<text key="railway:ref"
 				text="Name (no position)"
 				de.text="Name (keine Kilometerangabe oder kreuzende Straße)"
-				default=""
 				/>
 			<text key="railway:position"
 				text="Position (rounded, e.g. '12.3'; km)"
 				de.text="Hektometerwert (z. B. '12.3')"
-				default=""
 				/>
 			<text key="railway:position:exact"
 				text="Position (exact, e.g. '12.345'; km)"
 				de.text="Metergenauer Wert (z. B. '12.345'; km)"
-				default=""
 				/>
 			<space />
 			<combo key="crossing:barrier"
@@ -3633,7 +3286,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				values="half,double_half,full,gates,yes,no"
 				de.display_values="Halbschranke,Vollabschluss ('doppelte Halbschranke'),Vollschranke,Tore (England),Beschrankt,Unbeschrankt"
 				display_values="half boom gate,double half boom gate,full boom gate,gates (turnable),yes,no"
-				default=""
 				/>
 			<check key="crossing:light"
 				text="Lights"
@@ -3661,19 +3313,16 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				values="no,camera,attendant,automatic,phone"
 				display_values="no,camera,attendant,automatic,phone"
 				de.display_values="keine Überwachung,Kamera,Schrankenwärter/Fahrdienstleiter/Posten,Gefahrenraum-Freimeldeanlage,Telefon (Anrufschranken)"
-				default=""
 				/>
 			<combo key="crossing:activation"
 				text="Activation" de.text="Einschaltung"
 				values="automatic,remote,local"
 				display_values="automatic (contacts),remote (signal box), local (attendant/train staff)"
 				de.display_values="Einschaltkontakte, fahrdienstleitergesteuert, vor Ort (Schrankenwärter/Zugpersonal)"
-				default=""
 				/>
 			<text key="railway:level_crossing:closure:average"
 				text="average clousure duration (minutes)"
 				de.text="durchschnittliche Schließdauer (in Minuten)"
-				default=""
 				/>
 			<check key="crossing:on_demand"
 				text="On demand"
@@ -3697,12 +3346,10 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<text key="railway:position"
 				text="Distance indication (rounded, e.g. '12.3'; km)"
 				de.text="Hektometerwert (z. B. '12.3')"
-				default=""
 				/>
 			<text key="railway:position:exact"
 				text="Exact distance indication (exact, e.g. '12.345'; km)"
 				de.text="Metergenauer Wert (z. B. '12.345')"
-				default=""
 				/>
 			<check key="railway:milestone:catenary_mast"
 				text="On catenary mast"
@@ -3719,7 +3366,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				de.text="Richtung der Notbremsunterdrückung (falls vorhanden)"
 				values="forward,backward,both"
 				display_values="In Wegrichtung,Entgegen Wegrichtung,Beide Richtungen"
-				default=""
 				/>
 		</item>
 		<item name="Platform" de.name="Bahnsteig" icon="platform.png" type="way,closedway">
@@ -3729,12 +3375,10 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<text key="name"
 				text="Caption"
 				de.text="Beschriftung"
-				default=""
 				/>
 			<text key="ref"
 				text="Platform number(s)"
 				de.text="Bahnsteignummer(n)"
-				default=""
 				/>
 			<check key="area"
 				text="Area"
@@ -3756,7 +3400,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				de.text="Oberfläche"
 				values="asphalt,paving_stones,concrete,cobblestone,compacted,paved,unpaved"
 				display_values="Asphalt,Pflastersteine,Beton,Kopfsteinpflaster,Verdichtet,Befestigt,Unbefestigt"
-				default=""
 				/>
 			<key key="public_transport"
 				value="platform" />
@@ -3765,19 +3408,16 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				de.text="Rollstuhlgerecht"
 				values="yes,no,limited"
 				display_values="Ja,Nein,Eingeschränkt"
-				default=""
 				/>
 			<combo key="tactile_paving"
 				text="Tactile Paving"
 				de.text="Ertastbarer Untergrund"
 				values="yes,no,incorrect"
 				display_values="Ja,Nein,Ja (aber nicht sinnvoll)"
-				default=""
 				/>
 			<text key="height"
 				text="Platform height (in meters, e. g. 0.76)"
 				de.text="Bahnsteighöhe (in Metern, z. B. 0.76)"
-				default=""
 				/>
 			<check key="train"
 				text="Railway traffic?"
@@ -3808,17 +3448,14 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<text key="operator"
 				text="Operator (e.g. 'Deutsche Bahn')"
 				de.text="Betreiber (z. B. 'Deutsche Bahn')"
-				default=""
 				/>
 			<text key="name"
 				text="Name (e.g. 'Reisezentrum')"
 				de.text="Name (z. B. 'Reisezentrum')"
-				default=""
 				/>
 			<text key="opening_hours"
 				text="Opening hours"
 				de.text="Öffnungszeiten"
-				default=""
 				/>
 		</item>
 		<item name="Subway Entrance" de.name="U-Bahn-Zugang" icon="landuse.png" type="node">
@@ -3828,14 +3465,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<text key="name"
 				text="Name"
 				de.text="Name"
-				default=""
 				/>
 			<combo key="wheelchair"
 				text="Wheelchair"
 				de.text="Rollstuhlgerecht"
 				values="yes,no,limited"
 				display_values="Ja,Nein,Eingeschränkt"
-				default=""
 				/>
 			<check key="bicycle"
 				text="Accessible with bicycles"
@@ -3851,17 +3486,14 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<text key="start_date"
 				text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 				de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
-				default=""
 				/>
 			<text key="image"
 				text="Image URL"
 				de.text="URL eines Bildes"
-				default=""
 				/>
 			<text key="ele"
 				text="Height above sea level (m)"
 				de.text="Höhe über Meeresspiegel (m)"
-				default=""
 				/>
 		</item>
 		<item name="Railway Landuse Area" de.name="Bahngelände" icon="landuse.png" type="closedway">
@@ -3896,7 +3528,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				values="analogue,gsm-r"
 					display_values="analogue,GSM-R"
 				de.display_values="Analog,GSM-R"
-				default=""
 				/>
 		</item>
 		<separator />
@@ -3974,7 +3605,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<text key="name"
 					text="Name"
 					de.text="Name"
-					default=""
 					/>
 			</item>
 			<item name="Workshop" de.name="Werkstatt" icon="workshop.png" type="node,closedway">
@@ -3989,7 +3619,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<text key="name"
 					text="Name"
 					de.text="Name"
-					default=""
 					/>
 			</item>
 		</group>
@@ -4016,7 +3645,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<text key="name"
 					text="Name"
 					de.text="Name"
-					default=""
 					/>
 				<check key="lit"
 					text="Lit"
@@ -4028,12 +3656,10 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Oberfläche"
 					values="asphalt,paving_stones,concrete,cobblestone,compacted,paved,unpaved"
 					display_values="Asphalt,Pflastersteine,Beton,Kopfsteinpflaster,Verdichtet,Befestigt,Unbefestigt"
-					default=""
 					/>
 				<text key="height"
 					text="Ramp height (m) - 0 for loading streets"
 					de.text="Rampenhöhe (m) - bei Ladestraße 0 eintragen"
-					default=""
 					/>
 				<check key="area"
 					text="Area"
@@ -4043,7 +3669,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<text key="operator"
 					text="Operator (e.g. 'DB Netz AG')"
 					de.text="Betreiber (z. B. 'DB Netz AG')"
-					default=""
 					/>
 			</item>
 			<separator />
@@ -4056,22 +3681,18 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<text key="name"
 					text="Name"
 					de.text="Name"
-					default=""
 					/>
 				<text key="uic_ref"
 					text="UIC-ID"
 					de.text="UIC-Bahnhofsnummer"
-					default=""
 					/>
 				<text key="uic_name"
 					text="UIC name"
 					de.text="UIC-Bahnhofsname"
-					default=""
 					/>
 				<text key="operator"
 					text="Operator"
 					de.text="Betreiber"
-					default=""
 					/>
 			</item>
 			<item name="Eisenbahnfährverlauf" icon="ferry-way.png" type="way">
@@ -4083,12 +3704,10 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<text key="name"
 					text="Name"
 					de.text="Name"
-					default=""
 					/>
 				<text key="operator"
 					text="Operator"
 					de.text="Betreiber"
-					default=""
 					/>
 			</item>
 			<item name="Eisenbahnfährlinie" icon="ferry-line.png" type="relation">
@@ -4102,12 +3721,10 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<text key="name"
 					text="Name"
 					de.text="Name"
-					default=""
 					/>
 				<text key="operator"
 					text="Operator"
 					de.text="Betreiber"
-					default=""
 					/>
 			</item>
 			<separator />
@@ -4123,12 +3740,10 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<text key="name"
 					text="Name"
 					de.text="Name"
-					default=""
 					/>
 				<text key="wikipedia"
 					text="Wikipedia article in the format (Language):(Article)"
 					de.text="Wikipediaartikel in der Form (Sprachkürzel):(Artikelname)"
-					default=""
 					/>
 			</item>
 			<item name="Rollbock Siding" de.name="Rollwagen-/Rollschemelverladung" icon="carrier-truck-pit.png" type="node">
@@ -4144,32 +3759,26 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<text key="name"
 					text="Name"
 					de.text="Name"
-					default=""
 					/>
 				<text key="operator"
 					text="Operator"
 					de.text="Betreiber"
-					default=""
 					/>
 				<text key="uic_ref"
 					text="UIC-ID"
 					de.text="UIC-Bahnhofsnummer"
-					default=""
 					/>
 				<text key="uic_name"
 					text="UIC name"
 					de.text="UIC-Bahnhofsname"
-					default=""
 					/>
 				<text key="network"
 					text="Network"
 					de.text="Verkehrsverbund"
-					default=""
 					/>
 				<text key="image"
 					text="Image URL"
 					de.text="URL eines Bildes"
-					default=""
 					/>
 			</item>
 			<item name="Car Shuttle Station" de.name="Autozug-Verladung" icon="carshuttle.png" type="node">
@@ -4180,32 +3789,26 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<text key="name"
 					text="Name"
 					de.text="Name"
-					default=""
 					/>
 				<text key="operator"
 					text="Operator"
 					de.text="Betreiber"
-					default=""
 					/>
 				<text key="uic_ref"
 					text="UIC-ID"
 					de.text="UIC-Bahnhofsnummer"
-					default=""
 					/>
 				<text key="uic_name"
 					text="UIC name"
 					de.text="UIC-Bahnhofsname"
-					default=""
 					/>
 				<text key="network"
 					text="Network"
 					de.text="Verkehrsverbund"
-					default=""
 					/>
 				<text key="image"
 					text="Image URL"
 					de.text="URL eines Bildes"
-					default=""
 					/>
 			</item>
 		</group>
@@ -4244,12 +3847,10 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<text key="name"
 				text="Name"
 				de.text="Name"
-				default=""
 				/>
 			<text key="wikipedia"
 				text="Wikipedia article in the format (Language):(Article)"
 				de.text="Wikipediaartikel in der Form (Sprachkürzel):(Artikelname)"
-				default=""
 				/>
 		</item>
 		<item name="Company with railway siding" de.name="Firma mit Gleisanschluss" icon="industrial.png" type="closedway">
@@ -4261,7 +3862,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<text key="name"
 				text="Name"
 				de.text="Name"
-				default=""
 				/>
 		</item>
 		<item name="Gate" de.name="Tor" icon="gate.png" type="node">

--- a/josm-presets/de.xml
+++ b/josm-presets/de.xml
@@ -23,19 +23,19 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Line reference (VzG number, e.g. '2379')"
 					de.text="Streckennummer (VzG-Nummer, z. B. '2379')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="railway:track_ref"
 					text="Track ref (inside station)"
 					de.text="Gleisnummer (im Bahnhof)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="name"
 					text="Railway name"
 					de.text="Streckenname"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />	
-				<combo key="usage" text="Usage" de.text="Nutzung" default="" delete_if_empty="true">
+				<combo key="usage" text="Usage" de.text="Nutzung" default="">
 					<list_entry value="main" de.display_value="Hauptbahn" display_value="main line" de.short_description="Strecke mit übergeordneter Bedeutung; meist zweigleisig, meist elektrifiziert, in der Regel zumindest abschnittsweise mit mehr als 100 km/h befahrbar" short_description="An important line; often double tracks, electrified; usually more than 100 km/h" />
 					<list_entry value="branch" de.display_value="Nebenbahn" display_value="branch line" de.short_description="Strecke mit untergeordneter Bedeutung; oft nicht elektrifiziert, oft eingleisig. Keinesfalls mit mehr als 100 km/h befahrbar." short_description="less important line; often single-tracked; not electrified; less than 100 km/h" />
 					<list_entry value="industrial" de.display_value="Industriebahn" display_value="industrial/mine railway" de.short_description="Eine Strecke, die ausschließlich dem Güterverkehr dient und in der Regel Eigentum eines Industrieunternehmens ist. Meist nur innerhalb von Hafengebieten, Industrieanlagen, Tagebauen." short_description="A line only used for freight trains inside industrial areas or mines." />
@@ -49,47 +49,47 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="mixed,passenger,freight"
 					de.display_values="Gemischt,Personenverkehr,Güterverkehr" display_values="mixed,passenger,freight"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<check key="highspeed"
 					text="High-speed line (~ >200 km/h)"
 					de.text="Hochgeschwindigkeitsstrecke (~ >200 km/h)"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="railway:tilting"
 					text="Used by tilting trains"
 					de.text="Neigetechnik-Ausrüstung"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<space />
 				<check key="lit"
 					text="Lit"
 					de.text="Beleuchtung"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="railway:pzb"
 					text="PZB"
 					de.text="Punktförmige Zugbeeinflussung (PZB)"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="railway:lzb"
 					text="Linienzugbeeinflussung (LZB)"
 					de.text="Linienzugbeeinflussung (LZB)"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:gnt"
 					text="Tilting train system"
 					de.text="Geschwindigkeitsüberwachung Neigetechnik"
 					values="yes,no,zub122,zub262"
 					display_values="Ja,Nein,ZUB122,ZUB262"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:etcs"
 					text="ETCS"
 					de.text="ETCS"
 					values="yes,no,0,1,2,3"
 					display_values="Ja,Nein,Level 0,Level 1,Level 2,Level 3"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:radio"
 					text="Radio"
 					de.text="Zugfunk"
@@ -97,13 +97,13 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					display_values="analogue,GSM-R"
 					de.display_values="Analog,GSM-R"
 					default=""
-					delete_if_empty="true" />
-				<combo key="railway:preferred_direction" text="Direction of use (depends on direction of OSM way)" de.text="Regelfahrtrichtung (abhängig von Richtung des OSM-Ways)" default="" delete_if_empty="true">
+					/>
+				<combo key="railway:preferred_direction" text="Direction of use (depends on direction of OSM way)" de.text="Regelfahrtrichtung (abhängig von Richtung des OSM-Ways)" default="">
 					<list_entry value="forward" display_value="forward (in the same direction as the OSM way)" de.display_value="In Wegrichtung" short_description="Das Gleis wird üblicherweise in die Richtung befahren, in die der OSM-Way führt. Nur für mehrgleisige Strecken." />
 					<list_entry value="backward"  display_value="backward (in the other direction than the OSM way)" de.display_value="Entgegen Wegrichtung" short_description="Das Gleis wird üblicherweise entgegen der Richtung befahren, in die der OSM-Way führt. Nur für mehrgleisige Strecken." />
 					<list_entry value="both" display_value="both" de.display_value="Beide Richtungen" short_description="Es gibt keine Richtung, in die die Züge üblicherweise fahren bzw. nicht fahren. Nur für eingleisige Strecken." />
 				</combo>
-				<combo key="railway:bidirectional" text="Bidirectional traffic (depends on direction of OSM way)" de.text="Gleiswechselbetrieb (abhängig von Richtung des OSM-Ways)" default="" delete_if_empty="true">
+				<combo key="railway:bidirectional" text="Bidirectional traffic (depends on direction of OSM way)" de.text="Gleiswechselbetrieb (abhängig von Richtung des OSM-Ways)" default="">
 					<list_entry value="regular" de.display_value="Gleiswechselbetrieb" short_description="Das Gleis ist für beide Fahrtrichtungen mit Signalen ausgestattet und kann daher regulär entgegen der üblichen Fahrtrichtung befahren werden." />
 					<list_entry value="signals" de.display_value="Signalisierter Falschfahrbetrieb" short_description="Das Gleis ist signaltechnisch nur für eine Fahrtrichtung ausgelegt, sodass weiterhin Falschfahrten notwendig sind, diese sind aber durch Signale geregelt." />
 					<list_entry value="possible" de.display_value="Falschfahrt möglich" short_description="Signaltechnisch besteht keine Möglichkeit einer Befahrung des Gegengleises. Es ist ein schriftlicher Befehl notwendig." />
@@ -112,14 +112,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<combo key="maxspeed" default=""
 					text="Maxspeed (km/h)"
 					de.text="Höchstgeschwindigkeit (km/h)"
-					delete_if_empty="true"
 					values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,none"
 					display_values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,keine" />
 				<label text="Different speed limits depending on direction can be tagged manually using maxspeed:forward= and maxspeed:backward=*." de.text="Unterschiedliche Geschwindigkeiten je Richtung können manuell mit maxspeed:forward=* bzw. maxspeed:backward=* getaggt werden." />
 				<combo key="maxspeed:tilting" default=""
 					text="Maxspeed of Used by tilting trains (km/h)"
 					de.text="Höchstgeschwindigkeit von Neigetechnikzügen (km/h)"
-					delete_if_empty="true"
 					values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,none"
 					display_values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,keine" />
 				<space />
@@ -129,7 +127,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="yes,no,contact_line,rail"
 					display_values="Ja,Nein,Ja (mit Oberleitung),Ja (mit Stromschiene)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="voltage"
 					text="Voltage"
 					de.text="Spannung"
@@ -137,7 +135,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					display_values="15 kV (default in Germany),600 V,750 V,1200 V,1500 V,2400 V,3000 V,6600 V,25 kV"
 					de.display_values="15 kV (Standard in Deutschland),600 V,750 V,1200 V,1500 V,2400 V,3000 V,6600 V,25 kV"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="frequency"
 					text="Frequency"
 					de.text="Frequenz"
@@ -145,53 +143,53 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.display_values="16.7 Hz (Standard in Deutschland),Gleichspannung,16 2/3 Hz (in Teilen Deutschlands),50 Hz,60 Hz,25 Hz"
 					display_values="16.7 Hz (default in Germany),DC,16 2/3 Hz (in parts of Germany),50 Hz,60 Hz,25 Hz"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="gauge"
 					text="Gauge"
 					de.text="Spurweite"
 					values="1435,1520,1524,1800"
 					display_values="1435 mm (Normalspur),1520 mm (Russische Breitspur),1524 mm (Russische Breitspur),1800 mm"
 					default="1435"
-					delete_if_empty="true" />
+					/>
 				<check key="railway:ballastless"
 					text="Ballastless"
 					de.text="Feste Fahrbahn"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="rack"
 					text="Rack"
 					de.text="Zahnstange"
 					values="yes,no,riggenbach,strub,abt,locher,riggenbach-klose,marsh,von_roll"
 					display_values="Ja,Nein,System Riggenbach,System Strub,System Abt,System Locher,System Riggenbach-Klose,System Marsh,System Von Roll"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="incline"
 					text="Incline (e.g.. '3%')"
 					de.text="Steigung (z. B. '3%')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<text key="start_date"
 					text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="operator"
 					text="Operator (e.g. 'DB Netz AG')"
 					de.text="Betreiber (z. B. 'DB Netz AG')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<check key="embankment"
 					text="Embankment"
 					de.text="Damm"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="cutting"
 					text="Cutting"
 					de.text="Einschnitt"
 					default="off"
-					delete_if_empty="true" />
+					/>
 			</item>
 			<item de.name="Hauptgleis" name="Siding Track" icon="siding-32.png" type="way">
 				<label text="Siding tracks inside stations which are no yard or spur tracks. Every track is mapped individually." de.text="Nicht durchgehendes Hauptgleis in einem Bahnhof und alle sonstigen Gleise, die weder durchgehendes Hauptgleis, noch Nebengleis, Anschlussgleis, Abstellgleis oder Überleitgleis sind. Jedes Gleis wird einzeln erfasst." />
@@ -204,7 +202,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Track ref (inside station)"
 					de.text="Gleisnummer (im Bahnhof)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<combo key="railway:traffic_mode"
 					text="Traffic mode"
@@ -212,35 +210,35 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="mixed,passenger,freight"
 					de.display_values="Gemischt,Personenverkehr,Güterverkehr" display_values="mixed,passenger,freight"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<check key="highspeed"
 					text="High-speed line (~ >200 km/h)"
 					de.text="Hochgeschwindigkeitsstrecke (~ >200 km/h)"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<space />
 				<check key="lit"
 					text="Lit"
 					de.text="Beleuchtung"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="railway:pzb"
 					text="PZB"
 					de.text="Punktförmige Zugbeeinflussung (PZB)"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="railway:lzb"
 					text="Linienzugbeeinflussung (LZB)"
 					de.text="Linienzugbeeinflussung (LZB)"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:etcs"
 					text="ETCS"
 					de.text="ETCS"
 					values="yes,no,0,1,2,3"
 					display_values="Ja,Nein,Level 0,Level 1,Level 2,Level 3"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:radio"
 					text="Radio"
 					de.text="Zugfunk"
@@ -248,11 +246,10 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					display_values="analogue,GSM-R"
 					de.display_values="Analog,GSM-R"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="maxspeed" default=""
 					text="Maxspeed (km/h)"
 					de.text="Höchstgeschwindigkeit (km/h)"
-					delete_if_empty="true"
 					values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,none"
 					display_values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,keine" />
 				<label text="Different speed limits depending on direction can be tagged manually using maxspeed:forward= and maxspeed:backward=*." de.text="Unterschiedliche Geschwindigkeiten je Richtung können manuell mit maxspeed:forward=* bzw. maxspeed:backward=* getaggt werden." />
@@ -263,7 +260,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="yes,no,contact_line,rail"
 					display_values="Ja,Nein,Oberleitung,Stromschiene"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="voltage"
 					text="Voltage"
 					de.text="Spannung"
@@ -271,7 +268,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					display_values="15 kV (default in Germany),600 V,750 V,1200 V,1500 V,2400 V,3000 V,6600 V,25 kV"
 					de.display_values="15 kV (Standard in Deutschland),600 V,750 V,1200 V,1500 V,2400 V,3000 V,6600 V,25 kV"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="frequency"
 					text="Frequency"
 					de.text="Frequenz"
@@ -279,53 +276,53 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.display_values="16.7 Hz (Standard in Deutschland),Gleichspannung,16 2/3 Hz (in Teilen Deutschlands),50 Hz,60 Hz,25 Hz"
 					display_values="16.7 Hz (default in Germany),DC,16 2/3 Hz (in parts of Germany),50 Hz,60 Hz,25 Hz"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="gauge"
 					text="Gauge"
 					de.text="Spurweite"
 					values="1435,1520,1524,1800"
 					display_values="1435 mm (Normalspur),1520 mm (Russische Breitspur),1524 mm (Russische Breitspur),1800 mm"
 					default="1435"
-					delete_if_empty="true" />
+					/>
 				<check key="railway:ballastless"
 					text="Ballastless"
 					de.text="Feste Fahrbahn"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="rack"
 					text="Rack"
 					de.text="Zahnstange"
 					values="yes,no,riggenbach,strub,abt,locher,riggenbach-klose,marsh,von_roll"
 					display_values="Ja,Nein,System Riggenbach,System Strub,System Abt,System Locher,System Riggenbach-Klose,System Marsh,System Von Roll"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="incline"
 					text="Incline (e.g.. '3%')"
 					de.text="Steigung (z. B. '3%')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<text key="start_date"
 					text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="operator"
 					text="Operator (e.g. 'DB Netz AG')"
 					de.text="Betreiber (z. B. 'DB Netz AG')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<check key="embankment"
 					text="Embankment"
 					de.text="Damm"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="cutting"
 					text="Cutting"
 					de.text="Einschnitt"
 					default="off"
-					delete_if_empty="true" />
+					/>
 			</item>
 			<item de.name="Nebengleis / Abstellgleis" name="Yard Track" icon="yard-track-32.png" type="way">
 				<label text="Yard tracs. Every track is mapped individually." de.text="Abstellgleise in Rangier-, Güter- oder Betriebsbahnhöfen, auf denen Züge zusammengestellt und Wagen abgestellt werden. Jedes Gleis wird einzeln erfasst." />
@@ -338,7 +335,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Track ref (inside station)"
 					de.text="Gleisnummer (im Bahnhof)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<combo key="railway:traffic_mode"
 					text="Traffic mode"
@@ -346,25 +343,25 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="mixed,passenger,freight"
 					de.display_values="Gemischt,Personenverkehr,Güterverkehr" display_values="mixed,passenger,freight"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<check key="lit"
 					text="Lit"
 					de.text="Beleuchtung"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="railway:pzb"
 					text="PZB"
 					de.text="Punktförmige Zugbeeinflussung (PZB)"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:etcs"
 					text="ETCS"
 					de.text="ETCS"
 					values="yes,no,0,1,2,3"
 					display_values="Ja,Nein,Level 0,Level 1,Level 2,Level 3"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:radio"
 					text="Radio"
 					de.text="Zugfunk"
@@ -372,11 +369,10 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					display_values="analogue,GSM-R"
 					de.display_values="Analog,GSM-R"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="maxspeed" default=""
 					text="Maxspeed (km/h)"
 					de.text="Höchstgeschwindigkeit (km/h)"
-					delete_if_empty="true"
 					values="10,20,30,40,50,60,70,80,90,100,none"
 					display_values="10,20,30,40,50,60,70,80,90,100,keine" />
 				<label text="Different speed limits depending on direction can be tagged manually using maxspeed:forward= and maxspeed:backward=*." de.text="Unterschiedliche Geschwindigkeiten je Richtung können manuell mit maxspeed:forward=* bzw. maxspeed:backward=* getaggt werden." />
@@ -387,7 +383,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="yes,no,contact_line,rail"
 					display_values="Ja,Nein,Oberleitung,Stromschiene"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="voltage"
 					text="Voltage"
 					de.text="Spannung"
@@ -395,7 +391,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					display_values="15 kV (default in Germany),600 V,750 V,1200 V,1500 V,2400 V,3000 V,6600 V,25 kV"
 					de.display_values="15 kV (Standard in Deutschland),600 V,750 V,1200 V,1500 V,2400 V,3000 V,6600 V,25 kV"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="frequency"
 					text="Frequency"
 					de.text="Frequenz"
@@ -403,53 +399,53 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.display_values="16.7 Hz (Standard in Deutschland),Gleichspannung,16 2/3 Hz (in Teilen Deutschlands),50 Hz,60 Hz,25 Hz"
 					display_values="16.7 Hz (default in Germany),DC,16 2/3 Hz (in parts of Germany),50 Hz,60 Hz,25 Hz"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="gauge"
 					text="Gauge"
 					de.text="Spurweite"
 					values="1435,1520,1524,1800"
 					display_values="1435 mm (Normalspur),1520 mm (Russische Breitspur),1524 mm (Russische Breitspur),1800 mm"
 					default="1435"
-					delete_if_empty="true" />
+					/>
 				<check key="railway:ballastless"
 					text="Ballastless"
 					de.text="Feste Fahrbahn"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="rack"
 					text="Rack"
 					de.text="Zahnstange"
 					values="yes,no,riggenbach,strub,abt,locher,riggenbach-klose,marsh,von_roll"
 					display_values="Ja,Nein,System Riggenbach,System Strub,System Abt,System Locher,System Riggenbach-Klose,System Marsh,System Von Roll"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="incline"
 					text="Incline (e.g.. '3%')"
 					de.text="Steigung (z. B. '3%')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<text key="start_date"
 					text="Year of opening"
 					de.text="Zeitpunkt der Inbetriebnahme"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="operator"
 					text="Operator (e.g. 'DB Netz AG')"
 					de.text="Betreiber (z. B. 'DB Netz AG')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<check key="embankment"
 					text="Embankment"
 					de.text="Damm"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="cutting"
 					text="Cutting"
 					de.text="Einschnitt"
 					default="off"
-					delete_if_empty="true" />
+					/>
 			</item>
 			<item de.name="Anschluss- oder Verladegleis" name="Spur Track" icon="spur-25.png" type="way">
 				<label text="Short tracks connecting companies to the nearby railway line" de.text="Kurze Gleise, die Industriebetriebe an eine Bahnstrecke anschließen oder Verladegleise in Industrieanlagen." />
@@ -466,24 +462,24 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Lit"
 					de.text="Beleuchtung"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="railway:pzb"
 					text="PZB"
 					de.text="Punktförmige Zugbeeinflussung (PZB)"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="railway:lzb"
 					text="Linienzugbeeinflussung (LZB)"
 					de.text="Linienzugbeeinflussung (LZB)"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:etcs"
 					text="ETCS"
 					de.text="ETCS"
 					values="yes,no,0,1,2,3"
 					display_values="Ja,Nein,Level 0,Level 1,Level 2,Level 3"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:radio"
 					text="Radio"
 					de.text="Zugfunk"
@@ -491,11 +487,10 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					display_values="analogue,GSM-R"
 					de.display_values="Analog,GSM-R"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="maxspeed" default=""
 					text="Maxspeed (km/h)"
 					de.text="Höchstgeschwindigkeit (km/h)"
-					delete_if_empty="true"
 					values="10,20,30,40,50,60,70,80,90,100,none"
 					display_values="10,20,30,40,50,60,70,80,90,100,keine" />
 				<label text="Different speed limits depending on direction can be tagged manually using maxspeed:forward= and maxspeed:backward=*." de.text="Unterschiedliche Geschwindigkeiten je Richtung können manuell mit maxspeed:forward=* bzw. maxspeed:backward=* getaggt werden." />
@@ -506,7 +501,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="yes,no,contact_line,rail"
 					display_values="Ja,Nein,Oberleitung,Stromschiene"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="voltage"
 					text="Voltage"
 					de.text="Spannung"
@@ -514,7 +509,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					display_values="15 kV (default in Germany),600 V,750 V,1200 V,1500 V,2400 V,3000 V,6600 V,25 kV"
 					de.display_values="15 kV (Standard in Deutschland),600 V,750 V,1200 V,1500 V,2400 V,3000 V,6600 V,25 kV"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="frequency"
 					text="Frequency"
 					de.text="Frequenz"
@@ -522,53 +517,53 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					display_values="16.7 Hz (default in Germany),16 2/3 Hz (in parts of Germany),50 Hz,60 Hz,25 Hz,DC"
 					de.display_values="16.7 Hz (Standard in Deutschland),16 2/3 Hz (in Teilen Deutschlands),50 Hz,60 Hz,25 Hz,Gleichspannung"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="gauge"
 					text="Gauge"
 					de.text="Spurweite"
 					values="1435,1520,1524,1800"
 					display_values="1435 mm (Normalspur),1520 mm (Russische Breitspur),1524 mm (Russische Breitspur),1800 mm"
 					default="1435"
-					delete_if_empty="true" />
+					/>
 				<check key="railway:ballastless"
 					text="Ballastless"
 					de.text="Feste Fahrbahn"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="rack"
 					text="Rack"
 					de.text="Zahnstange"
 					values="yes,no,riggenbach,strub,abt,locher,riggenbach-klose,marsh,von_roll"
 					display_values="Ja,Nein,System Riggenbach,System Strub,System Abt,System Locher,System Riggenbach-Klose,System Marsh,System Von Roll"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="incline"
 					text="Incline (e.g.. '3%')"
 					de.text="Steigung (z. B. '3%')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<text key="start_date"
 					text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="operator"
 					text="Operator (e.g. 'DB Netz AG')"
 					de.text="Betreiber (z. B. 'DB Netz AG')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<check key="embankment"
 					text="Embankment"
 					de.text="Damm"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="cutting"
 					text="Cutting"
 					de.text="Einschnitt"
 					default="off"
-					delete_if_empty="true" />
+					/>
 			</item>
 			<item de.name="Überleitgleis" name="Crossover Track" icon="crossover-track-28.png" type="way">
 				<label text="Crossover track which makes switching between left and right track on double-tracked railway lines possible." de.text="Überleitgleis, das den Wechsel zwischen zwei Gleisen einer Strecke ermöglicht." />
@@ -584,47 +579,47 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="mixed,passenger,freight"
 					de.display_values="Gemischt,Personenverkehr,Güterverkehr" display_values="mixed,passenger,freight"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<check key="highspeed"
 					text="High-speed line (~ >200 km/h)"
 					de.text="Hochgeschwindigkeitsstrecke (~ >200 km/h)"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="railway:tilting"
 					text="Used by tilting trains"
 					de.text="Neigetechnik-Ausrüstung"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<space />
 				<check key="lit"
 					text="Lit"
 					de.text="Beleuchtung"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="railway:pzb"
 					text="PZB"
 					de.text="Punktförmige Zugbeeinflussung (PZB)"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="railway:lzb"
 					text="LZB"
 					de.text="Linienzugbeeinflussung (LZB)"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:gnt"
 					text="Tilting train system"
 					de.text="Geschwindigkeitsüberwachung Neigetechnik"
 					values="yes,no,zub122,zub262"
 					display_values="Ja,Nein,ZUB122,ZUB262"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:etcs"
 					text="ETCS"
 					de.text="ETCS"
 					values="yes,no,0,1,2,3"
 					display_values="Ja,Nein,Level 0,Level 1,Level 2,Level 3"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:radio"
 					text="Radio"
 					de.text="Zugfunk"
@@ -632,19 +627,17 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					display_values="analogue,GSM-R"
 					de.display_values="Analog,GSM-R"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<combo key="maxspeed" default=""
 					text="Maxspeed (km/h)"
 					de.text="Höchstgeschwindigkeit (km/h)"
-					delete_if_empty="true"
 					values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,none"
 					display_values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,keine" />
 				<label text="Different speed limits depending on direction can be tagged manually using maxspeed:forward= and maxspeed:backward=*." de.text="Unterschiedliche Geschwindigkeiten je Richtung können manuell mit maxspeed:forward=* bzw. maxspeed:backward=* getaggt werden." />
 				<combo key="maxspeed:tilting" default=""
 					text="Maxspeed of Used by tilting trains (km/h)"
 					de.text="Höchstgeschwindigkeit von Neigetechnikzügen (km/h)"
-					delete_if_empty="true"
 					values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,none"
 					display_values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,keine" />
 				<space />
@@ -654,7 +647,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="yes,no,contact_line,rail"
 					display_values="Ja,Nein,Oberleitung,Stromschiene"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="voltage"
 					text="Voltage"
 					de.text="Spannung"
@@ -662,7 +655,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					display_values="15 kV (default in Germany),600 V,750 V,1200 V,1500 V,2400 V,3000 V,6600 V,25 kV"
 					de.display_values="15 kV (Standard in Deutschland),600 V,750 V,1200 V,1500 V,2400 V,3000 V,6600 V,25 kV"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="frequency"
 					text="Frequency"
 					de.text="Frequenz"
@@ -670,53 +663,53 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					display_values="16.7 Hz (default in Germany),DC,16 2/3 Hz (in large parts of Germany),50 Hz,60 Hz,25 Hz"
 					de.display_values="16.7 Hz (Standard in Deutschland),Gleichspannung,16 2/3 Hz (in Teilen Deutschlands),50 Hz,60 Hz,25 Hz"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="gauge"
 					text="Gauge"
 					de.text="Spurweite"
 					values="1435,1520,1524,1800"
 					display_values="1435 mm (Normalspur),1520 mm (Russische Breitspur),1524 mm (Russische Breitspur),1800 mm"
 					default="1435"
-					delete_if_empty="true" />
+					/>
 				<check key="railway:ballastless"
 					text="Ballastless"
 					de.text="Feste Fahrbahn"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="rack"
 					text="Rack"
 					de.text="Zahnstange"
 					values="yes,no,riggenbach,strub,abt,locher,riggenbach-klose,marsh,von_roll"
 					display_values="Ja,Nein,System Riggenbach,System Strub,System Abt,System Locher,System Riggenbach-Klose,System Marsh,System Von Roll"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="incline"
 					text="Incline (e.g.. '3%')"
 					de.text="Steigung (z. B. '3%')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<text key="start_date"
 					text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="operator"
 					text="Operator (e.g. 'DB Netz AG')"
 					de.text="Betreiber (z. B. 'DB Netz AG')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<check key="embankment"
 					text="Embankment"
 					de.text="Damm"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="cutting"
 					text="Cutting"
 					de.text="Einschnitt"
 					default="off"
-					delete_if_empty="true" />
+					/>
 			</item>
 			<separator />
 			<item de.name="Schmalspurgleis" name="Narrow-gauge Track" icon="narrowgauge.png" type="way">
@@ -728,19 +721,19 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Line ref (VzG number, e.g. '2379')"
 					de.text="Streckennummer (VzG-Nummer, z. B. '2379')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="railway:track_ref"
 					text="Track ref (inside station)"
 					de.text="Gleisnummer (im Bahnhof)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="name"
 					text="Railway name"
 					de.text="Streckenname"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
-				<combo key="usage" text="Usage (leave empty if main track or line)" de.text="Nutzung (leer lassen bei Strecken- und Hauptgleisen)" default="" delete_if_empty="true">
+				<combo key="usage" text="Usage (leave empty if main track or line)" de.text="Nutzung (leer lassen bei Strecken- und Hauptgleisen)" default="">
 					<list_entry value="branch" display_value="Reguläre Strecke" de.display_value="regular line" short_description="Eine Schmalspurbahn, auf der regulärer Personen- und/oder Güterverkehr stattfindet." />
 					<list_entry value="industrial" display_value="Industriebahn" de.display_value="industrial/mine railway" short_description="Eine Strecke, die ausschließlich dem Güterverkehr dient und in der Regel Eigentum eines Industrieunternehmens ist. Meist nur innerhalb von Hafengebieten, Industrieanlagen, Tagebauen." />
 					<list_entry value="military" de.display_value="Militärbahn" display_value="military railway" short_description="Eine Strecke, die ausschließlich dem Militärverkehr dient. Meistens Strecken zwischen normalen Bahnstrecken und Munitionsdepots oder Truppenübungsplätzen." />
@@ -753,8 +746,8 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="mixed,passenger,freight"
 					de.display_values="Gemischt,Personenverkehr,Güterverkehr" display_values="mixed,passenger,freight"
 					default=""
-					delete_if_empty="true" />
-				<combo key="service" text="Track service" de.text="Gleisfunktion" default="" delete_if_empty="true">
+					/>
+				<combo key="service" text="Track service" de.text="Gleisfunktion" default="">
 				  <list_entry value="siding" display_value="Nebengleis" short_description="Gleise in Bahnhöfen, die parallel zum durchgehenden Hauptgleis verlaufen und zum Überholen und Halten von Zügen dienen" /><!-- FIXME: Abgrenzung zwischen (nicht durchgehenden) Hauptgleisen und (planmäßig nicht von Zügen befahrenen) Nebengleisen herausstellen -->
 					<list_entry value="yard" display_value="Abstellgleis" short_description="Gleise in Rangier-, Güter- oder Betriebsbahnhöfen, die zum Rangieren, Zusammenstellen von Zügen und Abstellen von Wagen dienen" />
 					<list_entry value="crossover" display_value="Überleitgleis" short_description="Kurze Gleise, die das Wechseln zwischen zwei Gleisen ermöglichen" />
@@ -766,24 +759,24 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Lit"
 					de.text="Beleuchtung"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="railway:pzb"
 					text="PZB"
 					de.text="Punktförmige Zugbeeinflussung (PZB)"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="railway:lzb"
 					text="LZB"
 					de.text="Linienzugbeeinflussung (LZB)"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:etcs"
 					text="ETCS"
 					de.text="ETCS"
 					values="yes,no,0,1,2,3"
 					display_values="Ja,Nein,Level 0,Level 1,Level 2,Level 3"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:radio"
 					text="Radio"
 					de.text="Zugfunk"
@@ -791,13 +784,13 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					display_values="analogue,GSM-R"
 					de.display_values="Analog,GSM-R"
 					default=""
-					delete_if_empty="true" />
-				<combo key="railway:preferred_direction" text="Direction of use (depends on direction of OSM way)" de.text="Regelfahrtrichtung (abhängig von Richtung des OSM-Ways)" default="" delete_if_empty="true">
+					/>
+				<combo key="railway:preferred_direction" text="Direction of use (depends on direction of OSM way)" de.text="Regelfahrtrichtung (abhängig von Richtung des OSM-Ways)" default="">
 					<list_entry value="forward" display_value="forward (in the same direction as the OSM way)" de.display_value="In Wegrichtung" short_description="Das Gleis wird üblicherweise in die Richtung befahren, in die der OSM-Way führt. Nur für mehrgleisige Strecken." />
 					<list_entry value="backward"  display_value="backward (in the other direction than the OSM way)" de.display_value="Entgegen Wegrichtung" short_description="Das Gleis wird üblicherweise entgegen der Richtung befahren, in die der OSM-Way führt. Nur für mehrgleisige Strecken." />
 					<list_entry value="both" display_value="both" de.display_value="Beide Richtungen" short_description="Es gibt keine Richtung, in die die Züge üblicherweise fahren bzw. nicht fahren. Nur für eingleisige Strecken." />
 				</combo>
-				<combo key="railway:bidirectional" text="Bidirectional traffic (depends on direction of OSM way)" de.text="Gleiswechselbetrieb (abhängig von Richtung des OSM-Ways)" default="" delete_if_empty="true">
+				<combo key="railway:bidirectional" text="Bidirectional traffic (depends on direction of OSM way)" de.text="Gleiswechselbetrieb (abhängig von Richtung des OSM-Ways)" default="">
 					<list_entry value="regular" de.display_value="Gleiswechselbetrieb" short_description="Das Gleis ist für beide Fahrtrichtungen mit Signalen ausgestattet und kann daher regulär entgegen der üblichen Fahrtrichtung befahren werden." />
 					<list_entry value="signals" de.display_value="Signalisierter Falschfahrbetrieb" short_description="Das Gleis ist signaltechnisch nur für eine Fahrtrichtung ausgelegt, sodass weiterhin Falschfahrten notwendig sind, diese sind aber durch Signale geregelt." />
 					<list_entry value="possible" de.display_value="Falschfahrt möglich" short_description="Signaltechnisch besteht keine Möglichkeit einer Befahrung des Gegengleises. Es ist ein schriftlicher Befehl notwendig." />
@@ -805,7 +798,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<combo key="maxspeed" default=""
 					text="Maxspeed (km/h)"
 					de.text="Höchstgeschwindigkeit (km/h)"
-					delete_if_empty="true"
 					values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,none"
 					display_values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,keine" />
 				<label text="Different speed limits depending on direction can be tagged manually using maxspeed:forward= and maxspeed:backward=*." de.text="Unterschiedliche Geschwindigkeiten je Richtung können manuell mit maxspeed:forward=* bzw. maxspeed:backward=* getaggt werden." />
@@ -816,7 +808,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="yes,no,contact_line,rail"
 					display_values="Ja,Nein,Oberleitung,Stromschiene"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="voltage"
 					text="Voltage"
 					de.text="Spannung"
@@ -824,7 +816,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					display_values="15 kV (default in Germany),400 V,600 V,750 V,1200 V,1500 V,2400 V,3000 V,6600 V"
 					de.display_values="15 kV (Standard in Deutschland),400 V,600 V,750 V,1200 V,1500 V,2400 V,3000 V,6600 V"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="frequency"
 					text="Frequency"
 					de.text="Frequenz"
@@ -832,53 +824,53 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					display_values="16.7 Hz (default in Germany),DC,16 2/3 Hz (in large parts of Germany),50 Hz,60 Hz,25 Hz"
 					de.display_values="16.7 Hz (Standard in Deutschland),Gleichspannung,16 2/3 Hz (in Teilen Deutschlands),50 Hz,60 Hz,25 Hz"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="gauge"
 					text="Gauge"
 					de.text="Spurweite"
 					values="1100,1000,900,889,880,860,800,775,750,660,655,630,600,575,560,550,500"
 					display_values="1100 mm,1000 mm (Meterspur),900 mm,889 mm,880 mm,860 mm,800 mm,775 mm,750 mm,660 mm,655 mm,630 mm,600 mm,575 mm,560 mm,550 mm,500 mm"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<check key="railway:ballastless"
 					text="Ballastless"
 					de.text="Feste Fahrbahn"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="rack"
 					text="Rack"
 					de.text="Zahnstange"
 					values="yes,no,riggenbach,strub,abt,locher,riggenbach-klose,marsh,von_roll"
 					display_values="Ja,Nein,System Riggenbach,System Strub,System Abt,System Locher,System Riggenbach-Klose,System Marsh,System Von Roll"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="incline"
 					text="Incline (e.g.. '3%')"
 					de.text="Steigung (z. B. '3%')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<text key="start_date"
 					text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="operator"
 					text="Operator (e.g. 'DB Netz AG')"
 					de.text="Betreiber (z. B. 'DB Netz AG')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<check key="embankment"
 					text="Embankment"
 					de.text="Damm"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="cutting"
 					text="Cutting"
 					de.text="Einschnitt"
 					default="off"
-					delete_if_empty="true" />
+					/>
 			</item>
 			<item de.name="Erhaltene Bahnstrecke" name="Preserved Track" icon="preserved.png" type="way">
 				<label text="A Track which is only used for tourism." de.text="Ein Gleis, auf dem kein regulärer Betrieb mehr stattfindet und nun für touristische Zwecke erhalten bleibt (z. B. Draisinenstrecken)." />
@@ -889,17 +881,17 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Line ref (VzG number, e.g. '2379')"
 					de.text="Streckennummer (VzG-Nummer, z. B. '2379')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="railway:track_ref"
 					text="Track ref (inside station)"
 					de.text="Gleisnummer (im Bahnhof)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="name"
 					text="Railway name"
 					de.text="Streckenname"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<combo key="railway:traffic_mode"
 					text="Traffic mode"
@@ -907,8 +899,8 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="mixed,passenger,freight"
 					de.display_values="Gemischt,Personenverkehr,Güterverkehr" display_values="mixed,passenger,freight"
 					default=""
-					delete_if_empty="true" />
-				<combo key="service" text="Track service" de.text="Gleisfunktion" default="" delete_if_empty="true">
+					/>
+				<combo key="service" text="Track service" de.text="Gleisfunktion" default="">
 					<list_entry value="siding" display_value="Nebengleis" short_description="Gleise in Bahnhöfen, die parallel zum durchgehenden Hauptgleis verlaufen und zum Überholen und Halten von Zügen dienen" />
 					<list_entry value="yard" display_value="Abstellgleis" short_description="Gleise in Rangier-, Güter- oder Betriebsbahnhöfen, die zum Rangieren, Zusammenstellen von Zügen und Abstellen von Wagen dienen" />
 					<list_entry value="crossover" display_value="Überleitgleis" short_description="Kurze Gleise, die das Wechseln zwischen zwei Gleisen ermöglichen" />
@@ -920,12 +912,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Lit"
 					de.text="Beleuchtung"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="railway:pzb"
 					text="PZB"
 					de.text="Punktförmige Zugbeeinflussung (PZB)"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:radio"
 					text="Radio"
 					de.text="Zugfunk"
@@ -933,13 +925,13 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					display_values="analogue,GSM-R"
 					de.display_values="Analog,GSM-R"
 					default=""
-					delete_if_empty="true" />
-				<combo key="railway:preferred_direction" text="Direction of use (depends on direction of OSM way)" de.text="Regelfahrtrichtung (abhängig von Richtung des OSM-Ways)" default="" delete_if_empty="true">
+					/>
+				<combo key="railway:preferred_direction" text="Direction of use (depends on direction of OSM way)" de.text="Regelfahrtrichtung (abhängig von Richtung des OSM-Ways)" default="">
 					<list_entry value="forward" display_value="forward (in the same direction as the OSM way)" de.display_value="In Wegrichtung" short_description="Das Gleis wird üblicherweise in die Richtung befahren, in die der OSM-Way führt. Nur für mehrgleisige Strecken." />
 					<list_entry value="backward"  display_value="backward (in the other direction than the OSM way)" de.display_value="Entgegen Wegrichtung" short_description="Das Gleis wird üblicherweise entgegen der Richtung befahren, in die der OSM-Way führt. Nur für mehrgleisige Strecken." />
 					<list_entry value="both" display_value="both" de.display_value="Beide Richtungen" short_description="Es gibt keine Richtung, in die die Züge üblicherweise fahren bzw. nicht fahren. Nur für eingleisige Strecken." />
 				</combo>
-				<combo key="railway:bidirectional" text="Bidirectional traffic (depends on direction of OSM way)" de.text="Gleiswechselbetrieb (abhängig von Richtung des OSM-Ways)" default="" delete_if_empty="true">
+				<combo key="railway:bidirectional" text="Bidirectional traffic (depends on direction of OSM way)" de.text="Gleiswechselbetrieb (abhängig von Richtung des OSM-Ways)" default="">
 					<list_entry value="regular" de.display_value="Gleiswechselbetrieb" short_description="Das Gleis ist für beide Fahrtrichtungen mit Signalen ausgestattet und kann daher regulär entgegen der üblichen Fahrtrichtung befahren werden." />
 					<list_entry value="signals" de.display_value="Signalisierter Falschfahrbetrieb" short_description="Das Gleis ist signaltechnisch nur für eine Fahrtrichtung ausgelegt, sodass weiterhin Falschfahrten notwendig sind, diese sind aber durch Signale geregelt." />
 					<list_entry value="possible" de.display_value="Falschfahrt möglich" short_description="Signaltechnisch besteht keine Möglichkeit einer Befahrung des Gegengleises. Es ist ein schriftlicher Befehl notwendig." />
@@ -947,7 +939,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<combo key="maxspeed" default=""
 					text="Maxspeed (km/h)"
 					de.text="Höchstgeschwindigkeit (km/h)"
-					delete_if_empty="true"
 					values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,none"
 					display_values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,keine" />
 				<label text="Different speed limits depending on direction can be tagged manually using maxspeed:forward= and maxspeed:backward=*." de.text="Unterschiedliche Geschwindigkeiten je Richtung können manuell mit maxspeed:forward=* bzw. maxspeed:backward=* getaggt werden." />
@@ -958,7 +949,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="yes,no,contact_line,rail"
 					display_values="Ja,Nein,Oberleitung,Stromschiene"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="voltage"
 					text="Voltage"
 					de.text="Spannung"
@@ -966,7 +957,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					display_values="15 kV (default in Germany),400 V,600 V,750 V,1200 V,1500 V,2400 V,3000 V,6600 V,25 kV"
 					de.display_values="15 kV (Standard in Deutschland),400 V,600 V,750 V,1200 V,1500 V,2400 V,3000 V,6600 V,25 kV"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="frequency"
 					text="Frequency"
 					de.text="Frequenz"
@@ -974,53 +965,53 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					display_values="16.7 Hz (default in Germany),DC,16 2/3 Hz (in large parts of Germany),50 Hz,60 Hz,25 Hz"
 					dedisplay_values="16.7 Hz (Standard in Deutschland),Gleichspannung,16 2/3 Hz (in Teilen Deutschlands),50 Hz,60 Hz,25 Hz"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="gauge"
 					text="Gauge"
 					de.text="Spurweite"
 					values="1435,1800,1524,1520,1458,1450,1100,1000,900,889,880,860,800,775,750,660,655,630,600,575,560,550,500,381,320,184,144,127,89"
 					display_values="1435 mm (Normalspur),1800 mm,1524 mm (Russische Breitspur),1520 mm (Russische Breitspur),1458 mm,1450 mm,1100 mm,1000 mm (Meterspur),900 mm,889 mm,880 mm,860 mm,800 mm,775 mm,750 mm,660 mm,655 mm,630 mm,600 mm,575 mm,560 mm,550 mm,500 mm,381 mm,320 mm,184 mm,144 mm,127 mm,89 mm"
 					default="1435"
-					delete_if_empty="true" />
+					/>
 				<check key="railway:ballastless"
 					text="Ballastless"
 					de.text="Feste Fahrbahn"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="rack"
 					text="Rack"
 					de.text="Zahnstange"
 					values="yes,no,riggenbach,strub,abt,locher,riggenbach-klose,marsh,von_roll"
 					display_values="Ja,Nein,System Riggenbach,System Strub,System Abt,System Locher,System Riggenbach-Klose,System Marsh,System Von Roll"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="incline"
 					text="Incline (e.g.. '3%')"
 					de.text="Steigung (z. B. '3%')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<text key="start_date"
 					text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="operator"
 					text="Operator (e.g. 'DB Netz AG')"
 					de.text="Betreiber (z. B. 'DB Netz AG')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<check key="embankment"
 					text="Embankment"
 					de.text="Damm"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="cutting"
 					text="Cutting"
 					de.text="Einschnitt"
 					default="off"
-					delete_if_empty="true" />
+					/>
 			</item>
 			<item de.name="Miniaturbahn / Parkeisenbahn" name="Miniature Railway" icon="miniature.png" type="way">
 				<label text="Miniature Railway which is usually used for tourists and leisure, gauge up to 600 mm." de.text="Parkeisenbahnen und vergleichbare, in der Regel touristisch genutzte, Schmalspurbahnen bis etwa 600 mm Spurweite." />
@@ -1031,14 +1022,14 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Track ref (inside station)"
 					de.text="Gleisnummer (im Bahnhof)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="name"
 					text="Railway name"
 					de.text="Streckenname"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
-				<combo key="usage" text="Usage (leave empty if main track or line)" de.text="Nutzung (leer lassen bei Strecken- und Hauptgleisen)" default="" delete_if_empty="true">
+				<combo key="usage" text="Usage (leave empty if main track or line)" de.text="Nutzung (leer lassen bei Strecken- und Hauptgleisen)" default="">
 					<list_entry value="branch" display_value="Reguläre Strecke" de.display_value="regular line" short_description="Eine Schmalspurbahn, auf der regulärer Personen- und/oder Güterverkehr stattfindet." />
 					<list_entry value="industrial" display_value="Industriebahn" de.display_value="industrial/mine railway" short_description="Eine Strecke, die ausschließlich dem Güterverkehr dient und in der Regel Eigentum eines Industrieunternehmens ist. Meist nur innerhalb von Hafengebieten, Industrieanlagen, Tagebauen." />
 					<list_entry value="tourism" de.display_value="Tourismusbahn" display_value="tourism" short_description="Eine Strecke, die ausschließlich touristischen Zwecken dient, z. B. Museumsstrecken oder Draisinenbahnen." />
@@ -1049,8 +1040,8 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="mixed,passenger,freight"
 					de.display_values="Gemischt,Personenverkehr,Güterverkehr" display_values="mixed,passenger,freight"
 					default=""
-					delete_if_empty="true" />
-				<combo key="service" text="Track service" de.text="Gleisfunktion" default="" delete_if_empty="true">
+					/>
+				<combo key="service" text="Track service" de.text="Gleisfunktion" default="">
 					<list_entry value="siding" display_value="Nebengleis" short_description="Gleise in Bahnhöfen, die parallel zum durchgehenden Hauptgleis verlaufen und zum Überholen und Halten von Zügen dienen" />
 					<list_entry value="yard" display_value="Abstellgleis" short_description="Gleise in Rangier-, Güter- oder Betriebsbahnhöfen, die zum Rangieren, Zusammenstellen von Zügen und Abstellen von Wagen dienen" />
 					<list_entry value="crossover" display_value="Überleitgleis" short_description="Kurze Gleise, die das Wechseln zwischen zwei Gleisen ermöglichen" />
@@ -1062,7 +1053,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Lit"
 					de.text="Beleuchtung"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:radio"
 					text="Radio"
 					de.text="Zugfunk"
@@ -1070,11 +1061,10 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					display_values="analogue,GSM-R"
 					de.display_values="Analog,GSM-R"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="maxspeed" default=""
 					text="Maxspeed (km/h)"
 					de.text="Höchstgeschwindigkeit (km/h)"
-					delete_if_empty="true"
 					values="10,20,30,40,50,60,70,80,90,100,none"
 					display_values="10,20,30,40,50,60,70,80,90,100,keine" />
 				<label text="Different speed limits depending on direction can be tagged manually using maxspeed:forward= and maxspeed:backward=*." de.text="Unterschiedliche Geschwindigkeiten je Richtung können manuell mit maxspeed:forward=* bzw. maxspeed:backward=* getaggt werden." />
@@ -1085,14 +1075,14 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="yes,no,contact_line,rail"
 					display_values="Ja,Nein,Oberleitung,Stromschiene"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="voltage"
 					text="Voltage"
 					de.text="Spannung"
 					values="45,220,400,600,750,1200,1500,6600"
 					display_values="45 V,220 V,400 V,600 V,750 V,1200 V,1500 V,6600 V"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="frequency"
 					text="Frequency"
 					de.text="Frequenz"
@@ -1100,53 +1090,53 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					display_values="16.7 Hz (default in Germany),DC,16 2/3 Hz (in large parts of Germany),50 Hz,60 Hz,25 Hz"
 					de.display_values="16.7 Hz (Standard in Deutschland),Gleichspannung,16 2/3 Hz (in Teilen Deutschlands),50 Hz,60 Hz,25 Hz"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="gauge"
 					text="Gauge"
 					de.text="Spurweite"
 					values="381,320,184,144,127,89"
 					display_values="381 mm,320 mm,184 mm,144 mm,127 mm,89 mm"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<check key="railway:ballastless"
 					text="Ballastless"
 					de.text="Feste Fahrbahn"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="rack"
 					text="Rack"
 					de.text="Zahnstange"
 					values="yes,no,riggenbach,strub,abt,locher,riggenbach-klose,marsh,von_roll"
 					display_values="Ja,Nein,System Riggenbach,System Strub,System Abt,System Locher,System Riggenbach-Klose,System Marsh,System Von Roll"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="incline"
 					text="Incline (e.g.. '3%')"
 					de.text="Steigung (z. B. '3%')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<text key="start_date"
 					text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="operator"
 					text="Operator (e.g. 'DB Netz AG')"
 					de.text="Betreiber (z. B. 'DB Netz AG')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<check key="embankment"
 					text="Embankment"
 					de.text="Damm"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="cutting"
 					text="Cutting"
 					de.text="Einschnitt"
 					default="off"
-					delete_if_empty="true" />
+					/>
 			</item>
 			<separator />
 			<item de.name="Straßenbahngleis" name="Tram" icon="tram.png" type="way">
@@ -1158,17 +1148,17 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Line ref"
 					de.text="Streckennummer"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="railway:track_ref"
 					text="Track ref (inside station)"
 					de.text="Gleisnummer (im Bahnhof)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="name"
 					text="Railway name"
 					de.text="Streckenname"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<combo key="railway:traffic_mode"
 					text="Traffic mode"
@@ -1176,8 +1166,8 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="mixed,freight, "
 					de.display_values="Gemischt,Güterverkehr,Personenverkehr" display_values="mixed,freight,passenger"
 					default="passenger"
-					delete_if_empty="true" />
-				<combo key="service" text="Track service" de.text="Gleisfunktion" default="" delete_if_empty="true">
+					/>
+				<combo key="service" text="Track service" de.text="Gleisfunktion" default="">
 					<list_entry value="siding" display_value="Nebengleis" short_description="Gleise in Bahnhöfen, die parallel zum durchgehenden Hauptgleis verlaufen und zum Überholen und Halten von Zügen dienen" />
 					<list_entry value="yard" display_value="Abstellgleis" short_description="Gleise in Rangier-, Güter- oder Betriebsbahnhöfen, die zum Rangieren, Zusammenstellen von Zügen und Abstellen von Wagen dienen" />
 					<list_entry value="crossover" display_value="Überleitgleis" short_description="Kurze Gleise, die das Wechseln zwischen zwei Gleisen ermöglichen" />
@@ -1188,30 +1178,30 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Lit"
 					de.text="Beleuchtung"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="railway:pzb"
 					text="PZB"
 					de.text="Punktförmige Zugbeeinflussung (PZB)"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="railway:lzb"
 					text="LZB"
 					de.text="Linienzugbeeinflussung (LZB)"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:etcs"
 					text="ETCS"
 					de.text="ETCS"
 					values="yes,no,0,1,2,3"
 					display_values="Ja,Nein,Level 0,Level 1,Level 2,Level 3"
 					default=""
-					delete_if_empty="true" />
-				<combo key="railway:preferred_direction" text="Direction of use (depends on direction of OSM way)" de.text="Regelfahrtrichtung (abhängig von Richtung des OSM-Ways)" default="" delete_if_empty="true">
+					/>
+				<combo key="railway:preferred_direction" text="Direction of use (depends on direction of OSM way)" de.text="Regelfahrtrichtung (abhängig von Richtung des OSM-Ways)" default="">
 					<list_entry value="forward" display_value="forward (in the same direction as the OSM way)" de.display_value="In Wegrichtung" short_description="Das Gleis wird üblicherweise in die Richtung befahren, in die der OSM-Way führt. Nur für mehrgleisige Strecken." />
 					<list_entry value="backward"  display_value="backward (in the other direction than the OSM way)" de.display_value="Entgegen Wegrichtung" short_description="Das Gleis wird üblicherweise entgegen der Richtung befahren, in die der OSM-Way führt. Nur für mehrgleisige Strecken." />
 					<list_entry value="both" display_value="both" de.display_value="Beide Richtungen" short_description="Es gibt keine Richtung, in die die Züge üblicherweise fahren bzw. nicht fahren. Nur für eingleisige Strecken." />
 				</combo>
-				<combo key="railway:bidirectional" text="Bidirectional traffic (depends on direction of OSM way)" de.text="Gleiswechselbetrieb (abhängig von Richtung des OSM-Ways)" default="" delete_if_empty="true">
+				<combo key="railway:bidirectional" text="Bidirectional traffic (depends on direction of OSM way)" de.text="Gleiswechselbetrieb (abhängig von Richtung des OSM-Ways)" default="">
 					<list_entry value="regular" de.display_value="Gleiswechselbetrieb" short_description="Das Gleis ist für beide Fahrtrichtungen mit Signalen ausgestattet und kann daher regulär entgegen der üblichen Fahrtrichtung befahren werden." />
 					<list_entry value="signals" de.display_value="Signalisierter Falschfahrbetrieb" short_description="Das Gleis ist signaltechnisch nur für eine Fahrtrichtung ausgelegt, sodass weiterhin Falschfahrten notwendig sind, diese sind aber durch Signale geregelt." />
 					<list_entry value="possible" de.display_value="Falschfahrt möglich" short_description="Signaltechnisch besteht keine Möglichkeit einer Befahrung des Gegengleises. Es ist ein schriftlicher Befehl notwendig." />
@@ -1219,7 +1209,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<combo key="maxspeed" default=""
 					text="Maxspeed (km/h)"
 					de.text="Höchstgeschwindigkeit (km/h)"
-					delete_if_empty="true"
 					values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,none"
 					display_values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,keine" />
 				<label text="Different speed limits depending on direction can be tagged manually using maxspeed:forward= and maxspeed:backward=*." de.text="Unterschiedliche Geschwindigkeiten je Richtung können manuell mit maxspeed:forward=* bzw. maxspeed:backward=* getaggt werden." />
@@ -1230,7 +1219,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="yes,no,contact_line,rail"
 					display_values="Ja,Nein,Oberleitung,Stromschiene"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="voltage"
 					text="Voltage"
 					de.text="Spannung"
@@ -1238,7 +1227,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					display_values="15 kV (default in Germany),500 V,550 V,600 V,750 V,850 V,1000 V,1200 V,1500 V,2400 V,3000 V,6500 V,6600 V,11 kV,25 kV"
 					de.display_values="15 kV (Standard in Deutschland),500 V,550 V,600 V,750 V,850 V,1000 V,1200 V,1500 V,2400 V,3000 V,6500 V,6600 V,11 kV,25 kV"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="frequency"
 					text="Frequency"
 					de.text="Frequenz"
@@ -1246,46 +1235,46 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.display_values="Gleichspannung,16.7 Hz, 16 2/3 Hz, 50 Hz, 60 Hz, 25 Hz"
 					display_values="DC,16.7 Hz,16 2/3 Hz,50 Hz,60 Hz,25 Hz"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="gauge"
 					text="Gauge"
 					de.text="Spurweite"
 					values="1435,1458,1450,1100,1000,900,750,600"
 					display_values="1435 mm (Normalspur),1458 mm,1450 mm,1100 mm,1000 mm (Meterspur),900 mm,750 mm,600 mm"
 					default="1435"
-					delete_if_empty="true" />
+					/>
 				<check key="railway:ballastless"
 					text="Ballastless (slab track)"
 					de.text="Feste Fahrbahn"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<text key="incline"
 					text="Incline (e.g.. '3%')"
 					de.text="Steigung (z. B. '3%')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<text key="start_date"
 					text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="operator"
 					text="Operator (e.g. 'Rheinbahn')"
 					de.text="Betreiber (z. B. 'Rheinbahn')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<check key="embankment"
 					text="Embankment"
 					de.text="Damm"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="cutting"
 					text="Cutting"
 					de.text="Einschnitt"
 					default="off"
-					delete_if_empty="true" />
+					/>
 			</item>
 			<item de.name="U-Bahngleis" name="Subway/Underground Railway" icon="subway-32.png" type="way">
 				<label text="Subway tracks. May run overground but separated from car traffic. Every track is mapped individually. Additionally you can choose 'Tunnel' if it is underground." de.text="Unterirdisch verlegte Stadt- und Schnellbahnen, teilweise auch oberirdischer Verlauf möglich. Jedes Gleis wird einzeln erfasst. Zusätzlich noch im Menü 'Tunnel' auswählen!" />
@@ -1296,19 +1285,19 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Line ref"
 					de.text="Streckennummer"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="railway:track_ref"
 					text="Track ref (inside station)"
 					de.text="Gleisnummer (im Bahnhof)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="name"
 					text="Railway name"
 					de.text="Streckenname"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
-				<combo key="service" text="Track service" de.text="Gleisfunktion" default="" delete_if_empty="true">
+				<combo key="service" text="Track service" de.text="Gleisfunktion" default="">
 					<list_entry value="siding" display_value="Nebengleis" short_description="Gleise in Bahnhöfen, die parallel zum durchgehenden Hauptgleis verlaufen und zum Überholen und Halten von Zügen dienen" />
 					<list_entry value="yard" display_value="Abstellgleis" short_description="Gleise in Rangier-, Güter- oder Betriebsbahnhöfen, die zum Rangieren, Zusammenstellen von Zügen und Abstellen von Wagen dienen" />
 					<list_entry value="crossover" display_value="Überleitgleis" short_description="Kurze Gleise, die das Wechseln zwischen zwei Gleisen ermöglichen" />
@@ -1318,30 +1307,30 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Lit"
 					de.text="Beleuchtung"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="railway:pzb"
 					text="PZB"
 					de.text="Punktförmige Zugbeeinflussung (PZB)"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="railway:lzb"
 					text="LZB"
 					de.text="Linienzugbeeinflussung (LZB)"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:etcs"
 					text="ETCS"
 					de.text="ETCS"
 					values="yes,no,0,1,2,3"
 					display_values="Ja,Nein,Level 0,Level 1,Level 2,Level 3"
 					default=""
-					delete_if_empty="true" />
-				<combo key="railway:preferred_direction" text="Direction of use (depends on direction of OSM way)" de.text="Regelfahrtrichtung (abhängig von Richtung des OSM-Ways)" default="" delete_if_empty="true">
+					/>
+				<combo key="railway:preferred_direction" text="Direction of use (depends on direction of OSM way)" de.text="Regelfahrtrichtung (abhängig von Richtung des OSM-Ways)" default="">
 					<list_entry value="forward" display_value="forward (in the same direction as the OSM way)" de.display_value="In Wegrichtung" short_description="Das Gleis wird üblicherweise in die Richtung befahren, in die der OSM-Way führt. Nur für mehrgleisige Strecken." />
 					<list_entry value="backward"  display_value="backward (in the other direction than the OSM way)" de.display_value="Entgegen Wegrichtung" short_description="Das Gleis wird üblicherweise entgegen der Richtung befahren, in die der OSM-Way führt. Nur für mehrgleisige Strecken." />
 					<list_entry value="both" display_value="both" de.display_value="Beide Richtungen" short_description="Es gibt keine Richtung, in die die Züge üblicherweise fahren bzw. nicht fahren. Nur für eingleisige Strecken." />
 				</combo>
-				<combo key="railway:bidirectional" text="Bidirectional traffic (depends on direction of OSM way)" de.text="Gleiswechselbetrieb (abhängig von Richtung des OSM-Ways)" default="" delete_if_empty="true">
+				<combo key="railway:bidirectional" text="Bidirectional traffic (depends on direction of OSM way)" de.text="Gleiswechselbetrieb (abhängig von Richtung des OSM-Ways)" default="">
 					<list_entry value="regular" de.display_value="Gleiswechselbetrieb" short_description="Das Gleis ist für beide Fahrtrichtungen mit Signalen ausgestattet und kann daher regulär entgegen der üblichen Fahrtrichtung befahren werden." />
 					<list_entry value="signals" de.display_value="Signalisierter Falschfahrbetrieb" short_description="Das Gleis ist signaltechnisch nur für eine Fahrtrichtung ausgelegt, sodass weiterhin Falschfahrten notwendig sind, diese sind aber durch Signale geregelt." />
 					<list_entry value="possible" de.display_value="Falschfahrt möglich" short_description="Signaltechnisch besteht keine Möglichkeit einer Befahrung des Gegengleises. Es ist ein schriftlicher Befehl notwendig." />
@@ -1349,7 +1338,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<combo key="maxspeed" default=""
 					text="Maxspeed (km/h)"
 					de.text="Höchstgeschwindigkeit (km/h)"
-					delete_if_empty="true"
 					values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,none"
 					display_values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,keine" />
 				<label text="Different speed limits depending on direction can be tagged manually using maxspeed:forward= and maxspeed:backward=*." de.text="Unterschiedliche Geschwindigkeiten je Richtung können manuell mit maxspeed:forward=* bzw. maxspeed:backward=* getaggt werden." />
@@ -1360,7 +1348,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="yes,no,contact_line,rail"
 					display_values="Ja,Nein,Oberleitung,Stromschiene"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="voltage"
 					text="Voltage"
 					de.text="Spannung"
@@ -1368,7 +1356,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					display_values="15 kV (default in Germany),500 V,550 V,600 V,750 V,850 V,1000 V,1200 V,1500 V,2400 V,3000 V,6500 V,6600 V,11 kV,25 kV"
 					de.display_values="15 kV (Standard in Deutschland),500 V,550 V,600 V,750 V,850 V,1000 V,1200 V,1500 V,2400 V,3000 V,6500 V,6600 V,11 kV,25 kV"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="frequency"
 					text="Frequency"
 					de.text="Frequenz"
@@ -1376,35 +1364,35 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.display_values="Gleichspannung,16.7 Hz, 16 2/3 Hz, 50 Hz, 60 Hz, 25 Hz"
 					display_values="DC,16.7 Hz,16 2/3 Hz,50 Hz,60 Hz,25 Hz"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="gauge"
 					text="Gauge"
 					de.text="Spurweite"
 					values="1435,1458,1450,1100,1000,900,750,600"
 					display_values="1435 mm (Normalspur),1458 mm,1450 mm,1100 mm,1000 mm (Meterspur),900 mm,750 mm,600 mm"
 					default="1435"
-					delete_if_empty="true" />
+					/>
 				<check key="railway:ballastless"
 					text="Ballastless"
 					de.text="Feste Fahrbahn"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<text key="incline"
 					text="Incline (e.g.. '3%')"
 					de.text="Steigung (z. B. '3%')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<text key="start_date"
 					text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="operator"
 					text="Operator (e.g. 'Rheinbahn')"
 					de.text="Betreiber (z. B. 'Rheinbahn')"
 					default=""
-					delete_if_empty="true" />
+					/>
 			</item>
 			<item de.name="Stadt-/Schnellbahngleis" name="Light Rail" icon="light-rail.png" type="way">
 				<label text="Light rail tracks. May run under- or overground, usually separated from car traffic. Uses usually a different voltage and frequency and differnt vehicles. Every track is mapped individually." de.text="Stadtbahnen und straßenbahnähnliche Untergrund- oder Überlandbahnen. Unterscheiden sich meist durch ein anderes Stromsystem, eigene Signaltechnik oder einen speziellen Fuhrpark (z. B. S-Bahnen Hamburg und Berlin, Hamburger Hochbahn) und sind meist völlig vom restlichen Straßenverkehr getrennt. Jedes Gleis wird einzeln erfasst." />
@@ -1415,21 +1403,21 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Line ref"
 					de.text="Streckennummer"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="railway:track_ref"
 					text="Track ref (inside station)"
 					de.text="Gleisnummer (im Bahnhof)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="name"
 					text="Railway name"
 					de.text="Streckenname"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<key key="railway:traffic_mode"
 					value="passenger" />
-				<combo key="service" text="Track service" de.text="Gleisfunktion" default="" delete_if_empty="true">
+				<combo key="service" text="Track service" de.text="Gleisfunktion" default="">
 					<list_entry value="siding" display_value="Nebengleis" short_description="Gleise in Bahnhöfen, die parallel zum durchgehenden Hauptgleis verlaufen und zum Überholen und Halten von Zügen dienen" />
 					<list_entry value="yard" display_value="Abstellgleis" short_description="Gleise in Rangier-, Güter- oder Betriebsbahnhöfen, die zum Rangieren, Zusammenstellen von Zügen und Abstellen von Wagen dienen" />
 					<list_entry value="crossover" display_value="Überleitgleis" short_description="Kurze Gleise, die das Wechseln zwischen zwei Gleisen ermöglichen" />
@@ -1440,30 +1428,30 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Lit"
 					de.text="Beleuchtung"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="railway:pzb"
 					text="PZB"
 					de.text="Punktförmige Zugbeeinflussung (PZB)"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="railway:lzb"
 					text="LZB"
 					de.text="Linienzugbeeinflussung (LZB)"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:etcs"
 					text="ETCS"
 					de.text="ETCS"
 					values="yes,no,0,1,2,3"
 					display_values="Ja,Nein,Level 0,Level 1,Level 2,Level 3"
 					default=""
-					delete_if_empty="true" />
-				<combo key="railway:preferred_direction" text="Direction of use (depends on direction of OSM way)" de.text="Regelfahrtrichtung (abhängig von Richtung des OSM-Ways)" default="" delete_if_empty="true">
+					/>
+				<combo key="railway:preferred_direction" text="Direction of use (depends on direction of OSM way)" de.text="Regelfahrtrichtung (abhängig von Richtung des OSM-Ways)" default="">
 					<list_entry value="forward" display_value="forward (in the same direction as the OSM way)" de.display_value="In Wegrichtung" short_description="Das Gleis wird üblicherweise in die Richtung befahren, in die der OSM-Way führt. Nur für mehrgleisige Strecken." />
 					<list_entry value="backward"  display_value="backward (in the other direction than the OSM way)" de.display_value="Entgegen Wegrichtung" short_description="Das Gleis wird üblicherweise entgegen der Richtung befahren, in die der OSM-Way führt. Nur für mehrgleisige Strecken." />
 					<list_entry value="both" display_value="both" de.display_value="Beide Richtungen" short_description="Es gibt keine Richtung, in die die Züge üblicherweise fahren bzw. nicht fahren. Nur für eingleisige Strecken." />
 				</combo>
-				<combo key="railway:bidirectional" text="Bidirectional traffic (depends on direction of OSM way)" de.text="Gleiswechselbetrieb (abhängig von Richtung des OSM-Ways)" default="" delete_if_empty="true">
+				<combo key="railway:bidirectional" text="Bidirectional traffic (depends on direction of OSM way)" de.text="Gleiswechselbetrieb (abhängig von Richtung des OSM-Ways)" default="">
 					<list_entry value="regular" de.display_value="Gleiswechselbetrieb" short_description="Das Gleis ist für beide Fahrtrichtungen mit Signalen ausgestattet und kann daher regulär entgegen der üblichen Fahrtrichtung befahren werden." />
 					<list_entry value="signals" de.display_value="Signalisierter Falschfahrbetrieb" short_description="Das Gleis ist signaltechnisch nur für eine Fahrtrichtung ausgelegt, sodass weiterhin Falschfahrten notwendig sind, diese sind aber durch Signale geregelt." />
 					<list_entry value="possible" de.display_value="Falschfahrt möglich" short_description="Signaltechnisch besteht keine Möglichkeit einer Befahrung des Gegengleises. Es ist ein schriftlicher Befehl notwendig." />
@@ -1471,7 +1459,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<combo key="maxspeed" default=""
 					text="Maxspeed (km/h)"
 					de.text="Höchstgeschwindigkeit (km/h)"
-					delete_if_empty="true"
 					values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,none"
 					display_values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,keine" />
 				<label text="Different speed limits depending on direction can be tagged manually using maxspeed:forward= and maxspeed:backward=*." de.text="Unterschiedliche Geschwindigkeiten je Richtung können manuell mit maxspeed:forward=* bzw. maxspeed:backward=* getaggt werden." />
@@ -1482,7 +1469,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="yes,no,contact_line,rail"
 					display_values="Ja,Nein,Oberleitung,Stromschiene"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="voltage"
 					text="Voltage"
 					de.text="Spannung"
@@ -1490,7 +1477,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					display_values="15 kV (default in Germany),500 V,550 V,600 V,750 V,850 V,1000 V,1200 V,1500 V,2400 V,3000 V,6500 V,6600 V,11 kV,25 kV"
 					de.display_values="15 kV (Standard in Deutschland),500 V,550 V,600 V,750 V,850 V,1000 V,1200 V,1500 V,2400 V,3000 V,6500 V,6600 V,11 kV,25 kV"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="frequency"
 					text="Frequency"
 					de.text="Frequenz"
@@ -1498,46 +1485,46 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.display_values="Gleichspannung,16.7 Hz, 16 2/3 Hz, 50 Hz, 60 Hz, 25 Hz"
 					display_values="DC,16.7 Hz,16 2/3 Hz,50 Hz,60 Hz,25 Hz"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="gauge"
 					text="Gauge"
 					de.text="Spurweite"
 					values="1435,1458,1450,1100,1000,900,750,600"
 					display_values="1435 mm (Normalspur),1458 mm,1450 mm,1100 mm,1000 mm (Meterspur),900 mm,750 mm,600 mm"
 					default="1435"
-					delete_if_empty="true" />
+					/>
 				<check key="railway:ballastless"
 					text="Ballastless"
 					de.text="Feste Fahrbahn"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<text key="incline"
 					text="Incline (e.g.. '3%')"
 					de.text="Steigung (z. B. '3%')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<text key="start_date"
 					text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="operator"
 					text="Operator (e.g. 'Rheinbahn')"
 					de.text="Betreiber (z. B. 'Rheinbahn')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<check key="embankment"
 					text="Embankment"
 					de.text="Damm"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="cutting"
 					text="Cutting"
 					de.text="Einschnitt"
 					default="off"
-					delete_if_empty="true" />
+					/>
 			</item>
 			<separator />
 			<item de.name="Geplantes Gleis" name="Proposed Track" icon="proposed-32.png" type="way">
@@ -1549,19 +1536,19 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Line ref (VzG number, e.g. '2379')"
 					de.text="Streckennummer (VzG-Nummer, z. B. '2379')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="railway:track_ref"
 					text="Track ref (inside station)"
 					de.text="Gleisnummer (im Bahnhof)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="name"
 					text="Railway name"
 					de.text="Streckenname"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
-				<combo key="usage" text="Usage" de.text="Nutzung" default="" delete_if_empty="true">
+				<combo key="usage" text="Usage" de.text="Nutzung" default="">
 					<list_entry value="main" de.display_value="Hauptbahn" display_value="main line" short_description="Strecke mit übergeordneter Bedeutung; meist zweigleisig, meist elektrifiziert, zumindest abschnittsweise mit mehr als 100 km/h befahrbar" />
 					<list_entry value="branch" de.display_value="Nebenbahn" display_value="branch line" short_description="Strecke mit untergeordneter Bedeutung; oft nicht elektrifiziert, oft eingleisig. Keinesfalls mit mehr als 100 km/h befahrbar." />
 					<list_entry value="industrial" display_value="Industriebahn" de.display_value="industrial/mine railway" short_description="Eine Strecke, die ausschließlich dem Güterverkehr dient und in der Regel Eigentum eines Industrieunternehmens ist. Meist nur innerhalb von Hafengebieten, Industrieanlagen, Tagebauen." />
@@ -1575,42 +1562,42 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="mixed,passenger,freight"
 					de.display_values="Gemischt,Personenverkehr,Güterverkehr" display_values="mixed,passenger,freight"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<check key="highspeed"
 					text="Highspeed traffic (~ >200 km/h)"
 					de.text="Hochgeschwindigkeitsstrecke (~ >200 km/h)"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="railway:tilting"
 					text="Used by tilting trains"
 					de.text="Neigetechnik-Ausrüstung"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<space />
 				<check key="railway:pzb"
 					text="PZB"
 					de.text="Punktförmige Zugbeeinflussung (PZB)"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="railway:lzb"
 					text="LZB"
 					de.text="Linienzugbeeinflussung (LZB)"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:gnt"
 					text="Tilting train system"
 					de.text="Geschwindigkeitsüberwachung Neigetechnik"
 					values="yes,no,zub122,zub262"
 					display_values="Ja,Nein,ZUB122,ZUB262"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:etcs"
 					text="ETCS"
 					de.text="ETCS"
 					values="yes,no,0,1,2,3"
 					display_values="Ja,Nein,Level 0,Level 1,Level 2,Level 3"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:radio"
 					text="Radio"
 					de.text="Zugfunk"
@@ -1618,13 +1605,13 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					display_values="analogue,GSM-R"
 					de.display_values="Analog,GSM-R"
 					default=""
-					delete_if_empty="true" />
-				<combo key="railway:preferred_direction" text="Direction of use (depends on direction of OSM way)" de.text="Regelfahrtrichtung (abhängig von Richtung des OSM-Ways)" default="" delete_if_empty="true">
+					/>
+				<combo key="railway:preferred_direction" text="Direction of use (depends on direction of OSM way)" de.text="Regelfahrtrichtung (abhängig von Richtung des OSM-Ways)" default="">
 					<list_entry value="forward" display_value="forward (in the same direction as the OSM way)" de.display_value="In Wegrichtung" short_description="Das Gleis wird üblicherweise in die Richtung befahren, in die der OSM-Way führt. Nur für mehrgleisige Strecken." />
 					<list_entry value="backward"  display_value="backward (in the other direction than the OSM way)" de.display_value="Entgegen Wegrichtung" short_description="Das Gleis wird üblicherweise entgegen der Richtung befahren, in die der OSM-Way führt. Nur für mehrgleisige Strecken." />
 					<list_entry value="both" display_value="both" de.display_value="Beide Richtungen" short_description="Es gibt keine Richtung, in die die Züge üblicherweise fahren bzw. nicht fahren. Nur für eingleisige Strecken." />
 				</combo>
-				<combo key="railway:bidirectional" text="Bidirectional traffic (depends on direction of OSM way)" de.text="Gleiswechselbetrieb (abhängig von Richtung des OSM-Ways)" default="" delete_if_empty="true">
+				<combo key="railway:bidirectional" text="Bidirectional traffic (depends on direction of OSM way)" de.text="Gleiswechselbetrieb (abhängig von Richtung des OSM-Ways)" default="">
 					<list_entry value="regular" de.display_value="Gleiswechselbetrieb" short_description="Das Gleis ist für beide Fahrtrichtungen mit Signalen ausgestattet und kann daher regulär entgegen der üblichen Fahrtrichtung befahren werden." />
 					<list_entry value="signals" de.display_value="Signalisierter Falschfahrbetrieb" short_description="Das Gleis ist signaltechnisch nur für eine Fahrtrichtung ausgelegt, sodass weiterhin Falschfahrten notwendig sind, diese sind aber durch Signale geregelt." />
 					<list_entry value="possible" de.display_value="Falschfahrt möglich" short_description="Signaltechnisch besteht keine Möglichkeit einer Befahrung des Gegengleises. Es ist ein schriftlicher Befehl notwendig." />
@@ -1633,14 +1620,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<combo key="maxspeed" default=""
 					text="Maxspeed (km/h)"
 					de.text="Höchstgeschwindigkeit (km/h)"
-					delete_if_empty="true"
 					values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,none"
 					display_values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,keine" />
 				<label text="Different speed limits depending on direction can be tagged manually using maxspeed:forward= and maxspeed:backward=*." de.text="Unterschiedliche Geschwindigkeiten je Richtung können manuell mit maxspeed:forward=* bzw. maxspeed:backward=* getaggt werden." />
 				<combo key="maxspeed:tilting" default=""
 					text="Maxspeed of Used by tilting trains (km/h)"
 					de.text="Höchstgeschwindigkeit von Neigetechnikzügen (km/h)"
-					delete_if_empty="true"
 					values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,none"
 					display_values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,keine" />
 				<space />
@@ -1650,7 +1635,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="yes,no,contact_line,rail"
 					display_values="Ja,Nein,Oberleitung,Stromschiene"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="voltage"
 					text="Voltage"
 					de.text="Spannung"
@@ -1658,7 +1643,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					display_values="15 kV (default in Germany),400 V,600 V,750 V,1200 V,1500 V,2400 V,3000 V,6600 V,25 kV"
 					de.display_values="15 kV (Standard in Deutschland),400 V,600 V,750 V,1200 V,1500 V,2400 V,3000 V,6600 V,25 kV"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="frequency"
 					text="Frequency"
 					de.text="Frequenz"
@@ -1666,53 +1651,53 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					display_values="16.7 Hz (default in Germany),DC,16 2/3 Hz (in parts of Germany),50 Hz,60 Hz,25 Hz"
 					de.display_values="16.7 Hz (Standard in Deutschland),Gleichspannung,16 2/3 Hz (in Teilen Deutschlands),50 Hz,60 Hz,25 Hz"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="gauge"
 					text="Gauge"
 					de.text="Spurweite"
 					values="1435,1800,1524,1520,1458,1450,1100,1000,900,889,880,860,800,775,750,660,655,630,600,575,560,550,500,381,320,184,144,127,89"
 					display_values="1435 mm (Normalspur),1800 mm,1524 mm (Russische Breitspur),1520 mm (Russische Breitspur),1458 mm,1450 mm,1100 mm,1000 mm (Meterspur),900 mm,889 mm,880 mm,860 mm,800 mm,775 mm,750 mm,660 mm,655 mm,630 mm,600 mm,575 mm,560 mm,550 mm,500 mm,381 mm,320 mm,184 mm,144 mm,127 mm,89 mm"
 					default="1435"
-					delete_if_empty="true" />
+					/>
 				<check key="railway:ballastless"
 					text="Ballastless"
 					de.text="Feste Fahrbahn"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="rack"
 					text="Rack"
 					de.text="Zahnstange"
 					values="yes,no,riggenbach,strub,abt,locher,riggenbach-klose,marsh,von_roll"
 					display_values="Ja,Nein,System Riggenbach,System Strub,System Abt,System Locher,System Riggenbach-Klose,System Marsh,System Von Roll"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="incline"
 					text="Incline (e.g.. '3%')"
 					de.text="Steigung (z. B. '3%')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<text key="start_date"
 					text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="operator"
 					text="Operator (e.g. 'DB Netz AG')"
 					de.text="Betreiber (z. B. 'DB Netz AG')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<check key="embankment"
 					text="Embankment"
 					de.text="Damm"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="cutting"
 					text="Cutting"
 					de.text="Einschnitt"
 					default="off"
-					delete_if_empty="true" />
+					/>
 			</item>
 			<item de.name="Gleis im Bau" name="Track under construction" icon="construction.png" type="way">
 				<label text="Track under construction but not finished." de.text="Ein Gleis, dessen Bau momentan noch nicht fertiggestellt ist." />
@@ -1723,19 +1708,19 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Line ref (VzG number, e.g. '2379')"
 					de.text="Streckennummer (VzG-Nummer, z. B. '2379')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="railway:track_ref"
 					text="Track ref (inside station)"
 					de.text="Gleisnummer (im Bahnhof)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="name"
 					text="Railway name"
 					de.text="Streckenname"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
-				<combo key="usage" text="Usage" de.text="Nutzung" default="" delete_if_empty="true">
+				<combo key="usage" text="Usage" de.text="Nutzung" default="">
 					<list_entry value="main" de.display_value="Hauptbahn" display_value="main line" short_description="Strecke mit übergeordneter Bedeutung; meist zweigleisig, meist elektrifiziert, zumindest abschnittsweise mit mehr als 100 km/h befahrbar" />
 					<list_entry value="branch" de.display_value="Nebenbahn" display_value="branch line" short_description="Strecke mit untergeordneter Bedeutung; oft nicht elektrifiziert, oft eingleisig. Keinesfalls mit mehr als 100 km/h befahrbar." />
 					<list_entry value="industrial" display_value="Industriebahn" de.display_value="industrial/mine railway" short_description="Eine Strecke, die ausschließlich dem Güterverkehr dient und in der Regel Eigentum eines Industrieunternehmens ist. Meist nur innerhalb von Hafengebieten, Industrieanlagen, Tagebauen." />
@@ -1749,42 +1734,42 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="mixed,passenger,freight"
 					de.display_values="Gemischt,Personenverkehr,Güterverkehr" display_values="mixed,passenger,freight"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<check key="highspeed"
 					text="Highspeed traffic (~ >200 km/h)"
 					de.text="Hochgeschwindigkeitsstrecke (~ >200 km/h)"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="railway:tilting"
 					text="Used by tilting trains"
 					de.text="Neigetechnik-Ausrüstung"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<space />
 				<check key="railway:pzb"
 					text="PZB"
 					de.text="Punktförmige Zugbeeinflussung (PZB)"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="railway:lzb"
 					text="LZB"
 					de.text="Linienzugbeeinflussung (LZB)"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:gnt"
 					text="Tilting train system"
 					de.text="Geschwindigkeitsüberwachung Neigetechnik"
 					values="yes,no,zub122,zub262"
 					display_values="Ja,Nein,ZUB122,ZUB262"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:etcs"
 					text="ETCS"
 					de.text="ETCS"
 					values="yes,no,0,1,2,3"
 					display_values="Ja,Nein,Level 0,Level 1,Level 2,Level 3"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:radio"
 					text="Radio"
 					de.text="Zugfunk"
@@ -1792,13 +1777,13 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					display_values="analogue,GSM-R"
 					de.display_values="Analog,GSM-R"
 					default=""
-					delete_if_empty="true" />
-				<combo key="railway:preferred_direction" text="Direction of use (depends on direction of OSM way)" de.text="Regelfahrtrichtung (abhängig von Richtung des OSM-Ways)" default="" delete_if_empty="true">
+					/>
+				<combo key="railway:preferred_direction" text="Direction of use (depends on direction of OSM way)" de.text="Regelfahrtrichtung (abhängig von Richtung des OSM-Ways)" default="">
 					<list_entry value="forward" display_value="forward (in the same direction as the OSM way)" de.display_value="In Wegrichtung" short_description="Das Gleis wird üblicherweise in die Richtung befahren, in die der OSM-Way führt. Nur für mehrgleisige Strecken." />
 					<list_entry value="backward"  display_value="backward (in the other direction than the OSM way)" de.display_value="Entgegen Wegrichtung" short_description="Das Gleis wird üblicherweise entgegen der Richtung befahren, in die der OSM-Way führt. Nur für mehrgleisige Strecken." />
 					<list_entry value="both" display_value="both" de.display_value="Beide Richtungen" short_description="Es gibt keine Richtung, in die die Züge üblicherweise fahren bzw. nicht fahren. Nur für eingleisige Strecken." />
 				</combo>
-				<combo key="railway:bidirectional" text="Bidirectional traffic (depends on direction of OSM way)" de.text="Gleiswechselbetrieb (abhängig von Richtung des OSM-Ways)" default="" delete_if_empty="true">
+				<combo key="railway:bidirectional" text="Bidirectional traffic (depends on direction of OSM way)" de.text="Gleiswechselbetrieb (abhängig von Richtung des OSM-Ways)" default="">
 					<list_entry value="regular" de.display_value="Gleiswechselbetrieb" short_description="Das Gleis ist für beide Fahrtrichtungen mit Signalen ausgestattet und kann daher regulär entgegen der üblichen Fahrtrichtung befahren werden." />
 					<list_entry value="signals" de.display_value="Signalisierter Falschfahrbetrieb" short_description="Das Gleis ist signaltechnisch nur für eine Fahrtrichtung ausgelegt, sodass weiterhin Falschfahrten notwendig sind, diese sind aber durch Signale geregelt." />
 					<list_entry value="possible" de.display_value="Falschfahrt möglich" short_description="Signaltechnisch besteht keine Möglichkeit einer Befahrung des Gegengleises. Es ist ein schriftlicher Befehl notwendig." />
@@ -1807,14 +1792,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<combo key="maxspeed" default=""
 					text="Maxspeed (km/h)"
 					de.text="Höchstgeschwindigkeit (km/h)"
-					delete_if_empty="true"
 					values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,none"
 					display_values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,keine" />
 				<label text="Different speed limits depending on direction can be tagged manually using maxspeed:forward= and maxspeed:backward=*." de.text="Unterschiedliche Geschwindigkeiten je Richtung können manuell mit maxspeed:forward=* bzw. maxspeed:backward=* getaggt werden." />
 				<combo key="maxspeed:tilting" default=""
 					text="Maxspeed of Used by tilting trains (km/h)"
 					de.text="Höchstgeschwindigkeit von Neigetechnikzügen (km/h)"
-					delete_if_empty="true"
 					values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,none"
 					display_values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,keine" />
 				<space />
@@ -1824,7 +1807,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="yes,no,contact_line,rail"
 					display_values="Ja,Nein,Oberleitung,Stromschiene"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="voltage"
 					text="Voltage"
 					de.text="Spannung"
@@ -1832,7 +1815,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					display_values="15 kV (default in Germany),400 V,600 V,750 V,1200 V,1500 V,2400 V,3000 V,6600 V,25 kV"
 					de.display_values="15 kV (Standard in Deutschland),400 V,600 V,750 V,1200 V,1500 V,2400 V,3000 V,6600 V,25 kV"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="frequency"
 					text="Frequency"
 					de.text="Frequenz"
@@ -1840,53 +1823,53 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					display_values="16.7 Hz (default in Germany),DC,16 2/3 Hz (in parts of Germany),50 Hz,60 Hz,25 Hz"
 					de.display_values="16.7 Hz (Standard in Deutschland),Gleichspannung,16 2/3 Hz (in Teilen Deutschlands),50 Hz,60 Hz,25 Hz"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="gauge"
 					text="Gauge"
 					de.text="Spurweite"
 					values="1435,1800,1524,1520,1458,1450,1100,1000,900,889,880,860,800,775,750,660,655,630,600,575,560,550,500,381,320,184,144,127,89"
 					display_values="1435 mm (Normalspur),1800 mm,1524 mm (Russische Breitspur),1520 mm (Russische Breitspur),1458 mm,1450 mm,1100 mm,1000 mm (Meterspur),900 mm,889 mm,880 mm,860 mm,800 mm,775 mm,750 mm,660 mm,655 mm,630 mm,600 mm,575 mm,560 mm,550 mm,500 mm,381 mm,320 mm,184 mm,144 mm,127 mm,89 mm"
 					default="1435"
-					delete_if_empty="true" />
+					/>
 				<check key="railway:ballastless"
 					text="Ballastless"
 					de.text="Feste Fahrbahn"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="rack"
 					text="Rack"
 					de.text="Zahnstange"
 					values="yes,no,riggenbach,strub,abt,locher,riggenbach-klose,marsh,von_roll"
 					display_values="Ja,Nein,System Riggenbach,System Strub,System Abt,System Locher,System Riggenbach-Klose,System Marsh,System Von Roll"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="incline"
 					text="Incline (e.g.. '3%')"
 					de.text="Steigung (z. B. '3%')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<text key="start_date"
 					text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="operator"
 					text="Operator (e.g. 'DB Netz AG')"
 					de.text="Betreiber (z. B. 'DB Netz AG')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<check key="embankment"
 					text="Embankment"
 					de.text="Damm"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="cutting"
 					text="Cutting"
 					de.text="Einschnitt"
 					default="off"
-					delete_if_empty="true" />
+					/>
 			</item>
 			<item de.name="Stillgelegtes Gleis" name="Disused Track" icon="disused.png" type="way">
 				<label text="Ein Gleis, das zwar noch vorhanden ist und jederzeit wieder genutzt werden könnte, im Moment aber nicht mehr in Betrieb ist." />
@@ -1897,19 +1880,19 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Line ref (VzG number, e.g. '2379')"
 					de.text="Streckennummer (VzG-Nummer, z. B. '2379')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="railway:track_ref"
 					text="Track ref (inside station)"
 					de.text="Gleisnummer (im Bahnhof)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="name"
 					text="Railway name"
 					de.text="Streckenname"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
-				<combo key="usage" text="Usage" de.text="Nutzung" default="" delete_if_empty="true">
+				<combo key="usage" text="Usage" de.text="Nutzung" default="">
 					<list_entry value="main" de.display_value="Hauptbahn" display_value="main line" short_description="Strecke mit übergeordneter Bedeutung; meist zweigleisig, meist elektrifiziert, zumindest abschnittsweise mit mehr als 100 km/h befahrbar" />
 					<list_entry value="branch" de.display_value="Nebenbahn" display_value="branch line" short_description="Strecke mit untergeordneter Bedeutung; oft nicht elektrifiziert, oft eingleisig. Keinesfalls mit mehr als 100 km/h befahrbar." />
 					<list_entry value="industrial" display_value="Industriebahn" de.display_value="industrial/mine railway" short_description="Eine Strecke, die ausschließlich dem Güterverkehr dient und in der Regel Eigentum eines Industrieunternehmens ist. Meist nur innerhalb von Hafengebieten, Industrieanlagen, Tagebauen." />
@@ -1924,30 +1907,30 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.display_values="Gemischt,Personenverkehr,Güterverkehr" 
 					display_values="mixed,passenger,freight"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<check key="highspeed"
 					text="Highspeed traffic (~ >200 km/h)"
 					de.text="Hochgeschwindigkeitsstrecke (~ >200 km/h)"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<space />
 				<check key="railway:pzb"
 					text="PZB"
 					de.text="Punktförmige Zugbeeinflussung (PZB)"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="railway:lzb"
 					text="LZB"
 					de.text="Linienzugbeeinflussung (LZB)"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:etcs"
 					text="ETCS"
 					de.text="ETCS"
 					values="yes,no,0,1,2,3"
 					display_values="Ja,Nein,Level 0,Level 1,Level 2,Level 3"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:radio"
 					text="Radio"
 					de.text="Zugfunk"
@@ -1955,13 +1938,13 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					display_values="analogue,GSM-R"
 					de.display_values="Analog,GSM-R"
 					default=""
-					delete_if_empty="true" />
-				<combo key="railway:preferred_direction" text="Direction of use (depends on direction of OSM way)" de.text="Regelfahrtrichtung (abhängig von Richtung des OSM-Ways)" default="" delete_if_empty="true">
+					/>
+				<combo key="railway:preferred_direction" text="Direction of use (depends on direction of OSM way)" de.text="Regelfahrtrichtung (abhängig von Richtung des OSM-Ways)" default="">
 					<list_entry value="forward" display_value="forward (in the same direction as the OSM way)" de.display_value="In Wegrichtung" short_description="Das Gleis wird üblicherweise in die Richtung befahren, in die der OSM-Way führt. Nur für mehrgleisige Strecken." />
 					<list_entry value="backward"  display_value="backward (in the other direction than the OSM way)" de.display_value="Entgegen Wegrichtung" short_description="Das Gleis wird üblicherweise entgegen der Richtung befahren, in die der OSM-Way führt. Nur für mehrgleisige Strecken." />
 					<list_entry value="both" display_value="both" de.display_value="Beide Richtungen" short_description="Es gibt keine Richtung, in die die Züge üblicherweise fahren bzw. nicht fahren. Nur für eingleisige Strecken." />
 				</combo>
-				<combo key="railway:bidirectional" text="Bidirectional traffic (depends on direction of OSM way)" de.text="Gleiswechselbetrieb (abhängig von Richtung des OSM-Ways)" default="" delete_if_empty="true">
+				<combo key="railway:bidirectional" text="Bidirectional traffic (depends on direction of OSM way)" de.text="Gleiswechselbetrieb (abhängig von Richtung des OSM-Ways)" default="">
 					<list_entry value="regular" de.display_value="Gleiswechselbetrieb" short_description="Das Gleis ist für beide Fahrtrichtungen mit Signalen ausgestattet und kann daher regulär entgegen der üblichen Fahrtrichtung befahren werden." />
 					<list_entry value="signals" de.display_value="Signalisierter Falschfahrbetrieb" short_description="Das Gleis ist signaltechnisch nur für eine Fahrtrichtung ausgelegt, sodass weiterhin Falschfahrten notwendig sind, diese sind aber durch Signale geregelt." />
 					<list_entry value="possible" de.display_value="Falschfahrt möglich" short_description="Signaltechnisch besteht keine Möglichkeit einer Befahrung des Gegengleises. Es ist ein schriftlicher Befehl notwendig." />
@@ -1969,7 +1952,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<combo key="maxspeed" default=""
 					text="Maxspeed (km/h)"
 					de.text="Höchstgeschwindigkeit (km/h)"
-					delete_if_empty="true"
 					values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,none"
 					display_values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,keine" />
 				<label text="Different speed limits depending on direction can be tagged manually using maxspeed:forward= and maxspeed:backward=*." de.text="Unterschiedliche Geschwindigkeiten je Richtung können manuell mit maxspeed:forward=* bzw. maxspeed:backward=* getaggt werden." />
@@ -1980,7 +1962,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="yes,no,contact_line,rail"
 					display_values="Ja,Nein,Oberleitung,Stromschiene"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="voltage"
 					text="Voltage"
 					de.text="Spannung"
@@ -1988,7 +1970,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					display_values="15 kV (default in Germany),45 V,220 V,400 V,600 V,650 V,750 V,800 V,1100 V,1200 V,1500 V,2400 V,3000 V,5000 V,5500 V,6300 V,6600 V,8000 V,10 kV,20 kV,25 kV"
 					de.display_values="15 kV (Standard in Deutschland),45 V,220 V,400 V,600 V,650 V,750 V,800 V,1100 V,1200 V,1500 V,2400 V,3000 V,5000 V,5500 V,6300 V,6600 V,8000 V,10 kV,20 kV,25 kV"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="frequency"
 					text="Frequency"
 					de.text="Frequenz"
@@ -1996,58 +1978,58 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.display_values="16.7 Hz (Standard in Deutschland),Gleichspannung,16 2/3 Hz (in Teilen Deutschlands),50 Hz,60 Hz,25 Hz"
 					display_values="16.7 Hz (default in Germany),DC,16 2/3 Hz (in parts of Germany),50 Hz,60 Hz,25 Hz"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="gauge"
 					text="Gauge"
 					de.text="Spurweite"
 					values="1435,1800,1600,1524,1520,1458,1450,1440,1432,1100,1000,925,915,900,889,880,860,820,800,785,775,750,660,655,630,600,575,560,550,500,410,381,320,184,144,127,89"
 					display_values="1435 mm (Normalspur),1800 mm,1600 mm,1524 mm (Russische Breitspur),1520 mm (Russische Breitspur),1458 mm,1450 mm,1440 mm,1432 mm,1100 mm,1000 mm (Meterspur),925 mm,915 mm,900 mm,889 mm,880 mm,860 mm,820 mm,800 mm,785 mm,775 mm,750 mm,660 mm,655 mm,630 mm,600 mm,575 mm,560 mm,550 mm,500 mm,410 mm,381 mm,320 mm,184 mm,144 mm,127 mm,89 mm"
 					default="1435"
-					delete_if_empty="true" />
+					/>
 				<check key="railway:ballastless"
 					text="Ballastless"
 					de.text="Feste Fahrbahn"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="rack"
 					text="Rack"
 					de.text="Zahnstange"
 					values="yes,no,riggenbach,strub,abt,locher,riggenbach-klose,marsh,von_roll"
 					display_values="Ja,Nein,System Riggenbach,System Strub,System Abt,System Locher,System Riggenbach-Klose,System Marsh,System Von Roll"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="incline"
 					text="Incline (e.g.. '3%')"
 					de.text="Steigung (z. B. '3%')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<text key="start_date"
 					text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="end_date"
 					text="Closed at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Stilllegung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="operator"
 					text="Operator (e.g. 'DB Netz AG')"
 					de.text="Betreiber (z. B. 'DB Netz AG')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<check key="embankment"
 					text="Embankment"
 					de.text="Damm"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="cutting"
 					text="Cutting"
 					de.text="Einschnitt"
 					default="off"
-					delete_if_empty="true" />
+					/>
 			</item>
 			<item de.name="Abgebautes Gleis" name="Abandoned Track" icon="abandoned.png" type="way">
 				<label text="A tracks whose rails has been dismounted but whose train path and ballast is still visible on ground." de.text="Ein Gleis, das entfernt wurde. Das Gleisbett ist weiterhin vorhanden und der Streckenverlauf ist weiterhin sichtbar." />
@@ -2058,19 +2040,19 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Line ref (VzG number, e.g. '2379')"
 					de.text="Streckennummer (VzG-Nummer, z. B. '2379')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="railway:track_ref"
 					text="Track ref (inside station)"
 					de.text="Gleisnummer (im Bahnhof)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="name"
 					text="Railway name"
 					de.text="Streckenname"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
-				<combo key="usage" text="Usage" de.text="Nutzung" default="" delete_if_empty="true">
+				<combo key="usage" text="Usage" de.text="Nutzung" default="">
 					<list_entry value="main" de.display_value="Hauptbahn" display_value="main line" short_description="Strecke mit übergeordneter Bedeutung; meist zweigleisig, meist elektrifiziert, zumindest abschnittsweise mit mehr als 100 km/h befahrbar" />
 					<list_entry value="branch" de.display_value="Nebenbahn" display_value="branch line" short_description="Strecke mit untergeordneter Bedeutung; oft nicht elektrifiziert, oft eingleisig. Keinesfalls mit mehr als 100 km/h befahrbar." />
 					<list_entry value="industrial" display_value="Industriebahn" de.display_value="industrial/mine railway" short_description="Eine Strecke, die ausschließlich dem Güterverkehr dient und in der Regel Eigentum eines Industrieunternehmens ist. Meist nur innerhalb von Hafengebieten, Industrieanlagen, Tagebauen." />
@@ -2085,30 +2067,30 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.display_values="Gemischt,Personenverkehr,Güterverkehr" 
 					display_values="mixed,passenger,freight"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<check key="highspeed"
 					text="Highspeed traffic (~ >200 km/h)"
 					de.text="Hochgeschwindigkeitsstrecke (~ >200 km/h)"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<space />
 				<check key="railway:pzb"
 					text="PZB"
 					de.text="Punktförmige Zugbeeinflussung (PZB)"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="railway:lzb"
 					text="LZB"
 					de.text="Linienzugbeeinflussung (LZB)"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:etcs"
 					text="ETCS"
 					de.text="ETCS"
 					values="yes,no,0,1,2,3"
 					display_values="Ja,Nein,Level 0,Level 1,Level 2,Level 3"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:radio"
 					text="Radio"
 					de.text="Zugfunk"
@@ -2116,13 +2098,13 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					display_values="analogue,GSM-R"
 					de.display_values="Analog,GSM-R"
 					default=""
-					delete_if_empty="true" />
-				<combo key="railway:preferred_direction" text="Direction of use (depends on direction of OSM way)" de.text="Regelfahrtrichtung (abhängig von Richtung des OSM-Ways)" default="" delete_if_empty="true">
+					/>
+				<combo key="railway:preferred_direction" text="Direction of use (depends on direction of OSM way)" de.text="Regelfahrtrichtung (abhängig von Richtung des OSM-Ways)" default="">
 					<list_entry value="forward" display_value="forward (in the same direction as the OSM way)" de.display_value="In Wegrichtung" short_description="Das Gleis wird üblicherweise in die Richtung befahren, in die der OSM-Way führt. Nur für mehrgleisige Strecken." />
 					<list_entry value="backward"  display_value="backward (in the other direction than the OSM way)" de.display_value="Entgegen Wegrichtung" short_description="Das Gleis wird üblicherweise entgegen der Richtung befahren, in die der OSM-Way führt. Nur für mehrgleisige Strecken." />
 					<list_entry value="both" display_value="both" de.display_value="Beide Richtungen" short_description="Es gibt keine Richtung, in die die Züge üblicherweise fahren bzw. nicht fahren. Nur für eingleisige Strecken." />
 				</combo>
-				<combo key="railway:bidirectional" text="Bidirectional traffic (depends on direction of OSM way)" de.text="Gleiswechselbetrieb (abhängig von Richtung des OSM-Ways)" default="" delete_if_empty="true">
+				<combo key="railway:bidirectional" text="Bidirectional traffic (depends on direction of OSM way)" de.text="Gleiswechselbetrieb (abhängig von Richtung des OSM-Ways)" default="">
 					<list_entry value="regular" de.display_value="Gleiswechselbetrieb" short_description="Das Gleis ist für beide Fahrtrichtungen mit Signalen ausgestattet und kann daher regulär entgegen der üblichen Fahrtrichtung befahren werden." />
 					<list_entry value="signals" de.display_value="Signalisierter Falschfahrbetrieb" short_description="Das Gleis ist signaltechnisch nur für eine Fahrtrichtung ausgelegt, sodass weiterhin Falschfahrten notwendig sind, diese sind aber durch Signale geregelt." />
 					<list_entry value="possible" de.display_value="Falschfahrt möglich" short_description="Signaltechnisch besteht keine Möglichkeit einer Befahrung des Gegengleises. Es ist ein schriftlicher Befehl notwendig." />
@@ -2130,7 +2112,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<combo key="maxspeed" default=""
 					text="Maxspeed (km/h)"
 					de.text="Höchstgeschwindigkeit (km/h)"
-					delete_if_empty="true"
 					values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,none"
 					display_values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,keine" />
 				<label text="Different speed limits depending on direction can be tagged manually using maxspeed:forward= and maxspeed:backward=*." de.text="Unterschiedliche Geschwindigkeiten je Richtung können manuell mit maxspeed:forward=* bzw. maxspeed:backward=* getaggt werden." />
@@ -2141,7 +2122,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="yes,no,contact_line,rail"
 					display_values="Ja,Nein,Oberleitung,Stromschiene"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="voltage"
 					text="Voltage"
 					de.text="Spannung"
@@ -2149,7 +2130,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					display_values="15 kV (default in Germany),45 V,220 V,400 V,600 V,650 V,750 V,800 V,1100 V,1200 V,1500 V,2400 V,3000 V,5000 V,5500 V,6300 V,6600 V,8000 V,10 kV,20 kV,25 kV"
 					de.display_values="15 kV (Standard in Deutschland),45 V,220 V,400 V,600 V,650 V,750 V,800 V,1100 V,1200 V,1500 V,2400 V,3000 V,5000 V,5500 V,6300 V,6600 V,8000 V,10 kV,20 kV,25 kV"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="frequency"
 					text="Frequency"
 					de.text="Frequenz"
@@ -2157,58 +2138,58 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.display_values="16.7 Hz (Standard in Deutschland),Gleichspannung,16 2/3 Hz (in Teilen Deutschlands),50 Hz,60 Hz,25 Hz"
 					display_values="16.7 Hz (default in Germany),DC,16 2/3 Hz (in parts of Germany),50 Hz,60 Hz,25 Hz"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="gauge"
 					text="Gauge"
 					de.text="Spurweite"
 					values="1435,1800,1600,1524,1520,1458,1450,1440,1432,1100,1000,925,915,900,889,880,860,820,800,785,775,750,660,655,630,600,575,560,550,500,410,381,320,184,144,127,89"
 					display_values="1435 mm (Normalspur),1800 mm,1600 mm,1524 mm (Russische Breitspur),1520 mm (Russische Breitspur),1458 mm,1450 mm,1440 mm,1432 mm,1100 mm,1000 mm (Meterspur),925 mm,915 mm,900 mm,889 mm,880 mm,860 mm,820 mm,800 mm,785 mm,775 mm,750 mm,660 mm,655 mm,630 mm,600 mm,575 mm,560 mm,550 mm,500 mm,410 mm,381 mm,320 mm,184 mm,144 mm,127 mm,89 mm"
 					default="1435"
-					delete_if_empty="true" />
+					/>
 				<check key="railway:ballastless"
 					text="Ballastless"
 					de.text="Feste Fahrbahn"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="rack"
 					text="Rack"
 					de.text="Zahnstange"
 					values="yes,no,riggenbach,strub,abt,locher,riggenbach-klose,marsh,von_roll"
 					display_values="Ja,Nein,System Riggenbach,System Strub,System Abt,System Locher,System Riggenbach-Klose,System Marsh,System Von Roll"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="incline"
 					text="Incline (e.g.. '3%')"
 					de.text="Steigung (z. B. '3%')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<text key="start_date"
 					text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="end_date"
 					text="Closed at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Stilllegung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="operator"
 					text="Operator (e.g. 'DB Netz AG')"
 					de.text="Betreiber (z. B. 'DB Netz AG')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<check key="embankment"
 					text="Embankment"
 					de.text="Damm"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="cutting"
 					text="Cutting"
 					de.text="Einschnitt"
 					default="off"
-					delete_if_empty="true" />
+					/>
 			</item>
 			<item de.name="Überbauter Streckenverlauf" name="Razed Track" icon="razed.png" type="way">
 				<label text="Overbuilt track which could only be seen if you know where it is." de.text="Ein ehemaliges Gleis, dessen Verlauf heute durch Überbauung o.ä. nur noch zu erahnen ist." />
@@ -2219,19 +2200,19 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Line ref (VzG number, e.g. '2379')"
 					de.text="Streckennummer (VzG-Nummer, z. B. '2379')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="railway:track_ref"
 					text="Track ref (inside station)"
 					de.text="Gleisnummer (im Bahnhof)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="name"
 					text="Railway name"
 					de.text="Streckenname"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
-				<combo key="usage" text="Usage" de.text="Nutzung" default="" delete_if_empty="true">
+				<combo key="usage" text="Usage" de.text="Nutzung" default="">
 					<list_entry value="main" de.display_value="Hauptbahn" display_value="main line" short_description="Strecke mit übergeordneter Bedeutung; meist zweigleisig, meist elektrifiziert, zumindest abschnittsweise mit mehr als 100 km/h befahrbar" />
 					<list_entry value="branch" de.display_value="Nebenbahn" display_value="branch line" short_description="Strecke mit untergeordneter Bedeutung; oft nicht elektrifiziert, oft eingleisig. Keinesfalls mit mehr als 100 km/h befahrbar." />
 					<list_entry value="industrial" display_value="Industriebahn" de.display_value="industrial/mine railway" short_description="Eine Strecke, die ausschließlich dem Güterverkehr dient und in der Regel Eigentum eines Industrieunternehmens ist. Meist nur innerhalb von Hafengebieten, Industrieanlagen, Tagebauen." />
@@ -2246,23 +2227,23 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.display_values="Gemischt,Personenverkehr,Güterverkehr"
 					display_values="mixed,passenger only,freight only"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<check key="highspeed"
 					text="Highspeed traffic (~ >200 km/h)"
 					de.text="Hochgeschwindigkeitsstrecke (~ >200 km/h)"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<space />
 				<check key="railway:pzb"
 					text="PZB"
 					de.text="Punktförmige Zugbeeinflussung (PZB)"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="railway:lzb"
 					text="LZB"
 					de.text="Linienzugbeeinflussung (LZB)"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:etcs"
 					text="ETCS"
 					de.text="ETCS"
@@ -2270,7 +2251,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					display_values="Yes,No,Level 0,Level 1,Level 2,Level 3"
 					de.display_values="Ja,Nein,Level 0,Level 1,Level 2,Level 3"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:radio"
 					text="Radio"
 					de.text="Zugfunk"
@@ -2278,13 +2259,13 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					display_values="analogue,GSM-R"
 					de.display_values="Analog,GSM-R"
 					default=""
-					delete_if_empty="true" />
-				<combo key="railway:preferred_direction" text="Direction of use (depends on direction of OSM way)" de.text="Regelfahrtrichtung (abhängig von Richtung des OSM-Ways)" default="" delete_if_empty="true">
+					/>
+				<combo key="railway:preferred_direction" text="Direction of use (depends on direction of OSM way)" de.text="Regelfahrtrichtung (abhängig von Richtung des OSM-Ways)" default="">
 					<list_entry value="forward" display_value="forward (in the same direction as the OSM way)" de.display_value="In Wegrichtung" short_description="Das Gleis wird üblicherweise in die Richtung befahren, in die der OSM-Way führt. Nur für mehrgleisige Strecken." />
 					<list_entry value="backward"  display_value="backward (in the other direction than the OSM way)" de.display_value="Entgegen Wegrichtung" short_description="Das Gleis wird üblicherweise entgegen der Richtung befahren, in die der OSM-Way führt. Nur für mehrgleisige Strecken." />
 					<list_entry value="both" display_value="both" de.display_value="Beide Richtungen" short_description="Es gibt keine Richtung, in die die Züge üblicherweise fahren bzw. nicht fahren. Nur für eingleisige Strecken." />
 				</combo>
-				<combo key="railway:bidirectional" text="Bidirectional traffic (depends on direction of OSM way)" de.text="Gleiswechselbetrieb (abhängig von Richtung des OSM-Ways)" default="" delete_if_empty="true">
+				<combo key="railway:bidirectional" text="Bidirectional traffic (depends on direction of OSM way)" de.text="Gleiswechselbetrieb (abhängig von Richtung des OSM-Ways)" default="">
 					<list_entry value="regular" de.display_value="Gleiswechselbetrieb" short_description="Das Gleis ist für beide Fahrtrichtungen mit Signalen ausgestattet und kann daher regulär entgegen der üblichen Fahrtrichtung befahren werden." />
 					<list_entry value="signals" de.display_value="Signalisierter Falschfahrbetrieb" short_description="Das Gleis ist signaltechnisch nur für eine Fahrtrichtung ausgelegt, sodass weiterhin Falschfahrten notwendig sind, diese sind aber durch Signale geregelt." />
 					<list_entry value="possible" de.display_value="Falschfahrt möglich" short_description="Signaltechnisch besteht keine Möglichkeit einer Befahrung des Gegengleises. Es ist ein schriftlicher Befehl notwendig." />
@@ -2292,7 +2273,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<combo key="maxspeed" default=""
 					text="Maxspeed (km/h)"
 					de.text="Höchstgeschwindigkeit (km/h)"
-					delete_if_empty="true"
 					values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,none"
 					display_values="10,20,30,40,50,60,70,80,90,100,110,120,130,140,150,160,170,180,190,200,keine" />
 				<label text="Different speed limits depending on direction can be tagged manually using maxspeed:forward= and maxspeed:backward=*." de.text="Unterschiedliche Geschwindigkeiten je Richtung können manuell mit maxspeed:forward=* bzw. maxspeed:backward=* getaggt werden." />
@@ -2303,7 +2283,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="yes,no,contact_line,rail"
 					display_values="Ja,Nein,Oberleitung,Stromschiene"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="voltage"
 					text="Voltage"
 					de.text="Spannung"
@@ -2311,7 +2291,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.display_values="15 kV (Standard in Deutschland),45 V,220 V,400 V,600 V,650 V,750 V,800 V,1100 V,1200 V,1500 V,2400 V,3000 V,5000 V,5500 V,6300 V,6600 V,8000 V,10 kV,20 kV,25 kV"
 					display_values="15 kV (default in Germany),45 V,220 V,400 V,600 V,650 V,750 V,800 V,1100 V,1200 V,1500 V,2400 V,3000 V,5000 V,5500 V,6300 V,6600 V,8000 V,10 kV,20 kV,25 kV"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="frequency"
 					text="Frequency"
 					de.text="Frequenz"
@@ -2319,58 +2299,58 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.display_values="16.7 Hz (Standard in Deutschland),Gleichspannung,16 2/3 Hz (in Teilen Deutschlands),50 Hz,60 Hz,25 Hz"
 					display_values="16.7 Hz (default in Germany),DC,16 2/3 Hz (in parts of Germany),50 Hz,60 Hz,25 Hz"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="gauge"
 					text="Gauge"
 					de.text="Spurweite"
 					values="1435,1800,1600,1524,1520,1458,1450,1440,1432,1100,1000,925,915,900,889,880,860,820,800,785,775,750,660,655,630,600,575,560,550,500,410,381,320,184,144,127,89"
 					display_values="1435 mm (Normalspur),1800 mm,1600 mm,1524 mm (Russische Breitspur),1520 mm (Russische Breitspur),1458 mm,1450 mm,1440 mm,1432 mm,1100 mm,1000 mm (Meterspur),925 mm,915 mm,900 mm,889 mm,880 mm,860 mm,820 mm,800 mm,785 mm,775 mm,750 mm,660 mm,655 mm,630 mm,600 mm,575 mm,560 mm,550 mm,500 mm,410 mm,381 mm,320 mm,184 mm,144 mm,127 mm,89 mm"
 					default="1435"
-					delete_if_empty="true" />
+					/>
 				<check key="railway:ballastless"
 					text="Ballastless"
 					de.text="Feste Fahrbahn"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="rack"
 					text="Rack"
 					de.text="Zahnstange"
 					values="yes,no,riggenbach,strub,abt,locher,riggenbach-klose,marsh,von_roll"
 					display_values="Ja,Nein,System Riggenbach,System Strub,System Abt,System Locher,System Riggenbach-Klose,System Marsh,System Von Roll"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="incline"
 					text="Incline (e.g.. '3%')"
 					de.text="Steigung (z. B. '3%')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<text key="start_date"
 					text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="end_date"
 					text="Closed at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Stilllegung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="operator"
 					text="Operator (e.g. 'DB Netz AG')"
 					de.text="Betreiber (z. B. 'DB Netz AG')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<space />
 				<check key="embankment"
 					text="Embankment"
 					de.text="Damm"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="cutting"
 					text="Cutting"
 					de.text="Einschnitt"
 					default="off"
-					delete_if_empty="true" />
+					/>
 			</item>
 			<separator />
 			<item de.name="Brücke" name="Brücke" icon="bridge-32.png" type="way">
@@ -2382,17 +2362,17 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Bridge name"
 					de.text="Name der Brücke"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="image"
 					text="Image URL"
 					de.text="URL eines Bildes"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="wikipedia"
 					text="Wikipedia article in the format (Language):(Article)"
 					de.text="Wikipediaartikel in der Form (Sprachkürzel):(Artikelname)"
 					default=""
-					delete_if_empty="true" />
+					/>
 			</item>
 			<item de.name="Tunnel" name="Tunnel" icon="tunnel-32.png" type="way">
 				<key key="tunnel"
@@ -2403,17 +2383,17 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Tunnel name"
 					de.text="Name des Tunnels"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="image"
 					text="Image URL"
 					de.text="URL eines Bildes"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="wikipedia"
 					text="Wikipedia article in the format (Language):(Article)"
 					de.text="Wikipediaartikel in der Form (Sprachkürzel):(Artikelname)"
 					default=""
-					delete_if_empty="true" />
+					/>
 			</item>
 			<separator />
 			<item de.name="Prellbock" name="Buffer Stop" icon="buffer_stop-32.png" type="node">
@@ -2428,7 +2408,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.display_values="In Wegrichtung,Entgegen Wegrichtung"
 					display_values="forward,backward"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:signal:minor"
 					text="Exact type of signal"
 					de.text="Signaltyp"
@@ -2447,27 +2427,27 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Switch reference"
 					de.text="Weichennummer"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<check key="railway:local_operated"
 					text="Local operated"
 					de.text="Ortsgestellt"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="railway:switch:electric"
 					text="Electric"
 					de.text="Elektrischer Weichenantrieb"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="railway:switch:heated"
 					text="Heated"
 					de.text="Weichenheizung"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="railway:switch:resetting"
 					text="resetting switch"
 					de.text="Rückfallweiche"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:switch"
 					text="Switch type"
 					de.text="Weichentyp"
@@ -2475,7 +2455,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					display_values="default switch,three way switch,single slip switch,double slip switch,wye switch,abt switch"
 					de.display_values="Einfache Weiche,Dreiwegweiche,einfache Kreuzungsweiche,Doppelkreuzungsweiche,Y-Weiche,Abtsche Weiche"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:turnout_side"
 					text="Turnout side (only default and resetting switches)"
 					de.text="Seite der Abzweigung (nur bei Standard- und Rückfallweichen)"
@@ -2483,35 +2463,35 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					display_values="Left,Right"
 					de.display_values="Links,Rechts"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:radius"
 					text="Switch radius (m)"
 					de.text="Radius der Weichengrundform (m)"
 					values="190,300,500,760,1200,2500"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="railway:maxspeed:straight"
 					text="Maxspeed in straight direction (km/h)"
 					de.text="Geschwindigkeit auf dem geraden Zweig (km/h)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="railway:maxspeed:diverging"
 					text="Maxspeed in diverging direction (km/h)"
 					de.text="Geschwindigkeit auf dem Abzweig (km/h)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:switch:configuration"
 					text="Configuration"
 					de.text="Bauform (bei Doppelkreuzungsweichen)"
 					values="inside,outside"
 					display_values="Innenliegende Zungen (Engländer),Außenliegende Zungen (Baeseler)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<check key="railway:switch:movable_frog"
 					text="Movable frog"
 					de.text="Bewegliches Herzstück"
 					default="off"
-					delete_if_empty="true" />
+					/>
 			</item>
 			<item name="Railway Crossing" de.name="Kreuzung" icon="railway-crossing.png" type="node">
 				<label de.text="Kreuzung" text="Two tracks crosses each other without a switch" />
@@ -2522,7 +2502,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Ref"
 					de.text="Bezeichnung/Nummer"
 					default=""
-					delete_if_empty="true" />
+					/>
 			</item>
 			<item name="Derailer" de.name="Gleissperre" icon="derail.png" type="node">
 				<label text="Derailer" de.text="Gleissperre" />
@@ -2535,17 +2515,17 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Ref"
 					de.text="Bezeichnung/Nummer"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<check key="railway:local_operated"
 					text="Local operated"
 					de.text="Ortsbedient"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="railway:signal:minor:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<key key="railway:signal:minor"
 					value="DE-ESO:sh" />
 				<combo key="railway:signal:minor:states"
@@ -2554,7 +2534,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="DE-ESO:sh0;DE-ESO:sh1,DE-ESO:sh0;DE-ESO:wn7"
 					display_values="Sh 0 / Sh 1,Sh 0 / Wn 7 (vormals Gsp 2)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<key key="railway:signal:minor:form"
 					value="semaphore" />
 				<key key="railway:signal:minor:height"
@@ -2572,7 +2552,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					display_values="insulated_rail_joint,axle_counter"
 					de.display_values="Isolierstoß,Achszähler"
 					default=""
-					delete_if_empty="true" />
+					/>
 			</item>
 		</group>
 		<item name="Signal Box" de.name="Stellwerk" icon="signalbox.png" type="node,closedway">
@@ -2584,54 +2564,54 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				text="Name"
 				de.text="Name (z. B. 'Neuss Ngf', 'Riesa B8' 'Holzheim ESTW-A')"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<text key="railway:ref"
 				text="Short name"
 				de.text="Abkürzung (z. B. 'Ngf' oder 'B8')"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<combo key="railway:signal_box"
 				text="Signal box type"
 				de.text="Stellwerkstechnik"
 				values="mechanical,electric,track_diagram,electronic"
 				display_values="Mechanisches Stellwerk,Elektrisches/Elektromechanisches Stellwerk,Gleisbildstellwerk,Elektronisches Stellwerk (ESTW)"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<text key="start_date"
 				text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 				de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<text key="railway:position"
 				text="Distance indication (rounded, e.g. '12.3'; km)"
 				de.text="Hektometerwert (z. B. '12.3')"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<text key="railway:position:exact"
 				text="Exact distance indication (exact, e.g. '12.345'; km)"
 				de.text="Metergenauer Wert (genau, z. B: '12.345'; km)"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<text key="image"
 				text="Image URL"
 				de.text="URL eines Bildes"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<check key="railway:local_operated"
 				text="Local operated"
 				de.text="Ortsbedient"
 				default="off"
-				delete_if_empty="true" />
+				/>
 			<check key="building"
 				text="Building"
 				de.text="Gebäude"
 				default="off"
-				delete_if_empty="true" />
+				/>
 			<check key="disused"
 				text="out of service"
 				de.text="Außer Betrieb"
 				default="off"
-				delete_if_empty="true" />
+				/>
 		</item>
 		<group name="Operating Sites" de.name="Betriebsstellen" icon="facilities.png">
 			<item name="Station" de.name="Bahnhof" icon="station.png" type="node">
@@ -2647,63 +2627,63 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.display_values="ja,nein"
 					display_values="yes,no"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="name" text="Name"
 					de.text="Name"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="railway:ref"
 					text="Short name (DS100)"
 					de.text="Abkürzung (nach DS100, z. B. 'ABC')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="uic_ref"
 					text="UIC-ID"
 					de.text="UIC-Bahnhofsnummer"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="uic_name"
 					text="UIC name"
 					de.text="UIC-Bahnhofsname"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:station_category"
 					text="Station category"
 					de.text="Bahnhofskategorie"
 					values="1,2,3,4,5,6,7"
 					display_values="1,2,3,4,5,6,7"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="operator"
 					text="Operator (e.g. 'DB Station&amp;Service AG')"
 					de.text="Betreiber (z. B. 'DB Station&amp;Service AG')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="network"
 					text="Network"
 					de.text="Verkehrsverbund"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="start_date"
 					text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="image"
 					text="Image URL"
 					de.text="URL eines Bildes"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="wikipedia"
 					text="Wikipedia article in the format (Language):(Article)"
 					de.text="Wikipediaartikel in der Form (Sprachkürzel):(Artikelname)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="ele"
 					text="Height above sea level (m)"
 					de.text="Höhe über Meeresspiegel (m)"
 					default=""
-					delete_if_empty="true" />
+					/>
 			</item>
 			<item name="Halt" de.name="Haltepunkt/Haltestelle" icon="halt.png" type="node">
 				<label de.text="Haltepunkt/Haltestelle" text="a small station without switches" />
@@ -2718,63 +2698,63 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.display_values="ja,nein"
 					display_values="yes,no"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="name" text="Name"
 					de.text="Name"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="railway:ref"
 					text="Short name (DS100)"
 					de.text="Abkürzung (DS100, z. B. 'ABC')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="uic_ref"
 					text="UIC-ID"
 					de.text="UIC-Bahnhofsnummer"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="uic_name"
 					text="UIC name"
 					de.text="UIC-Bahnhofsname"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="railway:station_category"
 					text="Station category"
 					de.text="Bahnhofskategorie"
 					values="1,2,3,4,5,6,7"
 					display_values="1,2,3,4,5,6,7"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="operator"
 					text="Operator (e.g. 'DB Station&amp;Service AG')"
 					de.text="Betreiber (z. B. 'DB Station&amp;Service AG')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="network"
 					text="Network"
 					de.text="Verkehrsverbund"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="start_date"
 					text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="image"
 					text="Image URL"
 					de.text="URL eines Bildes"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="wikipedia"
 					text="Wikipedia article in the format (Language):(Article)"
 					de.text="Wikipediaartikel in der Form (Sprachkürzel):(Artikelname)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="ele"
 					text="Height above sea level (m)"
 					de.text="Höhe über Meeresspiegel (m)"
 					default=""
-					delete_if_empty="true" />
+					/>
 			</item>
 			<item name="Tram Stop" de.name="Straßenbahnhaltestelle" icon="tramstop.png" type="node">
 				<label text="Tram Stop" de.text="Straßenbahnhaltestelle" />
@@ -2789,46 +2769,46 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.display_values="ja,nein"
 					display_values="yes,no"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="name" text="Name"
 					de.text="Name"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="railway:ref"
 					text="Short name"
 					de.text="Abkürzung"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="uic_ref"
 					text="UIC-ID"
 					de.text="UIC-Bahnhofsnummer"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="uic_name"
 					text="UIC name"
 					de.text="UIC-Bahnhofsname"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="operator"
 					text="Operator (e.g. 'Rheinbahn')"
 					de.text="Betreiber (z. B. 'Rheinbahn')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="network"
 					text="Network"
 					de.text="Verkehrsverbund"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="start_date"
 					text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="ele"
 					text="Height above sea level (m)"
 					de.text="Höhe über Meeresspiegel (m)"
 					default=""
-					delete_if_empty="true" />
+					/>
 			</item>
 			<item name="Freight Station" de.name="Güterbahnhof/Rangierbahnhof" icon="yard-32.png" type="node">
 				<label text="Güterbahnhof/Rangierbahnhof" />
@@ -2839,37 +2819,37 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<text key="name" text="Name"
 					de.text="Name"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="railway:ref"
 					text="Short name (DS100)"
 					de.text="Abkürzung (nach DS100, z. B. 'ABC')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="operator"
 					text="Operator (e.g. 'DB Netz AG')"
 					de.text="Betreiber (z. B. 'DB Netz AG')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="start_date"
 					text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="image"
 					text="Image URL"
 					de.text="URL eines Bildes"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="wikipedia"
 					text="Wikipedia article in the format (Language):(Article)"
 					de.text="Wikipediaartikel in der Form (Sprachkürzel):(Artikelname)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="ele"
 					text="Height above sea level (m)"
 					de.text="Höhe über Meeresspiegel (m)"
 					default=""
-					delete_if_empty="true" />
+					/>
 			</item>
 			<item name="Service Station" de.name="Betriebsbahnhof" icon="service-station.png" type="node">
 				<label text="Betriebsbahnhof" />
@@ -2880,37 +2860,37 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<text key="name" text="Name"
 					de.text="Name"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="railway:ref"
 					text="Short name (DS100)"
 					de.text="Abkürzung (nach DS100, z. B. 'ABC')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="operator"
 					text="Operator (e.g. 'DB Netz AG')"
 					de.text="Betreiber (z. B. 'DB Netz AG')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="start_date"
 					text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="image"
 					text="Image URL"
 					de.text="URL eines Bildes"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="wikipedia"
 					text="Wikipedia article in the format (Language):(Article)"
 					de.text="Wikipediaartikel in der Form (Sprachkürzel):(Artikelname)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="ele"
 					text="Height above sea level (m)"
 					de.text="Höhe über Meeresspiegel (m)"
 					default=""
-					delete_if_empty="true" />
+					/>
 			</item>
 			<item name="Juction" de.name="Abzweig" icon="junction-25.png" type="node">
 				<label text="Abzweig" />
@@ -2922,37 +2902,37 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Name"
 					de.text="Name"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="railway:ref"
 					text="Short name (DS100, such as 'NAN')"
 					de.text="Abkürzung (nach DS100, z. B. 'NAN')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="operator"
 					text="Operator (e.g. 'DB Netz AG')"
 					de.text="Betreiber (z. B. 'DB Netz AG')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="start_date"
 					text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="image"
 					text="Image URL"
 					de.text="URL eines Bildes"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="wikipedia"
 					text="Wikipedia article in the format (Language):(Article)"
 					de.text="Wikipediaartikel in der Form (Sprachkürzel):(Artikelname)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="ele"
 					text="Height above sea level (m)"
 					de.text="Höhe über Meeresspiegel (m)"
 					default=""
-					delete_if_empty="true" />
+					/>
 			</item>
 			<item name="Spur juction" de.name="Anst / Awanst" icon="junction-25.png" type="node">
 				<label text="Anschlusstelle oder Ausweichanschlusstelle" />
@@ -2964,37 +2944,37 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Name"
 					de.text="Name"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="railway:ref"
 					text="Short name (DS100, such as 'NAN')"
 					de.text="Abkürzung (nach DS100, z. B. 'NAN')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="operator"
 					text="Operator (e.g. 'DB Netz AG')"
 					de.text="Betreiber (z. B. 'DB Netz AG')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="start_date"
 					text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="image"
 					text="Image URL"
 					de.text="URL eines Bildes"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="wikipedia"
 					text="Wikipedia article in the format (Language):(Article)"
 					de.text="Wikipediaartikel in der Form (Sprachkürzel):(Artikelname)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="ele"
 					text="Height above sea level (m)"
 					de.text="Höhe über Meeresspiegel (m)"
 					default=""
-					delete_if_empty="true" />
+					/>
 			</item>
 			<item name="Crossover" de.name="Überleitstelle" icon="crossover-28.png" type="node">
 				<label text="Überleitstelle" />
@@ -3006,37 +2986,37 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Name"
 					de.text="Name"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="railway:ref"
 					text="Short name (DS100)"
 					de.text="Abkürzung (nach DS100, z. B. 'ABC')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="operator"
 					text="Operator (e.g. 'DB Netz AG')"
 					de.text="Betreiber (z. B. 'DB Netz AG')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="start_date"
 					text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="image"
 					text="Image URL"
 					de.text="URL eines Bildes"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="wikipedia"
 					text="Wikipedia article in the format (Language):(Article)"
 					de.text="Wikipediaartikel in der Form (Sprachkürzel):(Artikelname)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="ele"
 					text="Height above sea level (m)"
 					de.text="Höhe über Meeresspiegel (m)"
 					default=""
-					delete_if_empty="true" />
+					/>
 			</item>
 			<item name="Station Part or Blockpost" de.name="Bahnhofsteil, Blockstelle, Deckungsstelle" icon="site.png" type="node">
 				<label text="Bahnhofsteil, Blockstelle, Deckungsstelle" />
@@ -3048,37 +3028,37 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Name"
 					de.text="Name"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="railway:ref"
 					text="Short name (DS100)"
 					de.text="Abkürzung (nach DS100, z. B. 'ABC')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="operator"
 					text="Operator (e.g. 'DB Netz AG')"
 					de.text="Betreiber (z. B. 'DB Netz AG')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="start_date"
 					text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 					de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="image"
 					text="Image URL"
 					de.text="URL eines Bildes"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="wikipedia"
 					text="Wikipedia article in the format (Language):(Article)"
 					de.text="Wikipediaartikel in der Form (Sprachkürzel):(Artikelname)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="ele"
 					text="Height above sea level (m)"
 					de.text="Höhe über Meeresspiegel (m)"
 					default=""
-					delete_if_empty="true" />
+					/>
 			</item>
 			<separator />
 			<item name="Stop Position" de.name="Halteposition" icon="stop.png" type="node">
@@ -3092,79 +3072,79 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.display_values="ja,nein"
 					display_values="yes,no"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<key key="railway"
 					value="stop" />
 				<text key="name"
 					text="Name"
 					de.text="Name"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="railway:ref"
 					text="Short name (DS100)"
 					de.text="Abkürzung (nach DS100, z. B. 'ABC')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="uic_ref"
 					text="UIC-ID"
 					de.text="UIC-Bahnhofsnummer"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="uic_name"
 					text="UIC name"
 					de.text="UIC-Bahnhofsname"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="local_ref"
 					text="track number (e.g. 5 or 5a)"
 					de.text="Gleisnummer (z.B. 5 oder 5a)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<check key="train"
 					text="Railway traffic?"
 					de.text="Eisenbahnverkehr?"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="light_rail"
 					text="Light rail traffic?"
 					de.text="Stadtbahn- oder Schnellbahn-Verkehr?"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="subway"
 					text="Subway traffic?"
 					de.text="U-Bahn-Verkehr?"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="tram"
 					text="Tram traffic?"
 					de.text="Straßenbahnverkehr?"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<text key="operator"
 					text="Operator (e.g. 'DB Netz AG' or 'DB Station&amp;Service AG')"
 					de.text="Betreiber (z. B. 'DB Netz AG' oder 'DB Station&amp;Service AG')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="network"
 					text="Network"
 					de.text="Verkehrsverbund"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="ele"
 					text="Height above sea level (m)"
 					de.text="Höhe über Meeresspiegel (m)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="railway:position"
 					text="Distance indication (rounded, e.g. '12.3'; km)"
 					de.text="Entfernungsangabe (gerundet, z. B. '12.3'; km)"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="railway:position:exact"
 					text="Exact distance indication (exact, e.g. '12.345'; km)"
 					de.text="Exakte Entfernungsangabe (genau, z.B: '12.345'; km)"
 					default=""
-					delete_if_empty="true" />
+					/>
 			</item>
 			<item name="Railway Landuse Area" de.name="Bahngelände" icon="landuse.png" type="closedway">
 				<label text="Bahngelände" />
@@ -3183,7 +3163,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.display_values="ja,nein"
 					display_values="yes,no"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<combo key="public_transport"
 					text="Public transport?"
 					de.text="Öffentlicher Verkehr?"
@@ -3191,52 +3171,52 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.display_values="ja,nein"
 					display_values="yes,no"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="name"
 					text="Name"
 					de.text="Name"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="uic_ref"
 					text="UIC-ID"
 					de.text="UIC-Bahnhofsnummer"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="uic_name"
 					text="UIC name"
 					de.text="UIC-Bahnhofsname"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="railway:ref"
 					text="Short name (DS100)"
 					de.text="Abkürzung (nach DS100, z. B. 'ABC')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="operator"
 					text="Operator (e.g. 'DB Netz AG' or 'DB Station&amp;Service AG')"
 					de.text="Betreiber (z. B. 'DB Netz AG' oder 'DB Station&amp;Service AG')"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<check key="train"
 					text="Railway traffic?"
 					de.text="Eisenbahnverkehr?"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="light_rail"
 					text="Light rail traffic?"
 					de.text="Stadtbahn- oder Schnellbahn-Verkehr?"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="subway"
 					text="Subway traffic?"
 					de.text="U-Bahn-Verkehr?"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<check key="tram"
 					text="Tram traffic?"
 					de.text="Straßenbahnverkehr?"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<roles>
 					<role key=""
 						text="Railway facility node/area"
@@ -3284,32 +3264,32 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				text="Name of track (e.g. '1234 Eifelquerbahn Gerolstein - Kaisersesch')"
 				de.text="Streckenname (z. B. '1234 Eifelquerbahn Gerolstein – Kaisersesch')"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<text key="ref"
 				text="Line ref (VzG number, e.g. '2379')"
 				de.text="Streckennummer (VzG-Nummer, z. B. '2379')"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<text key="from"
 				text="Initial station"
 				de.text="Streckenanfang"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<text key="to"
 				text="Terminus station"
 				de.text="Streckenende"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<text key="operator"
 				text="Operator (e.g. 'DB Netz AG')"
 				de.text="Betreiber (z. B. 'DB Netz AG')"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<text key="wikipedia"
 				text="Wikipedia article in the format (Language):(Article)"
 				de.text="Wikipediaartikel in der Form (Sprachkürzel):(Artikelname)"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<roles>
 				<role key=""
 					text="Tracks"
@@ -3329,27 +3309,27 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				text="Name of route (e.g. 'KBS 123 Voreifelbahn')"
 				de.text="Name der Kursbuchstrecke (z. B. 'KBS 123 Voreifelbahn')"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<text key="ref"
 				text="Line ref (KBS number, e.g. '123')"
 				de.text="Streckennummer (KBS-Nummer, z. B. '123')"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<text key="from"
 				text="Initial station"
 				de.text="Streckenanfang"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<text key="to"
 				text="Terminus station"
 				de.text="Streckenende"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<text key="wikipedia"
 				text="Wikipedia article in the format (Language):(Article)"
 				de.text="Wikipediaartikel in der Form (Sprachkürzel):(Artikelname)"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<roles>
 				<role key=""
 					text="Tracks"
@@ -3370,8 +3350,8 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				de.display_values="Zug,Stadt-/Schnellbahn,Straßenbahn,U-Bahn"
 				display_values="train,light rail,tram,subway"
 				default=""
-				delete_if_empty="true" />
-			<combo key="service" text="Zuggattung" default="" delete_if_empty="true">
+				/>
+			<combo key="service" text="Zuggattung" default="">
 				<list_entry value="high_speed" de.display_value="Hochgeschwindigkeitszug" display_value="high speed train" short_description="ICE, Thalys, TGV, Railjet" />
 				<list_entry value="long_distance" de.display_value="Reisezug" display_value="long distance train" short_description="Eurocity, Intercity, D-Zug" />
 				<list_entry value="regional" de.display_value="Regionalzug" display_value="regional train" short_description="Regionalbahn, Regionalexpress" />
@@ -3385,32 +3365,32 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				text="Name of line (e.g. 'RE 7 Krefeld Rhein-Münsterland-Express')"
 				de.text="Name der Linie (z. B. 'RE 7 Krefeld Rhein-Münsterland-Express')"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<text key="operator"
 				text="Operator"
 				de.text="Betreiber"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<text key="ref"
 				text="Line or train ref (e.g. 'RE 7')"
 				de.text="Linien- bzw. Zugnummer (z. B. 'RE 7')"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<text key="from"
 				text="Initial station"
 				de.text="Streckenanfang"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<text key="to"
 				text="Terminus station"
 				de.text="Streckenende"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<text key="wikipedia"
 				text="Wikipedia article in the format (Language):(Article)"
 				de.text="Wikipediaartikel in der Form (Sprachkürzel):(Artikelname)"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<roles>
 				<role key=""
 					text="Tracks"
@@ -3467,8 +3447,8 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				de.display_values="Zug,Stadt-/Schnellbahn,Straßenbahn,U-Bahn"
 				display_values="train,light rail,tram,subway"
 				default=""
-				delete_if_empty="true" />
-			<combo key="service" text="Zuggattung" default="" delete_if_empty="true">
+				/>
+			<combo key="service" text="Zuggattung" default="">
 				<list_entry value="high_speed" de.display_value="Hochgeschwindigkeitszug" display_value="high speed train" short_description="ICE, Thalys, TGV, Railjet" />
 				<list_entry value="long_distance" de.display_value="Reisezug" display_value="long distance train" short_description="Eurocity, Intercity, D-Zug" />
 				<list_entry value="regional" de.display_value="Regionalzug" display_value="regional train" short_description="Regionalbahn, Regionalexpress" />
@@ -3482,32 +3462,32 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				text="Name of line (e.g. 'RE 7 Krefeld Rhein-Münsterland-Express')"
 				de.text="Name der Linie (z. B. 'RE 7 Krefeld Rhein-Münsterland-Express')"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<text key="operator"
 				text="Operator"
 				de.text="Betreiber"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<text key="ref"
 				text="Line or train ref (e.g. 'RE 7')"
 				de.text="Linien- bzw. Zugnummer (z. B. 'RE 7')"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<text key="from"
 				text="Initial station"
 				de.text="Streckenanfang"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<text key="to"
 				text="Terminus station"
 				de.text="Streckenende"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<text key="wikipedia"
 				text="Wikipedia article in the format (Language):(Article)"
 				de.text="Wikipediaartikel in der Form (Sprachkürzel):(Artikelname)"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<roles>
 				<role key=""
 					text="Tracks"
@@ -3562,17 +3542,17 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				text="Name (no position)"
 				de.text="Name (keine Kilometerangabe oder kreuzende Straße)"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<text key="railway:position"
 				text="Position (rounded, e.g. '12.3'; km)"
 				de.text="Hektometerwert (z. B. '12.3')"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<text key="railway:position:exact"
 				text="Position (exact, e.g. '12.345'; km)"
 				de.text="Metergenauer Wert (z. B. '12.345'; km)"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<space />
 			<combo key="crossing:barrier"
 				text="Barriers" de.text="Schranken"
@@ -3580,52 +3560,52 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				de.display_values="Halbschranke,Vollabschluss ('doppelte Halbschranke'),Vollschranke,Tore (England),Beschrankt,Unbeschrankt"
 				display_values="half boom gate,double half boom gate,full boom gate,gates (turnable),yes,no"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<check key="crossing:light"
 				text="Lights"
 				de.text="Warnlicht"
 				default="off"
-				delete_if_empty="true" />
+				/>
 			<check key="crossing:saltire"
 				text="Saltire"
 				de.text="Andreaskreuz"
 				default="off"
-				delete_if_empty="true" />
+				/>
 			<check key="crossing:bell"
 				text="Bell"
 				de.text="Akustischer Warnton"
 				default="off"
-				delete_if_empty="true" />
+				/>
 			<space />
 			<check key="crossing:chicane"
 				text="Chicane"
 				de.text="Umlaufgitter"
 				default="off"
-				delete_if_empty="true" />
+				/>
 			<combo key="crossing:supervision"
 				text="Type of supervision" de.text="Art der Überwachung"
 				values="no,camera,attendant,automatic,phone"
 				display_values="no,camera,attendant,automatic,phone"
 				de.display_values="keine Überwachung,Kamera,Schrankenwärter/Fahrdienstleiter/Posten,Gefahrenraum-Freimeldeanlage,Telefon (Anrufschranken)"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<combo key="crossing:activation"
 				text="Activation" de.text="Einschaltung"
 				values="automatic,remote,local"
 				display_values="automatic (contacts),remote (signal box), local (attendant/train staff)"
 				de.display_values="Einschaltkontakte, fahrdienstleitergesteuert, vor Ort (Schrankenwärter/Zugpersonal)"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<text key="railway:level_crossing:closure:average"
 				text="average clousure duration (minutes)"
 				de.text="durchschnittliche Schließdauer (in Minuten)"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<check key="crossing:on_demand"
 				text="On demand"
 				de.text="Anrufschranke"
 				default="off"
-				delete_if_empty="true" />
+				/>
 		</item>
 		<item name="Little crossing for pedestrians" de.name="Reisendenübergang"  icon="de-crossing.png" type="node">
 			<label de.text="Reisendenübergang (Übergänge für Reisende/Fußgänger ohne Andreaskreuz" text="Crossing for pedestrians (less secure than common level crossings)" />
@@ -3636,17 +3616,17 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				text="Name (no position)"
 				de.text="Name (keine Kilometerangabe oder kreuzende Straße)"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<text key="railway:position"
 				text="Position (rounded, e.g. '12.3'; km)"
 				de.text="Hektometerwert (z. B. '12.3')"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<text key="railway:position:exact"
 				text="Position (exact, e.g. '12.345'; km)"
 				de.text="Metergenauer Wert (z. B. '12.345'; km)"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<space />
 			<combo key="crossing:barrier"
 				text="Barriers" de.text="Schranken"
@@ -3654,52 +3634,52 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				de.display_values="Halbschranke,Vollabschluss ('doppelte Halbschranke'),Vollschranke,Tore (England),Beschrankt,Unbeschrankt"
 				display_values="half boom gate,double half boom gate,full boom gate,gates (turnable),yes,no"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<check key="crossing:light"
 				text="Lights"
 				de.text="Warnlicht"
 				default="off"
-				delete_if_empty="true" />
+				/>
 			<check key="crossing:saltire"
 				text="Saltire"
 				de.text="Andreaskreuz"
 				default="off"
-				delete_if_empty="true" />
+				/>
 			<check key="crossing:bell"
 				text="Bell"
 				de.text="Akustischer Warnton"
 				default="off"
-				delete_if_empty="true" />
+				/>
 			<space />
 			<check key="crossing:chicane"
 				text="Chicane"
 				de.text="Umlaufgitter"
 				default="off"
-				delete_if_empty="true" />
+				/>
 			<combo key="crossing:supervision"
 				text="Type of supervision" de.text="Art der Überwachung"
 				values="no,camera,attendant,automatic,phone"
 				display_values="no,camera,attendant,automatic,phone"
 				de.display_values="keine Überwachung,Kamera,Schrankenwärter/Fahrdienstleiter/Posten,Gefahrenraum-Freimeldeanlage,Telefon (Anrufschranken)"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<combo key="crossing:activation"
 				text="Activation" de.text="Einschaltung"
 				values="automatic,remote,local"
 				display_values="automatic (contacts),remote (signal box), local (attendant/train staff)"
 				de.display_values="Einschaltkontakte, fahrdienstleitergesteuert, vor Ort (Schrankenwärter/Zugpersonal)"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<text key="railway:level_crossing:closure:average"
 				text="average clousure duration (minutes)"
 				de.text="durchschnittliche Schließdauer (in Minuten)"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<check key="crossing:on_demand"
 				text="On demand"
 				de.text="Anrufschranke"
 				default="off"
-				delete_if_empty="true" />
+				/>
 		</item>
 		<separator />
 		<item name="Milestone" de.name="Kilo-/Hektometertafel" icon="milestone.png" type="node">
@@ -3718,29 +3698,29 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				text="Distance indication (rounded, e.g. '12.3'; km)"
 				de.text="Hektometerwert (z. B. '12.3')"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<text key="railway:position:exact"
 				text="Exact distance indication (exact, e.g. '12.345'; km)"
 				de.text="Metergenauer Wert (z. B. '12.345')"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<check key="railway:milestone:catenary_mast"
 				text="On catenary mast"
 				de.text="Am Oberleitungsmast"
 				default="off"
-				delete_if_empty="true" />
+				/>
 			<check key="railway:milestone:emergency_brake_override"
 				text="Emergency brake override"
 				de.text="Notbremsüberbrückung (NBÜ)"
 				default="off"
-				delete_if_empty="true" />
+				/>
 			<combo key="railway:milestone:emergency_brake_override:direction"
 				text="Direction of emergency brake override (if existing)"
 				de.text="Richtung der Notbremsunterdrückung (falls vorhanden)"
 				values="forward,backward,both"
 				display_values="In Wegrichtung,Entgegen Wegrichtung,Beide Richtungen"
 				default=""
-				delete_if_empty="true" />
+				/>
 		</item>
 		<item name="Platform" de.name="Bahnsteig" icon="platform.png" type="way,closedway">
 			<label text="Bahnsteig" />
@@ -3750,34 +3730,34 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				text="Caption"
 				de.text="Beschriftung"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<text key="ref"
 				text="Platform number(s)"
 				de.text="Bahnsteignummer(n)"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<check key="area"
 				text="Area"
 				de.text="Fläche"
 				default="off"
-				delete_if_empty="true" />
+				/>
 			<check key="lit"
 				text="Lit"
 				de.text="Beleuchtet"
 				default="off"
-				delete_if_empty="true" />
+				/>
 			<check key="covered"
 				text="Covered"
 				de.text="Überdacht"
 				default="off"
-				delete_if_empty="true" />
+				/>
 			<combo key="surface"
 				text="Surface"
 				de.text="Oberfläche"
 				values="asphalt,paving_stones,concrete,cobblestone,compacted,paved,unpaved"
 				display_values="Asphalt,Pflastersteine,Beton,Kopfsteinpflaster,Verdichtet,Befestigt,Unbefestigt"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<key key="public_transport"
 				value="platform" />
 			<combo key="wheelchair"
@@ -3786,39 +3766,39 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				values="yes,no,limited"
 				display_values="Ja,Nein,Eingeschränkt"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<combo key="tactile_paving"
 				text="Tactile Paving"
 				de.text="Ertastbarer Untergrund"
 				values="yes,no,incorrect"
 				display_values="Ja,Nein,Ja (aber nicht sinnvoll)"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<text key="height"
 				text="Platform height (in meters, e. g. 0.76)"
 				de.text="Bahnsteighöhe (in Metern, z. B. 0.76)"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<check key="train"
 				text="Railway traffic?"
 				de.text="Eisenbahnverkehr?"
 				default="off"
-				delete_if_empty="true" />
+				/>
 			<check key="light_rail"
 				text="Light rail traffic?"
 				de.text="Stadtbahn- oder Schnellbahn-Verkehr?"
 				default="off"
-				delete_if_empty="true" />
+				/>
 			<check key="subway"
 				text="Subway traffic?"
 				de.text="U-Bahn-Verkehr?"
 				default="off"
-				delete_if_empty="true" />
+				/>
 			<check key="tram"
 				text="Tram traffic?"
 				de.text="Straßenbahnverkehr?"
 				default="off"
-				delete_if_empty="true" />
+				/>
 		</item>
 		<item name="Ticket Counter" de.name="Fahrkartenschalter" icon="ticketshop.png" type="node">
 			<label text="Fahrkartenschalter" />
@@ -3829,17 +3809,17 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				text="Operator (e.g. 'Deutsche Bahn')"
 				de.text="Betreiber (z. B. 'Deutsche Bahn')"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<text key="name"
 				text="Name (e.g. 'Reisezentrum')"
 				de.text="Name (z. B. 'Reisezentrum')"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<text key="opening_hours"
 				text="Opening hours"
 				de.text="Öffnungszeiten"
 				default=""
-				delete_if_empty="true" />
+				/>
 		</item>
 		<item name="Subway Entrance" de.name="U-Bahn-Zugang" icon="landuse.png" type="node">
 			<label text="U-Bahn-Zugang" />
@@ -3849,19 +3829,19 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				text="Name"
 				de.text="Name"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<combo key="wheelchair"
 				text="Wheelchair"
 				de.text="Rollstuhlgerecht"
 				values="yes,no,limited"
 				display_values="Ja,Nein,Eingeschränkt"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<check key="bicycle"
 				text="Accessible with bicycles"
 				de.text="Passierbar mit Fahrrädern"
 				default="off"
-				delete_if_empty="true" />
+				/>
 		</item>
 		<item name="Station Building" de.name="Bahnhofsgebäude" icon="train-station.png" type="closedway">
 			<label text="Bahnhofsgebäude" />
@@ -3872,17 +3852,17 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				text="Opened/Inaugurated at (Format: YYYY, YYYY-MM or YYYY-MM-DD)"
 				de.text="Zeitpunkt der Eröffnung (Format: JJJJ, JJJJ-MM oder JJJJ-MM-TT)"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<text key="image"
 				text="Image URL"
 				de.text="URL eines Bildes"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<text key="ele"
 				text="Height above sea level (m)"
 				de.text="Höhe über Meeresspiegel (m)"
 				default=""
-				delete_if_empty="true" />
+				/>
 		</item>
 		<item name="Railway Landuse Area" de.name="Bahngelände" icon="landuse.png" type="closedway">
 			<label text="Bahngelände" />
@@ -3917,7 +3897,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					display_values="analogue,GSM-R"
 				de.display_values="Analog,GSM-R"
 				default=""
-				delete_if_empty="true" />
+				/>
 		</item>
 		<separator />
 		<item name="Grenzpunkt" icon="owner-change.png" type="node">
@@ -3940,7 +3920,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Building"
 					de.text="Gebäude"
 					default="off"
-					delete_if_empty="true" />
+					/>
 			</item>
 			<item name="Water Crane" de.name="Wasserkran" icon="water-crane.png" type="node">
 				<label text="Wasserkran" />
@@ -3965,7 +3945,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Area"
 					de.text="Fläche"
 					default="off"
-					delete_if_empty="true" />
+					/>
 			</item>
 			<item name="Train Wash" de.name="Waschanlage" icon="wash.png" type="node,closedway">
 				<label text="Waschanlage" />
@@ -3975,7 +3955,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Building"
 					de.text="Gebäude"
 					default="off"
-					delete_if_empty="true" />
+					/>
 			</item>
 			<item name="Pit" de.name="Lokgrube" icon="pit.png" type="node">
 				<label text="Lokgrube" />
@@ -3990,12 +3970,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Building"
 					de.text="Gebäude"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<text key="name"
 					text="Name"
 					de.text="Name"
 					default=""
-					delete_if_empty="true" />
+					/>
 			</item>
 			<item name="Workshop" de.name="Werkstatt" icon="workshop.png" type="node,closedway">
 				<label text="Werkstatt" />
@@ -4005,12 +3985,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Building"
 					de.text="Gebäude"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<text key="name"
 					text="Name"
 					de.text="Name"
 					default=""
-					delete_if_empty="true" />
+					/>
 			</item>
 		</group>
 		<group name="Verladeeinrichtungen" icon="loading.png">
@@ -4037,34 +4017,34 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Name"
 					de.text="Name"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<check key="lit"
 					text="Lit"
 					de.text="Beleuchtung"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<combo key="surface"
 					text="Surface"
 					de.text="Oberfläche"
 					values="asphalt,paving_stones,concrete,cobblestone,compacted,paved,unpaved"
 					display_values="Asphalt,Pflastersteine,Beton,Kopfsteinpflaster,Verdichtet,Befestigt,Unbefestigt"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="height"
 					text="Ramp height (m) - 0 for loading streets"
 					de.text="Rampenhöhe (m) - bei Ladestraße 0 eintragen"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<check key="area"
 					text="Area"
 					de.text="Fläche"
 					default="off"
-					delete_if_empty="true" />
+					/>
 				<text key="operator"
 					text="Operator (e.g. 'DB Netz AG')"
 					de.text="Betreiber (z. B. 'DB Netz AG')"
 					default=""
-					delete_if_empty="true" />
+					/>
 			</item>
 			<separator />
 			<item name="Eisenbahnfährverladestelle" icon="ferry-terminal.png" type="node">
@@ -4077,22 +4057,22 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Name"
 					de.text="Name"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="uic_ref"
 					text="UIC-ID"
 					de.text="UIC-Bahnhofsnummer"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="uic_name"
 					text="UIC name"
 					de.text="UIC-Bahnhofsname"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="operator"
 					text="Operator"
 					de.text="Betreiber"
 					default=""
-					delete_if_empty="true" />
+					/>
 			</item>
 			<item name="Eisenbahnfährverlauf" icon="ferry-way.png" type="way">
 				<label text="Eisenbahnfährverlauf" />
@@ -4104,12 +4084,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Name"
 					de.text="Name"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="operator"
 					text="Operator"
 					de.text="Betreiber"
 					default=""
-					delete_if_empty="true" />
+					/>
 			</item>
 			<item name="Eisenbahnfährlinie" icon="ferry-line.png" type="relation">
 				<label text="Eisenbahnfährlinie" />
@@ -4123,12 +4103,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Name"
 					de.text="Name"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="operator"
 					text="Operator"
 					de.text="Betreiber"
 					default=""
-					delete_if_empty="true" />
+					/>
 			</item>
 			<separator />
 			<item name="Containerterminal" de.name="Container-Umschlagbahnhof" icon="containerterminal.png" type="node,closedway">
@@ -4144,12 +4124,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Name"
 					de.text="Name"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="wikipedia"
 					text="Wikipedia article in the format (Language):(Article)"
 					de.text="Wikipediaartikel in der Form (Sprachkürzel):(Artikelname)"
 					default=""
-					delete_if_empty="true" />
+					/>
 			</item>
 			<item name="Rollbock Siding" de.name="Rollwagen-/Rollschemelverladung" icon="carrier-truck-pit.png" type="node">
 				<label text="Rollbock Siding/Transporter Trailers Siding" de.text="Rollwagenverladung" />
@@ -4165,32 +4145,32 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Name"
 					de.text="Name"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="operator"
 					text="Operator"
 					de.text="Betreiber"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="uic_ref"
 					text="UIC-ID"
 					de.text="UIC-Bahnhofsnummer"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="uic_name"
 					text="UIC name"
 					de.text="UIC-Bahnhofsname"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="network"
 					text="Network"
 					de.text="Verkehrsverbund"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="image"
 					text="Image URL"
 					de.text="URL eines Bildes"
 					default=""
-					delete_if_empty="true" />
+					/>
 			</item>
 			<item name="Car Shuttle Station" de.name="Autozug-Verladung" icon="carshuttle.png" type="node">
 				<label text="Car Shuttle Station" de.text="Autozug-Verladung" />
@@ -4201,32 +4181,32 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					text="Name"
 					de.text="Name"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="operator"
 					text="Operator"
 					de.text="Betreiber"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="uic_ref"
 					text="UIC-ID"
 					de.text="UIC-Bahnhofsnummer"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="uic_name"
 					text="UIC name"
 					de.text="UIC-Bahnhofsname"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="network"
 					text="Network"
 					de.text="Verkehrsverbund"
 					default=""
-					delete_if_empty="true" />
+					/>
 				<text key="image"
 					text="Image URL"
 					de.text="URL eines Bildes"
 					default=""
-					delete_if_empty="true" />
+					/>
 			</item>
 		</group>
 		<item name="Turntable" de.name="Drehscheibe" icon="turntable.png" type="node,closedway">
@@ -4265,12 +4245,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				text="Name"
 				de.text="Name"
 				default=""
-				delete_if_empty="true" />
+				/>
 			<text key="wikipedia"
 				text="Wikipedia article in the format (Language):(Article)"
 				de.text="Wikipediaartikel in der Form (Sprachkürzel):(Artikelname)"
 				default=""
-				delete_if_empty="true" />
+				/>
 		</item>
 		<item name="Company with railway siding" de.name="Firma mit Gleisanschluss" icon="industrial.png" type="closedway">
 			<label text="Company with railway siding" de.text="Firma mit Gleisanschluss" />
@@ -4282,7 +4262,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				text="Name"
 				de.text="Name"
 				default=""
-				delete_if_empty="true" />
+				/>
 		</item>
 		<item name="Gate" de.name="Tor" icon="gate.png" type="node">
 			<label text="Gate" de.text="Tor" />


### PR DESCRIPTION
This drops some unneeded keys from the JOSM presets. Those settings are the default since [JOSM version 5155](https://josm.openstreetmap.de/changeset/5155/josm) anyway. At one place one of those tags was even at an illegal position, resulting in the AVG presets not being loadable without error. Finally the check is improved to use the JOSM XML schema to better verify the templates.