### PR TITLE
Remove Defaults Which are not Necessary

### DIFF
--- a/josm-presets/at-signals-v2.xml
+++ b/josm-presets/at-signals-v2.xml
@@ -26,7 +26,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<check key="railway:signal:main:deactivated"
 				text="Out of order"
 				de.text="Ungültigkeitskreuz"
-				default="off"
 				/>
 			<combo key="railway:signal:position"
 				text="Signal position"
@@ -90,7 +89,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<check key="railway:signal:main:deactivated"
 				text="Out of order"
 				de.text="Ungültigkeitskreuz"
-				default="off"
 				/>
 			<combo key="railway:signal:position"
 				text="Signal position"
@@ -156,7 +154,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<check key="railway:signal:distant:deactivated"
 				text="Out of order"
 				de.text="Ungültigkeitskreuz"
-				default="off"
 				/>
 			<combo key="railway:signal:position"
 				text="Signal position"
@@ -199,7 +196,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<check key="railway:signal:distant:deactivated"
 				text="Out of order"
 				de.text="Ungültigkeitskreuz"
-				default="off"
 				/>
 			<combo key="railway:signal:position"
 				text="Signal position"
@@ -244,7 +240,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<check key="railway:signal:main:deactivated"
 				text="Out of order"
 				de.text="Ungültigkeitskreuz"
-				default="off"
 				/>
 			<combo key="railway:signal:position"
 				text="Signal position"
@@ -281,7 +276,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<check key="railway:signal:distant:deactivated"
 				text="Out of order"
 				de.text="Ungültigkeitskreuz"
-				default="off"
 				/>
 			<combo key="railway:signal:position"
 				text="Signal position"
@@ -315,7 +309,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<check key="railway:signal:minor:deactivated"
 				text="Out of order"
 				de.text="Ungültigkeitskreuz"
-				default="off"
 				/>
 			<combo key="railway:signal:position"
 				text="Signal position"
@@ -368,7 +361,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<check key="railway:signal:minor:deactivated"
 				text="Out of order"
 				de.text="Ungültigkeitskreuz"
-				default="off"
 				/>
 			<combo key="railway:signal:position"
 				text="Signal position"
@@ -409,7 +401,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<check key="railway:signal:minor:deactivated"
 				text="Out of order"
 				de.text="Ungültigkeitskreuz"
-				default="off"
 				/>
 			<combo key="railway:signal:position"
 				text="Signal position"
@@ -444,7 +435,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<check key="railway:signal:minor:deactivated"
 				text="Out of order"
 				de.text="Ungültigkeitskreuz"
-				default="off"
 				/>
 			<combo key="railway:signal:position"
 				text="Signal position"
@@ -485,7 +475,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<check key="railway:signal:shunting:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
-					default="off"
 					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
@@ -522,7 +511,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<check key="railway:signal:shunting:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
-					default="off"
 					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
@@ -557,7 +545,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<check key="railway:signal:shunting:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
-					default="off"
 					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
@@ -592,7 +579,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<check key="railway:signal:shunting:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
-					default="off"
 					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
@@ -629,7 +615,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<check key="railway:signal:humping:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
-					default="off"
 					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
@@ -668,7 +653,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<check key="railway:signal:speed_limit:deactivated"
 				text="Out of order"
 				de.text="Ungültigkeitskreuz"
-				default="off"
 				/>
 			<combo key="railway:signal:position"
 				text="Signal position"
@@ -713,7 +697,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<check key="railway:signal:speed_limit_distant:deactivated"
 				text="Out of order"
 				de.text="Ungültigkeitskreuz"
-				default="off"
 				/>
 			<combo key="railway:signal:position"
 				text="Signal position"
@@ -758,7 +741,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<check key="railway:signal:speed_limit:deactivated"
 				text="Out of order"
 				de.text="Ungültigkeitskreuz"
