### PR TITLE
update icon paths

### DIFF
--- a/josm-presets/de.xml
+++ b/josm-presets/de.xml
@@ -1836,8 +1836,8 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<label text="- railway:name:(abbrevation of operator 2) = (abbrevation of this location)"
 				de.text="- railway:ref:(Kürzel Betreiber 2) = (Abkürzung)" />
 		</item>
-		<item name="Border" de.name="Grenzpunkt" icon="presets/barrier/douane.png" type="node">
-			<!-- presets/douane.png is included in JOSM's internal preset set -->
+		<item name="Border" de.name="Grenzpunkt" icon="presets/barrier/douane.svg" type="node">
+			<!-- presets/barrier/douane.svg is included in JOSM's internal preset set -->
 			<label text="Change of owner/operator near a boundary (admin_level&lt;=2)"
 				de.text="Eigentumswechsel der Infrastruktur nahe der Staatsgrenze" />
 			<key key="railway"


### PR DESCRIPTION
In JOSM we transformed png icons to svg ([JOSM ticket](https://josm.openstreetmap.de/ticket/13357)). This PR fixes the icon paths of this preset.

This should be the last time this preset is affected for now :)