### PR TITLE
Change Path to Level Crossing Icon

### DIFF
--- a/josm-presets/de.xml
+++ b/josm-presets/de.xml
@@ -1397,7 +1397,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			</roles>
 		</item>
 		<separator />
-		<item name="Level Crossing" de.name="Bahnübergang" icon="presets/level_crossing.png" type="node">
+		<item name="Level Crossing" de.name="Bahnübergang" icon="styles/standard/transport/railway/level_crossing.svg" type="node">
 			<label text="Bahnübergang" />
 			<space />
 			<key key="railway"


### PR DESCRIPTION
This fixes #489.

@rurseekatze Some saltires are mounted in Germany in this way (i.e. rotated by 90°).