### PR TITLE
make the ZIP archive creation less verbose

### DIFF
--- a/josm-presets/Makefile
+++ b/josm-presets/Makefile
@@ -7,8 +7,8 @@ PRESETFILES = at.zip at-signals-v2.zip de.zip de-avg-signals.zip de-signals-eso.
 all: $(PRESETFILES)
 
 %.zip: %.xml
-	@zip $@ $^
-	cd ../styles/icons; grep -o 'icon="[^"]*' ../../josm-presets/$^ | sed 's/^icon="//' | zip -r ../../josm-presets/$@ -@
+	@zip $@ $^ | sed '/^[ \t]*adding: /d'
+	cd ../styles/icons; grep -o 'icon="[^"]*' ../../josm-presets/$^ | sed 's/^icon="//' | zip -r ../../josm-presets/$@ -@ | sed '/^[ \t]*adding: /d'
 
 check: *.xml
 	@xmllint --schema http://josm.openstreetmap.de/tagging-preset-1.0 --noout *.xml

--- a/styles/Makefile
+++ b/styles/Makefile
@@ -11,8 +11,8 @@ all: $(JSFILES) $(ZIPFILES)
 	python ../renderer/mapcss_converter.py --mapcss $^ --icons-path .
 
 %.zip: %.mapcss
-	zip $@ $^
-	grep -o 'icon-image: "[^"]*' $^ | sed 's/icon-image: "//' | zip -r $@ -@
+	zip $@ $^ | sed '/^[ \t]*adding: /d'
+	grep -o 'icon-image: "[^"]*' $^ | sed 's/icon-image: "//' | zip -r $@ -@ | sed '/^[ \t]*adding: /d'
 
 clean:
 	rm -f $(JSFILES)


### PR DESCRIPTION
Suppress the messages about added files, only show all others.

One can't simply use "-q" here as it would suppress also the warnings. One can't use "grep -v" either because that would return with 1 in case no output was written, i.e. all lines were suppressed.