-				default="off"
 				/>
 			<combo key="railway:signal:position"
 				text="Signal position"
@@ -804,7 +786,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<check key="railway:signal:speed_limit_distant:deactivated"
 				text="Out of order"
 				de.text="Ungültigkeitskreuz"
-				default="off"
 				/>
 			<combo key="railway:signal:position"
 				text="Signal position"
@@ -845,7 +826,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<check key="railway:signal:speed_limit_distant:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
-					default="off"
 					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
@@ -885,7 +865,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<check key="railway:signal:speed_limit:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
-					default="off"
 					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
@@ -925,7 +904,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<check key="railway:signal:speed_limit:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
-					default="off"
 					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
@@ -964,7 +942,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<check key="railway:signal:electricity:deactivated"
 				text="Out of order"
 				de.text="Ungültigkeitskreuz"
-				default="off"
 				/>
 			<combo key="railway:signal:position"
 				text="Signal position"
@@ -1015,7 +992,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<check key="railway:signal:electricity:deactivated"
 				text="Out of order"
 				de.text="Ungültigkeitskreuz"
-				default="off"
 				/>
 			<combo key="railway:signal:position"
 				text="Signal position"
@@ -1050,7 +1026,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<check key="railway:signal:crossing:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
-					default="off"
 					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
@@ -1081,7 +1056,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<check key="railway:signal:crossing_hint:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
-					default="off"
 					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
@@ -1119,7 +1093,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<check key="railway:signal:crossing_info:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
-					default="off"
 					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
@@ -1157,7 +1130,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<check key="railway:signal:crossing_distant:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
-					default="off"
 					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
@@ -1186,7 +1158,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<check key="railway:signal:crossing_distant:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
-					default="off"
 					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
@@ -1219,7 +1190,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<check key="railway:signal:whistle:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
-					default="off"
 					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
@@ -1248,7 +1218,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<check key="railway:signal:whistle:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
-					default="off"
 					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
@@ -1277,7 +1246,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<check key="railway:signal:whistle:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
-					default="off"
 					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
@@ -1307,7 +1275,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<check key="railway:signal:stop:deactivated"
 				text="Out of order"
 				de.text="Ungültigkeitskreuz"
-				default="off"
 				/>
 			<combo key="railway:signal:position"
 				text="Signal position"
@@ -1345,7 +1312,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<check key="railway:signal:station_distant:deactivated"
 				text="Out of order"
 				de.text="Ungültigkeitskreuz"
-				default="off"
 				/>
 			<combo key="railway:signal:position"
 				text="Signal position"
@@ -1373,7 +1339,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<check key="railway:signal:resetting_switch:deactivated"
 				text="Out of order"
 				de.text="Ungültigkeitskreuz"
-				default="off"
 				/>
 			<combo key="railway:signal:position"
 				text="Signal position"
@@ -1470,7 +1435,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<check key="railway:signal:brake_test:deactivated"
 				text="Out of order"
 				de.text="Ungültigkeitskreuz"
-				default="off"
 				/>
 			<combo key="railway:signal:position"
 				text="Signal position"
@@ -1500,7 +1464,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<check key="railway:signal:departure:deactivated"
 				text="Out of order"
 				de.text="Ungültigkeitskreuz"
-				default="off"
 				/>
 			<combo key="railway:signal:position"
 				text="Signal position"
@@ -1528,7 +1491,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<check key="railway:signal:departure:deactivated"
 				text="Out of order"
 				de.text="Ungültigkeitskreuz"
-				default="off"
 				/>
 			<combo key="railway:signal:position"
 				text="Signal position"
@@ -1565,7 +1527,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<check key="railway:signal:snowplow:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
-					default="off"
 					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
@@ -1595,7 +1556,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<check key="railway:signal:snowplow:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
-					default="off"
 					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
@@ -1625,7 +1585,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<check key="railway:signal:snowplow:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
-					default="off"
 					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
