### PR TITLE
Remove Defaults which May Impair Data Quality

### DIFF
--- a/josm-presets/de-signals-eso.xml
+++ b/josm-presets/de-signals-eso.xml
@@ -62,12 +62,10 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<check key="railway:signal:distant:shortened"
 						text="Shortened distance"
 						de.text="Verkürzter Bremsweg"
-						default="off"
 						/>
 					<check key="railway:signal:distant:repeated"
 						text="Repeated Signal"
 						de.text="Vorsignalwiederholer"
-						default="off"
 						/>
 					<space />
 					<preset_link preset_name="Richtungsvoranzeiger (Zs 2v)" />
@@ -122,7 +120,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<check key="railway:signal:combined:shortened"
 						text="Shortened distance"
 						de.text="Verkürzter Bremsweg"
-						default="off"
 						/>
 					<combo key="railway:signal:combined:function"
 						text="Signal function"
@@ -278,7 +275,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<check key="railway:signal:distant:shortened"
 					text="Shortened distance"
 					de.text="Verkürzter Bremsweg (Weißer Bremspfeil)"
-					default="off"
 					/>
 				<space />
 				<preset_link preset_name="Richtungsanzeiger (Zs 2)" />
@@ -468,12 +464,11 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<check key="railway:signal:distant:repeated"
 						text="Repeated Signal"
 						de.text="Vorsignalwiederholer"
-						default="off"
 						/>
 					<check key="railway:signal:distant:shortened"
 						text="Shortened Breaking Distance"
 						de.text="Reduzierter Bremswegabstand"
-						default="off"/>
+						/>
 					<space />
 					<preset_link preset_name="Richtungsvoranzeiger (Zs 2v)" />
 				</item>
@@ -492,7 +487,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<check key="railway:signal:combined:deactivated"
 						text="Out of order"
 						de.text="Ungültigkeitskreuz"
-						default="off"
 						/>
 					<combo key="railway:signal:position"
 						text="Signal position"
@@ -657,12 +651,10 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<check key="railway:signal:distant:shortened"
 						text="Shortened distance"
 						de.text="Verkürzter Bremsweg"
-						default="off"
 						/>
 					<check key="railway:signal:distant:repeated"
 						text="Repeated Signal"
 						de.text="Vorsignalwiederholer"
-						default="off"
 						/>
 					<space />
 					<preset_link preset_name="Richtungsvoranzeiger (Zs 2v)" />
@@ -860,7 +852,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<check key="railway:signal:distant:repeated"
 						text="Repeated Signal"
 						de.text="Vorsignalwiederholer"
-						default="off"
 						/>
 					<space />
 					<preset_link preset_name="Richtungsvoranzeiger (Zs 2v)" />
@@ -915,12 +906,10 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<check key="railway:signal:distant:shortened"
 						text="Shortened distance"
 						de.text="Verkürzter Bremsweg"
-						default="off"
 						/>
 					<check key="railway:signal:distant:repeated"
 						text="Repeated Signal"
 						de.text="Vorsignalwiederholer"
-						default="off"
 						/>
 					<space />
 					<preset_link preset_name="Richtungsvoranzeiger (Zs 2v)" />
@@ -1011,7 +1000,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<check key="railway:signal:distant:shortened"
 					text="Shortened distance"
 					de.text="Verkürzter Bremsweg"
-					default="off"
 					/>
 			</item>
 			<item name="Kreuztafel (So 106)" icon="de/so106-32.png" type="node">
@@ -1086,12 +1074,10 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<check key="railway:signal:crossing:repeated"
 						text="Repeated"
 						de.text="Signalwiederholer (weiße Scheibe)"
-						default="off"
 						/>
 					<check key="railway:signal:crossing:shortened"
 						text="Shortened distance"
 						de.text="Verkürzter Bremswegabstand (weißes Dreieck)"
-						default="off"
 						/>
 				</item>
 				<item name="Bü-Überwachungssignal erwarten (Bü 2/So 15)" icon="de/bue2-ds-28.png" type="node">
@@ -1103,7 +1089,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<check key="railway:signal:crossing_distant:deactivated"
 						text="Out of order"
 						de.text="Ungültigkeitskreuz"
-						default="off"
 						/>
 					<combo key="railway:signal:position"
 						text="Signal position"
@@ -1129,12 +1114,10 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<check key="railway:signal:crossing_distant:repeated"
 						text="Repeated"
 						de.text="Signalwiederholer (weiße Scheibe)"
-						default="off"
 						/>
 					<check key="railway:signal:crossing_distant:shortened"
 						text="Shortened distance"
 						de.text="Verkürzter Bremswegabstand (weißes Dreieck)"
-						default="off"
 						/>
 				</item>
 				<item de.name="Einschaltkontakt Bahnübergang/Merktafel (Bü 3)"
@@ -1236,7 +1219,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<check key="railway:signal:whistle:twice"
 						text="Whistle twice?"
 						de.text="Doppelte Pfeiftafel?"
-						default="off"
 						/>
 					<check key="railway:signal:whistle:only_transit"
 						text="Whistle only when train does not stop before crossing?"
@@ -1311,7 +1293,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<check key="railway:signal:crossing_info:repeated"
 						text="Repeated"
 						de.text="Signalwiederholer (weiße Scheibe)"
-						default="off"
 						/>
 					<combo key="railway:signal:crossing_info:height"
 						text="Signal height"
@@ -1354,7 +1335,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<check key="railway:signal:crossing_hint:repeated"
 						text="Repeated"
 						de.text="Signalwiederholer (weiße Scheibe)"
-						default="off"
 						/>
 					<combo key="railway:signal:crossing_hint:height"
 						text="Signal height"
@@ -2533,7 +2513,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<check key="railway:signal:catenary_mast"
 					text="On catenary mast"
 					de.text="Am Oberleitungsmast"
-					default="off"
 					/>
 				<text key="ref"
 					text="Block reference"
@@ -2572,7 +2551,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<check key="railway:signal:catenary_mast"
 					text="On catenary mast"
 					de.text="Am Oberleitungsmast"
-					default="off"
 					/>
 				<key key="railway:signal:train_protection"
 					value="DE-ESO:lzb-bereichskennzeichen" />


### PR DESCRIPTION
Example: You often cannot recognize if a distant signal is a repeater or not while passing it with a fast train. That's why this checkbox should not have a default value.