### PR TITLE
JOSM presets: drop presets that are already offered by JOSM itself

### DIFF
--- a/josm-presets/at.xml
+++ b/josm-presets/at.xml
@@ -3489,11 +3489,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<key key="railway"
 					value="track_scale" />
 			</item>
-			<item name="Kran" type="node">
-				<label text="Kran" />
-				<key key="man_made"
-					value="crane" />
-			</item>
 			<item name="Lademaßlehre" type="node">
 				<label text="Lademaßlehre" />
 				<key key="railway"
@@ -3712,17 +3707,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<text key="wikipedia"
 				text="Wikipedia article in the format (Language):(Article)"
 				de.text="Wikipediaartikel in der Form (Sprachkürzel):(Artikelname)"
-				/>
-		</item>
-		<item name="Firma mit Gleisanschluss" type="closedway">
-			<label text="Firma mit Gleisanschluss" />
-			<key key="landuse"
-				value="industrial" />
-			<key key="man_made"
-				value="works" />
-			<text key="name"
-				text="Name"
-				de.text="Name"
 				/>
 		</item>
 		<item name="Tor" type="node">

--- a/josm-presets/de.xml
+++ b/josm-presets/de.xml
@@ -3628,11 +3628,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<key key="railway"
 					value="track_scale" />
 			</item>
-			<item name="Crane" de.name="Kran" type="node">
-				<label text="Kran" />
-				<key key="man_made"
-					value="crane" />
-			</item>
 			<item name="Lademaßlehre" type="node">
 				<label text="Lademaßlehre" />
 				<key key="railway"
@@ -3851,17 +3846,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<text key="wikipedia"
 				text="Wikipedia article in the format (Language):(Article)"
 				de.text="Wikipediaartikel in der Form (Sprachkürzel):(Artikelname)"
-				/>
-		</item>
-		<item name="Company with railway siding" de.name="Firma mit Gleisanschluss" type="closedway">
-			<label text="Company with railway siding" de.text="Firma mit Gleisanschluss" />
-			<key key="landuse"
-				value="industrial" />
-			<key key="man_made"
-				value="works" />
-			<text key="name"
-				text="Name"
-				de.text="Name"
 				/>
 		</item>
 		<item name="Gate" de.name="Tor" type="node">


### PR DESCRIPTION
man_made=works may even be incorrect, and since it is not railway specific in any way drop it.