@@ -1656,7 +1615,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<check key="railway:signal:train_protection:deactivated"
 				text="Out of order"
 				de.text="Ungültigkeitskreuz"
-				default="off"
 				/>
 			<combo key="railway:signal:position"
 				text="Signal position"
@@ -1702,7 +1660,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<check key="railway:signal:main_repeated:deactivated"
 				text="Out of order"
 				de.text="Ungültigkeitskreuz"
-				default="off"
 				/>
 			<combo key="railway:signal:position"
 				text="Signal position"
@@ -1739,7 +1696,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<check key="railway:signal:minor:deactivated"
 				text="Out of order"
 				de.text="Ungültigkeitskreuz"
-				default="off"
 				/>
 			<combo key="railway:signal:position"
 				text="Signal position"
@@ -1774,7 +1730,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<check key="railway:signal:minor:deactivated"
 				text="Out of order"
 				de.text="Ungültigkeitskreuz"
-				default="off"
 				/>
 			<combo key="railway:signal:position"
 				text="Signal position"
@@ -1809,7 +1764,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<check key="railway:signal:lzb:deactivated"
 				text="Out of order"
 				de.text="Ungültigkeitskreuz"
-				default="off"
 				/>
 			<combo key="railway:signal:position"
 				text="Signal position"

--- a/josm-presets/de-signals-bostrab.xml
+++ b/josm-presets/de-signals-bostrab.xml
@@ -27,7 +27,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<check key="railway:signal:main:deactivated"
 				text="Out of order"
 				de.text="Ungültigkeitskreuz"
-				default="off"
 				/>
 			<combo key="railway:signal:position"
 				text="Signal position"
@@ -79,7 +78,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<check key="railway:signal:main:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
-					default="off"
 					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
@@ -130,7 +128,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<check key="railway:signal:combined:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
-					default="off"
 					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
@@ -181,7 +178,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<check key="railway:signal:distant:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
-					default="off"
 					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
@@ -232,7 +228,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<check key="railway:signal:departure:deactivated"
 				text="Out of order"
 				de.text="Ungültigkeitskreuz"
-				default="off"
 				/>
 			<combo key="railway:signal:position"
 				text="Signal position"
@@ -269,7 +264,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<check key="railway:signal:speed_limit_distant:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
-					default="off"
 					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
@@ -324,7 +318,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<check key="railway:signal:speed_limit_distant:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
-					default="off"
 					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
@@ -370,7 +363,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<check key="railway:signal:speed_limit:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
-					default="off"
 					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
@@ -425,7 +417,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<check key="railway:signal:speed_limit:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
-					default="off"
 					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
@@ -471,7 +462,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<check key="railway:signal:speed_limit:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
-					default="off"
 					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
@@ -506,7 +496,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<check key="railway:signal:speed_limit:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
-					default="off"
 					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
@@ -546,7 +535,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<check key="railway:signal:minor:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
-					default="off"
 					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
@@ -578,7 +566,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<check key="railway:signal:minor:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
-					default="off"
 					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
@@ -611,7 +598,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<check key="railway:signal:minor:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
-					default="off"
 					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
@@ -642,7 +628,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<check key="railway:signal:ring:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
-					default="off"
 					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
@@ -672,7 +657,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<check key="railway:signal:stop:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
-					default="off"
 					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
@@ -715,7 +699,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<check key="railway:signal:electricity:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
-					default="off"
 					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
@@ -754,7 +737,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<check key="railway:signal:electricity:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
-					default="off"
 					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
@@ -793,7 +775,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<check key="railway:signal:electricity:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
-					default="off"
 					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
@@ -832,7 +813,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<check key="railway:signal:electricity:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
-					default="off"
 					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
@@ -871,7 +851,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<check key="railway:signal:electricity:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
-					default="off"
 					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
@@ -910,7 +889,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<check key="railway:signal:electricity:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
-					default="off"
 					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
