### PR TITLE
Improve Handling of Ks Signals which Cannot Display Default States

### DIFF
--- a/josm-presets/de-signals-eso.xml
+++ b/josm-presets/de-signals-eso.xml
@@ -189,9 +189,9 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						text="Signal states"
 						de.text="Signalzustände"
 						delimiter="|"
-						values="DE-ESO:hp0;DE-ESO:ks1|DE-ESO:hp0;DE-ESO:ks1;DE-ESO:kennlicht|DE-ESO:hp0;DE-ESO:ks1;off"
-						de.display_values="Hp 0 und Ks 1|Hp 0, Ks 1 und Kennlicht|Hp 0, Ks 1 und Dunkelschaltung"
-						display_values="Hp 0 and Ks 1|Hp 0, Ks 1 and marker light|Hp 0, Ks 1 and dark" />
+						values="DE-ESO:hp0;DE-ESO:ks1|DE-ESO:hp0;DE-ESO:ks1;DE-ESO:kennlicht|DE-ESO:hp0;DE-ESO:ks1;off|DE-ESO:hp0;DE-ESO:kennlicht|DE-ESO:hp0"
+						de.display_values="Hp 0 und Ks 1|Hp 0, Ks 1 und Kennlicht|Hp 0, Ks 1 und Dunkelschaltung|Hp 0, Kennlicht|Hp 0 ausschließlich"
+						display_values="Hp 0 and Ks 1|Hp 0, Ks 1 and marker light|Hp 0, Ks 1 and dark|Hp 0, Kennlicht|Hp 0 only" />
 					<combo key="railway:signal:main:function"
 						text="Signal function"
 						de.text="Signalaufgabe"

--- a/styles/signals.mapcss
+++ b/styles/signals.mapcss
@@ -538,10 +538,10 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-
 /*****************************/
 /* DE distant signal type Ks */
 /*****************************/
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:ks"]["railway:signal:distant:form"=light]["railway:signal:distant:states"=~/DE-ESO:ks1;DE-ESO:ks2(;(off|DE-ESO:kennlicht|\?))*$/]["railway:signal:distant:shortened"="no"]["railway:signal:distant:repeated"="no"],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:ks"]["railway:signal:distant:form"=light]["railway:signal:distant:states"=~/DE-ESO:ks1;DE-ESO:ks2(;(off|DE-ESO:kennlicht|\?))*$/][!"railway:signal:distant:shortened"]["railway:signal:distant:repeated"="no"],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:ks"]["railway:signal:distant:form"=light]["railway:signal:distant:states"=~/DE-ESO:ks1;DE-ESO:ks2(;(off|DE-ESO:kennlicht|\?))*$/]["railway:signal:distant:shortened"="no"][!"railway:signal:distant:repeated"],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:ks"]["railway:signal:distant:form"=light]["railway:signal:distant:states"=~/DE-ESO:ks1;DE-ESO:ks2(;(off|DE-ESO:kennlicht|\?))*$/][!"railway:signal:distant:shortened"][!"railway:signal:distant:repeated"]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:ks"]["railway:signal:distant:form"=light]["railway:signal:distant:shortened"="no"]["railway:signal:distant:repeated"="no"],
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:ks"]["railway:signal:distant:form"=light][!"railway:signal:distant:shortened"]["railway:signal:distant:repeated"="no"],
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:ks"]["railway:signal:distant:form"=light]["railway:signal:distant:shortened"="no"][!"railway:signal:distant:repeated"],
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:ks"]["railway:signal:distant:form"=light][!"railway:signal:distant:shortened"][!"railway:signal:distant:repeated"]
 {
 	z-index: 8000;
 	text: "ref";
@@ -560,7 +560,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="
 /**************************************/
 /* DE repeated distant signal type Ks */
 /**************************************/
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:ks"]["railway:signal:distant:form"=light]["railway:signal:distant:states"=~/DE-ESO:ks1;DE-ESO:ks2(;(off|DE-ESO:kennlicht|\?))*$/]["railway:signal:distant:repeated"="yes"]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:ks"]["railway:signal:distant:form"=light]["railway:signal:distant:repeated"="yes"]
 {
 	z-index: 8000;
 	text: "ref";
@@ -579,7 +579,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="
 /***************************************/
 /* DE shortened distant signal type Ks */
 /***************************************/
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:ks"]["railway:signal:distant:form"=light]["railway:signal:distant:states"="DE-ESO:ks1;DE-ESO:ks2"]["railway:signal:distant:shortened"="yes"]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:distant"="DE-ESO:ks"]["railway:signal:distant:form"=light]["railway:signal:distant:shortened"="yes"]
 {
 	z-index: 8000;
 	text: "ref";
@@ -1610,7 +1610,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:combined"=
 /**************************/
 /* DE main signal type Ks */
 /**************************/
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-ESO:ks"]["railway:signal:main:form"=light]["railway:signal:main:states"=~/^DE-ESO:hp0;DE-ESO:ks1(;(off|DE-ESO:kennlicht|\?))*$/]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-ESO:ks"]["railway:signal:main:form"=light]
 {
 	z-index: 10100;
 	text: "ref";
@@ -1629,8 +1629,8 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:main"="DE-
 /******************************/
 /* DE combined signal type Ks */
 /******************************/
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:combined"="DE-ESO:ks"]["railway:signal:combined:form"=light]["railway:signal:combined:states"=~/DE-ESO:hp0;DE-ESO:ks1;DE-ESO:ks2(;(off|DE-ESO:kennlicht|\?))*$/]["railway:signal:combined:shortened"="no"],
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:combined"="DE-ESO:ks"]["railway:signal:combined:form"=light]["railway:signal:combined:states"=~/DE-ESO:hp0;DE-ESO:ks1;DE-ESO:ks2(;(off|DE-ESO:kennlicht|\?))*$/][!"railway:signal:combined:shortened"]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:combined"="DE-ESO:ks"]["railway:signal:combined:form"=light]["railway:signal:combined:shortened"="no"],
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:combined"="DE-ESO:ks"]["railway:signal:combined:form"=light][!"railway:signal:combined:shortened"]
 {
 	z-index: 10200;
 	text: "ref";
@@ -1649,7 +1649,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:combined"=
 /****************************************/
 /* DE shortened combined signal type Ks */
 /****************************************/
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:combined"="DE-ESO:ks"]["railway:signal:combined:form"=light]["railway:signal:combined:states"=~/DE-ESO:hp0;DE-ESO:ks1;DE-ESO:ks2(;(off|DE-ESO:kennlicht|\?))*$/]["railway:signal:combined:shortened"="yes"]
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:combined"="DE-ESO:ks"]["railway:signal:combined:form"=light]["railway:signal:combined:shortened"="yes"]
 {
 	z-index: 10200;
 	text: "ref";


### PR DESCRIPTION
There are Ks signals which can only show Hp 0. There are Ks signals which can only show Ks 2. That's why I remove the requirement of `railway:signal:*:states` at Ks signals because we do not have more possibilities to differ different Ks subvariants at the map.