### PR TITLE
makefiles: use .POSIX flag to catch errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
-.phony: check
+.POSIX:
+
+.PHONY: check
 
 PHP := php
 
@@ -6,7 +8,7 @@ check-php: *.php api/*.php
 
 check:
 	@for pf in $$(find . -name '*.php'); do \
-		$(PHP) -l $${pf} || exit 1; \
+		$(PHP) -l $${pf}; \
 	done
 	@make -C josm-presets $@
 	@make -C styles $@

--- a/josm-presets/Makefile
+++ b/josm-presets/Makefile
@@ -1,4 +1,4 @@
-.phony: check clean
+.PHONY: check clean
 
 PRESETFILES = at.zip at-signals-v2.zip de.zip de-avg-signals.zip de-signals-eso.zip
 

--- a/styles/Makefile
+++ b/styles/Makefile
@@ -1,4 +1,6 @@
-.phony: all
+.POSIX:
+
+.PHONY: all
 
 JSFILES = maxspeed.js signals.js standard.js
 
@@ -19,5 +21,5 @@ check: $(JSFILES)
 		false; \
 	fi
 	@for i in $(JSFILES); do \
-		python -m json.tool < $${i}on > /dev/null || exit 1; \
+		python -m json.tool < $${i}on > /dev/null; \
 	done


### PR DESCRIPTION
While at it uppercase the .PHONY target to match what the documentation says.