@@ -955,7 +933,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<check key="railway:signal:switch:deactivated"
 				text="Out of order"
 				de.text="Ungültigkeitskreuz"
-				default="off"
 				/>
 			<combo key="railway:signal:position"
 				text="Signal position"
@@ -1011,7 +988,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<check key="railway:signal:crossing:deactivated"
 				text="Out of order"
 				de.text="Ungültigkeitskreuz"
-				default="off"
 				/>
 			<combo key="railway:signal:position"
 				text="Signal position"
@@ -1052,7 +1028,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<check key="railway:signal:crossing_distant:deactivated"
 				text="Out of order"
 				de.text="Ungültigkeitskreuz"
-				default="off"
 				/>
 			<combo key="railway:signal:position"
 				text="Signal position"
@@ -1084,7 +1059,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<check key="railway:signal:train_protection:deactivated"
 				text="Out of order"
 				de.text="Ungültigkeitskreuz"
-				default="off"
 				/>
 			<combo key="railway:signal:position"
 				text="Signal position"
@@ -1116,7 +1090,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<check key="railway:signal:train_protection:deactivated"
 				text="Out of order"
 				de.text="Ungültigkeitskreuz"
-				default="off"
 				/>
 			<combo key="railway:signal:position"
 				text="Signal position"
@@ -1148,7 +1121,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<check key="railway:signal:passing:deactivated"
 				text="Out of order"
 				de.text="Ungültigkeitskreuz"
-				default="off"
 				/>
 			<combo key="railway:signal:position"
 				text="Signal position"
@@ -1185,7 +1157,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<check key="railway:signal:passing:deactivated"
 				text="Out of order"
 				de.text="Ungültigkeitskreuz"
-				default="off"
 				/>
 			<combo key="railway:signal:position"
 				text="Signal position"
@@ -1228,7 +1199,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<check key="railway:signal:main:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
-					default="off"
 					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
@@ -1274,7 +1244,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<check key="railway:signal:shunting:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
-					default="off"
 					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
@@ -1316,7 +1285,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<check key="railway:signal:distant:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
-					default="off"
 					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
@@ -1362,7 +1330,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<check key="railway:signal:speed_limit_distant:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
-					default="off"
 					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
@@ -1410,7 +1377,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<check key="railway:signal:departure:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
-					default="off"
 					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
@@ -1446,7 +1412,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<check key="railway:signal:electricity:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
-					default="off"
 					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
@@ -1485,7 +1450,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<check key="railway:signal:electricity:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
-					default="off"
 					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
@@ -1525,7 +1489,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<check key="railway:signal:minor:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
-					default="off"
 					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
@@ -1556,7 +1519,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<check key="railway:signal:speed_limit_distant:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
-					default="off"
 					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
@@ -1611,7 +1573,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<check key="railway:signal:minor_distant:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
-					default="off"
 					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
@@ -1649,7 +1610,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<check key="railway:signal:speed_limit:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
-					default="off"
 					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
@@ -1698,7 +1658,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<check key="railway:signal:speed_limit:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
-					default="off"
 					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
@@ -1742,7 +1701,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<check key="railway:signal:speed_limit:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
-					default="off"
 					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
@@ -1779,7 +1737,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<check key="railway:signal:stop:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
-					default="off"
 					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
@@ -1820,7 +1777,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<check key="railway:signal:wrong_road:deactivated"
 						text="Out of order"
 						de.text="Ungültigkeitskreuz"
-						default="off"
 						/>
 					<combo key="railway:signal:position"
 						text="Signal position"
@@ -1854,7 +1810,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<check key="railway:signal:route:deactivated"
 						text="Out of order"
 						de.text="Ungültigkeitskreuz"
-						default="off"
 						/>
 					<combo key="railway:signal:position"
 						text="Signal position"
@@ -1895,7 +1850,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<check key="railway:signal:switch:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
-					default="off"
 					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
