### PR TITLE
maxspeed legend: fix zoom level of Zs3 and Zs3v signals

### DIFF
--- a/styles/maxspeed.json
+++ b/styles/maxspeed.json
@@ -183,12 +183,12 @@
 			"caption": "381-400 km/h (disused/under construction)"
 		},
 		{
-			"minzoom": 16,
+			"minzoom": 17,
 			"icon": "icons/de/zs3v-50-sign-down-22.png",
 			"caption": "Zs 3v Geschwindigkeits&shy;voranzeiger"
 		},
 		{
-			"minzoom": 16,
+			"minzoom": 17,
 			"icon": "icons/de/zs3-60-sign-up-22.png",
 			"caption": "Zs 3 Geschwindigkeits&shy;anzeiger"
 		},


### PR DESCRIPTION
These are not shown on zoom 16 anymore since 98947aa41b3cf64359a6d37af04b65e0c7ee0f77.