### PR TITLE
only show branch lines starting at zoom 8

### DIFF
--- a/styles/common.mapcss
+++ b/styles/common.mapcss
@@ -1,7 +1,7 @@
 /* those tracks that are rendered at all                           */
 /* later rules still may decide to not render a track matched here */
-way|z2-[railway=rail][usage=branch][!service],
 way|z2-[railway=rail][usage=main][!service],
+way|z8-[railway=rail][usage=branch][!service],
 way|z10-[railway=rail],
 way|z9-[railway=narrow_gauge],
 way|z10-[railway=light_rail],


### PR DESCRIPTION
Tracks not tagged as usage=main are filtered from the vector tiles below zoom 8 anyway, so there is nothing this could render.