@@ -1940,7 +1894,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<check key="railway:signal:switch:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
-					default="off"
 					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
@@ -1998,7 +1951,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<check key="railway:signal:main:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
-					default="off"
 					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
@@ -2049,7 +2001,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<check key="railway:signal:combined:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
-					default="off"
 					/>
 				<combo key="railway:signal:position"
 					text="Signal position"

--- a/josm-presets/de-signals-eso.xml
+++ b/josm-presets/de-signals-eso.xml
@@ -27,7 +27,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<check key="railway:signal:distant:deactivated"
 						text="Out of order"
 						de.text="Ungültigkeitskreuz"
-						default="off"
 						/>
 					<combo key="railway:signal:position"
 						text="Signal position"
@@ -86,7 +85,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<check key="railway:signal:combined:deactivated"
 						text="Out of order"
 						de.text="Ungültigkeitskreuz"
-						default="off"
 						/>
 					<combo key="railway:signal:position"
 						text="Signal position"
@@ -160,7 +158,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<check key="railway:signal:main:deactivated"
 						text="Out of order"
 						de.text="Ungültigkeitskreuz"
-						default="off"
 						/>
 					<combo key="railway:signal:position"
 						text="Signal position"
@@ -228,7 +225,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<check key="railway:signal:combined:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
-					default="off"
 					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
@@ -303,7 +299,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<check key="railway:signal:combined:deactivated"
 						text="Out of order"
 						de.text="Ungültigkeitskreuz"
-						default="off"
 						/>
 					<combo key="railway:signal:position"
 						text="Signal position"
@@ -370,7 +365,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<check key="railway:signal:main:deactivated"
 						text="Out of order"
 						de.text="Ungültigkeitskreuz"
-						default="off"
 						/>
 					<combo key="railway:signal:position"
 						text="Signal position"
@@ -437,7 +431,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<check key="railway:signal:distant:deactivated"
 						text="Out of order"
 						de.text="Ungültigkeitskreuz"
-						default="off"
 						/>
 					<combo key="railway:signal:position"
 						text="Signal position"
@@ -558,7 +551,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<check key="railway:signal:main:deactivated"
 						text="Out of order"
 						de.text="Ungültigkeitskreuz"
-						default="off"
 						/>
 					<combo key="railway:signal:position"
 						text="Signal position"
@@ -626,7 +618,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<check key="railway:signal:distant:deactivated"
 						text="Out of order"
 						de.text="Ungültigkeitskreuz"
-						default="off"
 						/>
 					<combo key="railway:signal:position"
 						text="Signal position"
@@ -680,7 +671,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<check key="railway:signal:main:deactivated"
 						text="Out of order"
 						de.text="Ungültigkeitskreuz"
-						default="off"
 						/>
 					<combo key="railway:signal:position"
 						text="Signal position"
@@ -747,7 +737,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<check key="railway:signal:main:deactivated"
 						text="Out of order"
 						de.text="Ungültigkeitskreuz"
-						default="off"
 						/>
 					<combo key="railway:signal:position"
 						text="Signal position"
@@ -818,7 +807,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<check key="railway:signal:distant:deactivated"
 						text="Out of order"
 						de.text="Ungültigkeitskreuz"
-						default="off"
 						/>
 					<combo key="railway:signal:position"
 						text="Signal position"
@@ -879,7 +867,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<check key="railway:signal:distant:deactivated"
 						text="Out of order"
 						de.text="Ungültigkeitskreuz"
-						default="off"
 						/>
 					<combo key="railway:signal:position"
 						text="Signal position"
@@ -943,7 +930,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<check key="railway:signal:main:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
-					default="off"
 					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
@@ -984,7 +970,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<check key="railway:signal:distant:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
-					default="off"
 					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
@@ -1021,7 +1006,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<check key="railway:signal:distant:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
-					default="off"
 					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
