### PR TITLE
API: allow access from everywhere

### DIFF
--- a/api/config.json
+++ b/api/config.json
@@ -7,5 +7,5 @@
 	"maxsockets" : 100,
 	"apiPort" : 9002,
 	"queries": ["milestone", "facility", "networklength"],
-	"corsAllowOrigin": "http://www.openrailwaymap.org"
+	"corsAllowOrigin": "*"
 }


### PR DESCRIPTION
If we want that people are using it we should make it public again.

This should fix #391.