### PR TITLE
replace the remaining '<? ' tags by '<?php '

### DIFF
--- a/canvas.php
+++ b/canvas.php
@@ -16,11 +16,11 @@
 	includeLocale($lang);
 ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<? echo $lang; ?>" lang="<? echo $lang; ?>">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<?php echo $lang; ?>" lang="<?php echo $lang; ?>">
 	<head>
 		<title>OpenRailwayMap</title>
 		<meta http-equiv="content-type" content="text/html; charset=UTF-8" />
-		<meta http-equiv="content-language" content="<? echo $lang; ?>" />
+		<meta http-equiv="content-language" content="<?php echo $lang; ?>" />
 		<meta name="keywords" content="openstreetmap, openrailwaymap, alexander matheisen, rurseekatze, openlayers, osm, matheisen, orm, eisenbahnkarte, bahnkarte, railmap, railway, railways, eisenbahn, streckenkarte" />
 		<meta name="title" content="OpenRailwayMap" />
 		<meta name="author" content="rurseekatze, Alexander Matheisen" />
@@ -30,7 +30,7 @@
 		<meta name="date" content="2010-01-01" />
 		<meta name="page-topic" content="OpenRailwayMap" />
 		<meta name="robots" content="index,follow" />
-		<link rel="alternate" type="application/rss+xml" title="OpenRailwayMap RSS Feed" href="http://www.matheisen.org/<? echo ($lang == 'de') ? 'de' : 'en'; ?>/orm.rss" />
+		<link rel="alternate" type="application/rss+xml" title="OpenRailwayMap RSS Feed" href="http://www.matheisen.org/<?php echo ($lang == 'de') ? 'de' : 'en'; ?>/orm.rss" />
 		<link rel="shortcut icon" href="img/favicon.ico" type="image/vnd.microsoft.icon" />
 		<link rel="icon" href="img/favicon.ico" type="image/vnd.microsoft.icon" />
 		<meta http-equiv="content-script-type" content="text/javascript" />
@@ -90,7 +90,7 @@
 					break;
 			}
 		?>
-		<script type="text/javascript" src="api/jstranslations.php?lang=<? echo $lang; ?>"></script>
+		<script type="text/javascript" src="api/jstranslations.php?lang=<?php echo $lang; ?>"></script>
 		<script type="text/javascript" src="js/search.js"></script>
 		<script type="text/javascript" src="js/startposition.js"></script>
 		<script type="text/javascript" src="js/timestamp.js"></script>

--- a/embed.php
+++ b/embed.php
@@ -16,11 +16,11 @@
 	includeLocale($lang);
 ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<? echo $lang; ?>" lang="<? echo $lang; ?>">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<?php echo $lang; ?>" lang="<?php echo $lang; ?>">
 	<head>
 		<title>OpenRailwayMap</title>
 		<meta http-equiv="content-type" content="text/html; charset=UTF-8" />
-		<meta http-equiv="content-language" content="<? echo $lang; ?>" />
+		<meta http-equiv="content-language" content="<?php echo $lang; ?>" />
 		<meta name="keywords" content="openstreetmap, openrailwaymap, alexander matheisen, rurseekatze, openlayers, osm, matheisen, orm, eisenbahnkarte, bahnkarte, railmap, railway, railways, eisenbahn, streckenkarte" />
 		<meta name="title" content="OpenRailwayMap" />
 		<meta name="author" content="rurseekatze, Alexander Matheisen" />
@@ -41,7 +41,7 @@
 		<?php
 			urlArgsToParam(false, $urlbase);
 		?>
-		<script type="text/javascript" src="api/jstranslations.php?lang=<? echo $lang; ?>"></script>
+		<script type="text/javascript" src="api/jstranslations.php?lang=<?php echo $lang; ?>"></script>
 		<script type="text/javascript" src="js/startposition.js"></script>
 		<script type="text/javascript" src="js/functions.js"></script>
 		<script type="text/javascript" src="js/bitmap-map.js"></script>

--- a/index.php
+++ b/index.php
@@ -16,11 +16,11 @@
 	includeLocale($lang);
 ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<? echo $lang; ?>" lang="<? echo $lang; ?>">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<?php echo $lang; ?>" lang="<?php echo $lang; ?>">
 	<head>
 		<title>OpenRailwayMap</title>
 		<meta http-equiv="content-type" content="text/html; charset=UTF-8" />