@@ -1052,7 +1036,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<check key="railway:signal:crossing:deactivated"
 						text="Out of order"
 						de.text="Ungültigkeitskreuz"
-						default="off"
 						/>
 					<combo key="railway:signal:position"
 						text="Signal position"
@@ -1144,7 +1127,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<check key="railway:signal:crossing_distant:deactivated"
 						text="Out of order"
 						de.text="Ungültigkeitskreuz"
-						default="off"
 						/>
 					<combo key="railway:signal:position"
 						text="Signal position"
@@ -1178,7 +1160,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<check key="railway:signal:crossing_distant:deactivated"
 						text="Out of order"
 						de.text="Ungültigkeitskreuz"
-						default="off"
 						/>
 					<combo key="railway:signal:position"
 						text="Signal position"
@@ -1203,7 +1184,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<check key="railway:signal:whistle:deactivated"
 						text="Out of order"
 						de.text="Ungültigkeitskreuz"
-						default="off"
 						/>
 					<combo key="railway:signal:position"
 						text="Signal position"
@@ -1245,7 +1225,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<check key="railway:signal:ring:deactivated"
 						text="Out of order"
 						de.text="Ungültigkeitskreuz"
-						default="off"
 						/>
 					<combo key="railway:signal:position"
 						text="Signal position"
@@ -1277,7 +1256,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<check key="railway:signal:crossing_info:deactivated"
 						text="Out of order"
 						de.text="Ungültigkeitskreuz"
-						default="off"
 						/>
 					<combo key="railway:signal:position"
 						text="Signal position"
@@ -1319,7 +1297,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<check key="railway:signal:crossing_hint:deactivated"
 						text="Out of order"
 						de.text="Ungültigkeitskreuz"
-						default="off"
 						/>
 					<combo key="railway:signal:position"
 						text="Signal position"
@@ -1367,7 +1344,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<check key="railway:signal:minor:deactivated"
 						text="Out of order"
 						de.text="Ungültigkeitskreuz"
-						default="off"
 						/>
 					<combo key="railway:signal:position"
 						text="Signal position"
@@ -1414,7 +1390,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<check key="railway:signal:minor:deactivated"
 						text="Out of order"
 						de.text="Ungültigkeitskreuz"
-						default="off"
 						/>
 					<combo key="railway:signal:position"
 						text="Signal position"
@@ -1449,7 +1424,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<check key="railway:signal:minor_distant:deactivated"
 						text="Out of order"
 						de.text="Ungültigkeitskreuz"
-						default="off"
 						/>
 					<combo key="railway:signal:position"
 						text="Signal position"
@@ -1486,7 +1460,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<check key="railway:signal:shunting:deactivated"
 						text="Out of order"
 						de.text="Ungültigkeitskreuz"
-						default="off"
 						/>
 					<combo key="railway:signal:position"
 						text="Signal position"
@@ -1521,7 +1494,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<check key="railway:signal:shunting:deactivated"
 						text="Out of order"
 						de.text="Ungültigkeitskreuz"
-						default="off"
 						/>
 					<combo key="railway:signal:position"
 						text="Signal position"
@@ -1570,7 +1542,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<check key="railway:signal:humping:deactivated"
 						text="Out of order"
 						de.text="Ungültigkeitskreuz"
-						default="off"
 						/>
 					<combo key="railway:signal:position"
 						text="Signal position"
@@ -1628,7 +1599,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<check key="railway:signal:route:deactivated"
 						text="Out of order"
 						de.text="Ungültigkeitskreuz"
-						default="off"
 						/>
 					<combo key="railway:signal:position"
 						text="Signal position"
@@ -1661,7 +1631,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<check key="railway:signal:route_distant:deactivated"
 						text="Out of order"
 						de.text="Ungültigkeitskreuz"
-						default="off"
 						/>
 					<combo key="railway:signal:position"
 						text="Signal position"
