### PR TITLE
set linecap of tracks in tunnel to match the tunnel one

### DIFF
--- a/styles/standard.mapcss
+++ b/styles/standard.mapcss
@@ -131,6 +131,14 @@ way|z10-[tunnel=yes].tracks::tunnels
 	linecap: butt;
 	linejoin: butt;
 }
+/* also cap the tracks inside the tunnel with a straight line,
+ * otherwise the round end of the track would run out of the
+ * tunnel with the normal track color instead of the lighter one,
+ * looking like a glith. */
+way|z10-[tunnel=yes].tracks
+{
+	linecap: butt;
+}
 
 /**********************************************/
 /* text of tracks outside bridges and tunnels */


### PR DESCRIPTION
The default linecap is round, so the end runs slightly over the actual line end. However this is set to "butt" for tunnels, i.e. the tunnel has a hard end where it actually ends. However, this does not affect the tracks inside the tunnel. If now a track ends in a tunnel then the track would slightly run out of the tunnel, with a different color than it has inside the tunnel, making the whole thing look like a glitch. Just keep the default linecap value for all tracks but those inside tunnels to avoid that.

Fixes #417.