### PR TITLE
maxspeed legend: do not show Zs10 light signal

### DIFF
--- a/styles/maxspeed.json
+++ b/styles/maxspeed.json
@@ -211,11 +211,6 @@
 			"minzoom": 16,
 			"icon": "icons/de/zs10-sign-22.png",
 			"caption": "Zs 10 Endesignal (Tafel)"
-		},
-		{
-			"minzoom": 16,
-			"icon": "icons/de/zs10-light-22.png",
-			"caption": "Zs 10 Endesignal (Lichtsignal)"
 		}
 	]
 }


### PR DESCRIPTION
As of today there is only one instance of this signals in the entire OSM database. Several discussions on the net suggest that this may as well be a mistagging, as the common narrative is that this signal type has been defined, but never actually installed, and there will be no new installations as Zs3 will be used instead. Keep the rendering for the moment, but don't waste space in the already crowded legend.
