### PR TITLE
break on shell errors in a portable way

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.POSIX:
+SHELL = /bin/sh -e
 
 .PHONY: check
 

--- a/josm-presets/Makefile
+++ b/josm-presets/Makefile
@@ -1,3 +1,5 @@
+SHELL = /bin/sh -e
+
 .PHONY: check clean
 
 PRESETFILES = at.zip at-signals-v2.zip de.zip de-avg-signals.zip de-signals-eso.zip

--- a/styles/Makefile
+++ b/styles/Makefile
@@ -1,4 +1,4 @@
-.POSIX:
+SHELL = /bin/sh -e
 
 .PHONY: all
 


### PR DESCRIPTION
.POSIX requires newer versions of make, which is e.g. not present on Travis CI.