### PR TITLE
fix fallback code for browsers without navigator.languages

### DIFF
--- a/js/functions.js
+++ b/js/functions.js
@@ -16,10 +16,10 @@ function getUserLang()
 	var lang = navigator.language || navigator.userLanguage || 'en-GB';
 	var languages = navigator.languages || [lang];
 
-	for (var i=0; i<navigator.languages.length; i++)
+	for (var i = 0; i < languages.length; i++)
 	{
 		// lang-country combination as first choice
-		var langcountrycode = navigator.languages[i].replace('-', '_');
+		var langcountrycode = languages[i].replace('-', '_');
 		for (var key in window.openrailwaymap.availableTranslations)
 			if (window.openrailwaymap.availableTranslations.hasOwnProperty(key) && window.openrailwaymap.availableTranslations[key] === langcountrycode)
 				return langcountrycode;


### PR DESCRIPTION
There is a fallback variable defined for the case that a browser does not support navigator.languages (e.g. IE), but it was not used afterwards. This leads to accesses to an undefined object, breaking the website.