### PR TITLE
update icon paths

### DIFF
--- a/josm-presets/de.xml
+++ b/josm-presets/de.xml
@@ -1836,7 +1836,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<label text="- railway:name:(abbrevation of operator 2) = (abbrevation of this location)"
 				de.text="- railway:ref:(Kürzel Betreiber 2) = (Abkürzung)" />
 		</item>
-		<item name="Border" de.name="Grenzpunkt" icon="presets/douane.png" type="node">
+		<item name="Border" de.name="Grenzpunkt" icon="presets/barrier/douane.png" type="node">
 			<!-- presets/douane.png is included in JOSM's internal preset set -->
 			<label text="Change of owner/operator near a boundary (admin_level&lt;=2)"
 				de.text="Eigentumswechsel der Infrastruktur nahe der Staatsgrenze" />

--- a/styles/josm-additional.mapcss
+++ b/styles/josm-additional.mapcss
@@ -110,8 +110,8 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 node|z16-[railway=signal][!"railway:signal:direction"]
 {
 	z-index: 1000;
-	icon-image: "presets/misc/deprecated.png";
-	/* presets/misc/deprecated.png is part of the JOSM installation, 
+	icon-image: "presets/misc/deprecated.svg";
+	/* presets/misc/deprecated.svg is part of the JOSM installation, 
 	   that's why it is not included at OpenRailwayMap repository */
 	icon-width: 16;
 	icon-height: 16;
@@ -150,8 +150,8 @@ node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:stop:descr
 {
 	z-index: 10000;
 	/* high z-index to overwrite other stylesheets */
-	icon-image: "presets/misc/deprecated.png";
-	/* presets/misc/deprecated.png is part of the JOSM installation, 
+	icon-image: "presets/misc/deprecated.svg";
+	/* presets/misc/deprecated.svg is part of the JOSM installation, 
 	   that's why it is not included at OpenRailwayMap repository */
 	icon-width: 16;
 	icon-height: 16;


### PR DESCRIPTION
In JOSM we reordered a lot icons and replaced some png by svg. This PR fixes the icon paths for this style and preset.
(related [JOSM ticket](https://josm.openstreetmap.de/ticket/13217#comment:8))