### PR TITLE
allow other values for bridge tag other than "yes"

### DIFF
--- a/styles/standard.mapcss
+++ b/styles/standard.mapcss
@@ -66,13 +66,23 @@ way|z11-[railway=construction]["construction:railway"=tram]
 /***********/
 /* bridges */
 /***********/
-way|z10-[bridge=yes].tracks::bridges
+way|z10-[bridge=yes].tracks,
+way|z10-[bridge=cantilever].tracks,
+way|z10-[bridge=covered].tracks,
+way|z10-[bridge=movable].tracks,
+way|z10-[bridge=trestle].tracks,
+way|z10-[bridge=viaduct].tracks
+{
+	set .bridge;
+}
+
+way.bridge::bridges
 {
 	z-index: 1;
 	casing-width: 3.5;
 	casing-color: #797979;
 }
-way|z12-[bridge=yes][!"railway:track_ref"].tracks::bridges
+way|z12-[!"railway:track_ref"].bridge::bridges
 {
 	z-index: 4000;
 	text-position: line;


### PR DESCRIPTION
The selection is limited to those defined on [Key:bridge](http://wiki.openstreetmap.org/wiki/Key:bridge) that make sense for railway tracks.

Testcase: [Neckarvorlandbrücke](http://www.openrailwaymap.org/?lang=&lat=49.49874232536776&lon=8.457129746675491&zoom=19&style=standard)