### PR TITLE
Add Option "no substitute signal" to German Hl signals

### DIFF
--- a/josm-presets/de-signals-eso.xml
+++ b/josm-presets/de-signals-eso.xml
@@ -342,8 +342,8 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						text="Substitute signal (multi-selection)"
 						de.text="Ersatzsignal (Mehrfachauswahl)"
 						delimiter=";"
-						values="DE-ESO:dr:zs1;DE-ESO:db:zs12"
-						display_values="Ersatzsignal;M-Tafel"
+						values="DE-ESO:dr:zs1;DE-ESO:db:zs12;no"
+						display_values="Ersatzsignal;M-Tafel;kein Ersatzsignal"
 						/>
 					<space />
 					<preset_link preset_name="Richtungsanzeiger (Zs 2)" />

--- a/styles/signals.mapcss
+++ b/styles/signals.mapcss
@@ -1701,6 +1701,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:combined"=
 	set .fi_main_combined_signals;
 }
 
+
 /***********************************************/
 /* FI main light signals which                 */
 /*  - have no railway:signal:main:states=* tag */
@@ -1776,14 +1777,6 @@ node.fi_main_combined_signal_icon
 	font-weight: bold;
 	text-allow-overlap: true;
 	allow-overlap: true;
-}
-
-/************************************/
-/* FI combined block signal type So */
-/************************************/
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:combined"="FI:So"]["railway:signal:combined:form"=light]["railway:signal:combined:states"~="FI:Po1"]["railway:signal:combined:states"~="FI:Eo1"]
-{
-	icon-image: "icons/fi/eo1-po1-combined-block-30.png";
 }
 
 /**********************************************************************************/

--- a/styles/signals.mapcss
+++ b/styles/signals.mapcss
@@ -1701,7 +1701,6 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:combined"=
 	set .fi_main_combined_signals;
 }
 
-
 /***********************************************/
 /* FI main light signals which                 */
 /*  - have no railway:signal:main:states=* tag */
@@ -1777,6 +1776,14 @@ node.fi_main_combined_signal_icon
 	font-weight: bold;
 	text-allow-overlap: true;
 	allow-overlap: true;
+}
+
+/************************************/
+/* FI combined block signal type So */
+/************************************/
+node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:combined"="FI:So"]["railway:signal:combined:form"=light]["railway:signal:combined:states"~="FI:Po1"]["railway:signal:combined:states"~="FI:Eo1"]
+{
+	icon-image: "icons/fi/eo1-po1-combined-block-30.png";
 }
 
 /**********************************************************************************/


### PR DESCRIPTION
There are automatic Hl block signals (e.g. on "Berliner Außenring") which cannot display Zs 1 but have an white-yellow-white-yellow-white marker board at their pole.