### PR TITLE
maxspeed: do not show Zs10 on zoom 16

### DIFF
--- a/styles/maxspeed.json
+++ b/styles/maxspeed.json
@@ -118,7 +118,7 @@
 			"caption": "Lf 7 Geschwindigkeitssignal"
 		},
 		{
-			"minzoom": 16,
+			"minzoom": 17,
 			"icon": "icons/de/zs10-sign-22.png",
 			"caption": "Zs 10 Endesignal (Tafel)"
 		}

--- a/styles/maxspeed.mapcss
+++ b/styles/maxspeed.mapcss
@@ -381,7 +381,7 @@ way.styled
 }
 
 /* German speed signals (Zs 10) */
-node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:db:zs10"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=none]
+node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:db:zs10"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=none]
 {
 	z-index: 90;
 	icon-image: "icons/de/zs10-sign-44.png";
@@ -390,7 +390,7 @@ node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	allow-overlap: true;
 }
 
-node|z16-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:db:zs10"]["railway:signal:speed_limit:form"=light]["railway:signal:speed_limit:speed"=none]
+node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:db:zs10"]["railway:signal:speed_limit:form"=light]["railway:signal:speed_limit:speed"=none]
 {
 	z-index: 95;
 	icon-image: "icons/de/zs10-light-44.png";


### PR DESCRIPTION
Zs3 and Zs3v are first shown on zoom 17, so put this there, too.
