### PR TITLE
only show bridges and tunnels on level zoom 10 and higher

### DIFF
--- a/styles/standard.mapcss
+++ b/styles/standard.mapcss
@@ -48,21 +48,7 @@ way|z10-[railway=light_rail]
 /***********/
 /* bridges */
 /***********/
-way|z2-5[railway=rail][bridge=yes]::bridges
-{
-	z-index: 1;
-	casing-width: 1.5;
-	casing-color: #797979;
-	linejoin: butt;
-}
-way|z6-8[railway=rail][bridge=yes]::bridges
-{
-	z-index: 1;
-	casing-width: 2.5;
-	casing-color: #797979;
-	linejoin: butt;
-}
-way|z9-[bridge=yes].tracks::bridges
+way|z10-[bridge=yes].tracks::bridges
 {
 	z-index: 1;
 	casing-width: 3.5;
@@ -100,7 +86,7 @@ way|z9-[railway=razed]
 /*************************************************************/
 /* tunnel label (not render if the track has a track number) */
 /*************************************************************/
-way|z9-[tunnel=yes][!"railway:track_ref"].tracks::tunnels
+way|z10-[tunnel=yes][!"railway:track_ref"].tracks::tunnels
 {
 	z-index: 4001;
 	text-position: line;
@@ -116,7 +102,7 @@ way|z9-[tunnel=yes][!"railway:track_ref"].tracks::tunnels
 /*************************/
 /* tunnels color (white) */
 /*************************/
-way[tunnel=yes].tracks::tunnels
+way|z10-[tunnel=yes].tracks::tunnels
 {
 	z-index: 4000;
 	width: 6;


### PR DESCRIPTION
Otherwise it clutters the lines too much as the objects become too small.

This fixes #186. This depends on #399.