### PR TITLE
maxspeed style: fix text/color mismatch when speed is shown only for one direction

### DIFF
--- a/styles/maxspeed.mapcss
+++ b/styles/maxspeed.mapcss
@@ -192,6 +192,7 @@ way|z12-[!"railway:preferred_direction"]["maxspeed:forward"=~/^[1-9][0-9]*$/].tr
 		     "#BA00CB")))))))))))))))))))))))))))))))))));
 	dashes: 4,4;
 	width: 3;
+	text: "maxspeed:forward";
 }
 
 way|z12-["railway:preferred_direction"="backward"]["maxspeed:backward"=~/^[1-9][0-9]*$/].tracks,
@@ -237,6 +238,7 @@ way|z12-[!"railway:preferred_direction"]["maxspeed:forward"!~/^[1-9][0-9]*$/]["m
 		     "#BA00CB")))))))))))))))))))))))))))))))))));
 	dashes: 4,4;
 	width: 3;
+	text: "maxspeed:backward";
 }
 
 /* lines tagged in mph (miles per hour) */


### PR DESCRIPTION
For tracks where both maxspeed and maxspeed:forward or maxspeed:backward was given it was possible that the text from maxspeed but the color for one direction was rendered on the map.