### PR TITLE
fix generated permalink if the base URL contains subdirectories

### DIFF
--- a/js/functions.js
+++ b/js/functions.js
@@ -78,7 +78,7 @@ function changeLanguage(lang)
 // returns a permalink storing all current settings (language, position, zoom, url params); style parameter is necessary, lang parameter is not necessary
 function getPermalinkUrl(style, lang)
 {
-	var url = root+(window.location.pathname.substr(1));
+	var url = window.location.origin + window.location.pathname;
 
 	url += '?lang='+((lang) ? lang : params['lang']);
 


### PR DESCRIPTION
If the base URL is not the server root the subdirectories were used from both the root variable and the current URL, leading to duplication of the directories which resulted in broken links.

Example:
  root = http://example.com/test/
  URL was http://example.com/test/index.php
  generated permalink was http://example.com/test/test/index.php

Iterate over both paths and drop the common values at the beginning of the path.