-		<meta http-equiv="content-language" content="<? echo $lang; ?>" />
+		<meta http-equiv="content-language" content="<?php echo $lang; ?>" />
 		<meta name="keywords" content="openstreetmap, openrailwaymap, alexander matheisen, rurseekatze, openlayers, osm, matheisen, orm, eisenbahnkarte, bahnkarte, railmap, railway, railways, eisenbahn, streckenkarte" />
 		<meta name="title" content="OpenRailwayMap" />
 		<meta name="author" content="rurseekatze, Alexander Matheisen" />
@@ -30,7 +30,7 @@
 		<meta name="date" content="2010-01-01" />
 		<meta name="page-topic" content="OpenRailwayMap" />
 		<meta name="robots" content="index,follow" />
-		<link rel="alternate" type="application/rss+xml" title="OpenRailwayMap RSS Feed" href="http://www.matheisen.org/<? echo ($lang == 'de') ? 'de' : 'en'; ?>/orm.rss" />
+		<link rel="alternate" type="application/rss+xml" title="OpenRailwayMap RSS Feed" href="http://www.matheisen.org/<?php echo ($lang == 'de') ? 'de' : 'en'; ?>/orm.rss" />
 		<link rel="shortcut icon" href="img/favicon.ico" type="image/vnd.microsoft.icon" />
 		<link rel="icon" href="img/favicon.ico" type="image/vnd.microsoft.icon" />
 		<meta http-equiv="content-script-type" content="text/javascript" />
@@ -73,7 +73,7 @@
 					break;
 			}
 		?>
-		<script type="text/javascript" src="api/jstranslations.php?lang=<? echo $lang; ?>"></script>
+		<script type="text/javascript" src="api/jstranslations.php?lang=<?php echo $lang; ?>"></script>
 		<script type="text/javascript" src="js/search.js"></script>
 		<script type="text/javascript" src="js/startposition.js"></script>
 		<script type="text/javascript" src="js/timestamp.js"></script>

--- a/mobile.php
+++ b/mobile.php
@@ -16,11 +16,11 @@
 	includeLocale($lang);
 ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<? echo $lang; ?>" lang="<? echo $lang; ?>">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<?php echo $lang; ?>" lang="<?php echo $lang; ?>">
 	<head>
 		<title>OpenRailwayMap</title>
 		<meta http-equiv="content-type" content="text/html; charset=UTF-8" />
-		<meta http-equiv="content-language" content="<? echo $lang; ?>" />
+		<meta http-equiv="content-language" content="<?php echo $lang; ?>" />
 		<meta name="keywords" content="openstreetmap, openrailwaymap, alexander matheisen, rurseekatze, openlayers, osm, matheisen, orm, eisenbahnkarte, bahnkarte, railmap, railway, railways, eisenbahn, streckenkarte" />
 		<meta name="title" content="OpenRailwayMap" />
 		<meta name="author" content="rurseekatze, Alexander Matheisen" />
@@ -30,7 +30,7 @@
 		<meta name="date" content="2010-01-01" />
 		<meta name="page-topic" content="OpenRailwayMap" />
 		<meta name="robots" content="index,follow" />
-		<link rel="alternate" type="application/rss+xml" title="OpenRailwayMap RSS Feed" href="http://www.matheisen.org/<? echo ($lang == 'de') ? 'de' : 'en'; ?>/orm.rss" />
+		<link rel="alternate" type="application/rss+xml" title="OpenRailwayMap RSS Feed" href="http://www.matheisen.org/<?php echo ($lang == 'de') ? 'de' : 'en'; ?>/orm.rss" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
 		<link rel="shortcut icon" href="img/favicon.ico" type="image/vnd.microsoft.icon" />
 		<link rel="icon" href="img/favicon.ico" type="image/vnd.microsoft.icon" />
@@ -76,7 +76,7 @@
 					break;
 			}
 		?>
-		<script type="text/javascript" src="api/jstranslations.php?lang=<? echo $lang; ?>"></script>
+		<script type="text/javascript" src="api/jstranslations.php?lang=<?php echo $lang; ?>"></script>
 		<script type="text/javascript" src="js/search.js"></script>
 		<script type="text/javascript" src="js/startposition.js"></script>
 		<script type="text/javascript" src="js/timestamp.js"></script>


### PR DESCRIPTION
This works without any special options and we have already done that for other tags, too.

Suggested by @Nakaner.

Brute force approach using:

```
   sed 's/<? /<?php /g' -i *.php
```