### PR TITLE
use shorter dashes for razed tracks

### DIFF
--- a/styles/standard.json
+++ b/styles/standard.json
@@ -161,7 +161,7 @@
 		{
 			"minzoom": 9,
 			"maxzoom": 19,
-			"symbol": "<g fill=\"none\" stroke=\"black\" stroke-width=\"4\"><path stroke-linecap=\"butt\" stroke-dasharray=\"11,8\" opacity=\"0.2\" d=\"M5 8 l32 0\" /></g><g fill=\"none\" stroke=\"#70584D\" stroke-width=\"3\"><path stroke-linecap=\"round\" stroke-dasharray=\"11,8\" opacity=\"0.6\" d=\"M5 8 l32 0\" /></g>",
+			"symbol": "<g fill=\"none\" stroke=\"black\" stroke-width=\"4\"><path stroke-linecap=\"butt\" stroke-dasharray=\"3,7\" opacity=\"0.2\" d=\"M5 8 l32 0\" /></g><g fill=\"none\" stroke=\"#70584D\" stroke-width=\"3\"><path stroke-linecap=\"round\" stroke-dasharray=\"3,7\" opacity=\"0.6\" d=\"M5 8 l32 0\" /></g>",
 			"caption": "Razed track"
 		},
 		{

--- a/styles/standard.mapcss
+++ b/styles/standard.mapcss
@@ -392,7 +392,7 @@ way|z9-[railway=abandoned]
 way|z9-[railway=razed]
 {
 	z-index: 200;
-	dashes: 11,8;
+	dashes: 3,7;
 	color: #70584D;
 	opacity: 0.6;
 	width: 3;


### PR DESCRIPTION
Those being longer than the ones of abandoned tracks is confusing.