@@ -1695,7 +1664,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<check key="railway:signal:speed_limit:deactivated"
 						text="Out of order"
 						de.text="Ungültigkeitskreuz"
-						default="off"
 						/>
 					<combo key="railway:signal:position"
 						text="Signal position"
@@ -1741,7 +1709,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<check key="railway:signal:speed_limit_distant:deactivated"
 						text="Out of order"
 						de.text="Ungültigkeitskreuz"
-						default="off"
 						/>
 					<combo key="railway:signal:position"
 						text="Signal position"
@@ -1787,7 +1754,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<check key="railway:signal:speed_limit:deactivated"
 						text="Out of order"
 						de.text="Ungültigkeitskreuz"
-						default="off"
 						/>
 					<combo key="railway:signal:position"
 						text="Signal position"
@@ -1829,7 +1795,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<check key="railway:signal:wrong_road:deactivated"
 						text="Out of order"
 						de.text="Ungültigkeitskreuz"
-						default="off"
 						/>
 					<combo key="railway:signal:position"
 						text="Signal position"
@@ -1864,7 +1829,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<check key="railway:signal:wrong_road:deactivated"
 						text="Out of order"
 						de.text="Ungültigkeitskreuz"
-						default="off"
 						/>
 					<combo key="railway:signal:position"
 						text="Signal position"
@@ -1900,7 +1864,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<check key="railway:signal:short_route:deactivated"
 						text="Out of order"
 						de.text="Ungültigkeitskreuz"
-						default="off"
 						/>
 					<combo key="railway:signal:position"
 						text="Signal position"
@@ -1945,7 +1908,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<check key="railway:signal:speed_limit:deactivated"
 						text="Out of order"
 						de.text="Ungültigkeitskreuz"
-						default="off"
 						/>
 					<combo key="railway:signal:position"
 						text="Signal position"
@@ -1999,7 +1961,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<check key="railway:signal:speed_limit_distant:deactivated"
 						text="Out of order"
 						de.text="Ungültigkeitskreuz"
-						default="off"
 						/>
 					<combo key="railway:signal:position"
 						text="Signal position"
@@ -2052,7 +2013,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<check key="railway:signal:resetting_switch:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
-					default="off"
 					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
@@ -2089,7 +2049,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<check key="railway:signal:resetting_switch_distant:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
-					default="off"
 					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
@@ -2125,7 +2084,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<check key="railway:signal:expected_position:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
-					default="off"
 					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
@@ -2161,7 +2119,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<check key="railway:signal:stop:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
-					default="off"
 					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
@@ -2201,7 +2158,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<check key="railway:signal:stop_demand:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
-					default="off"
 					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
@@ -2235,7 +2191,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<check key="railway:signal:station_distant:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
-					default="off"
 					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
@@ -2263,7 +2218,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<check key="railway:signal:snowplow:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
-					default="off"
 					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
@@ -2307,7 +2261,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<check key="railway:signal:train_protection:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
-					default="off"
 					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
@@ -2341,7 +2294,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<check key="railway:signal:electricity:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
-					default="off"
 					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
@@ -2406,7 +2358,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<check key="railway:signal:main_repeated:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
-					default="off"
 					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
@@ -2435,7 +2386,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<check key="railway:signal:departure:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
-					default="off"
 					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
@@ -2470,7 +2420,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<check key="railway:signal:brake_test:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
-					default="off"
 					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
@@ -2504,7 +2453,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<check key="railway:signal:train_protection:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
-					default="off"
 					/>
 				<combo key="railway:signal:position"
 					text="Signal position"
@@ -2542,7 +2490,6 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<check key="railway:signal:train_protection:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
-					default="off"
 					/>
 				<combo key="railway:signal:position"
 					text="Signal position"


### PR DESCRIPTION
Most mapped signals are not out of order and therefore we do not have to set a default for them. It just creates unnecessary data.