### PR TITLE
feat: add containerfile and build config

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -55,6 +55,9 @@ Constantin Müller (ubahnverleih)
  - Website improvements
  - Signal icons
 
+Josh Habdas (VHS)
+ - Multi-stage container build
+
 fri <pavelfric@seznam.cz>
  - Czech translation
 

--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,125 @@
+# Stage 1: PostGIS Setup Stage
+FROM ubuntu:rolling as postgis-setup
+
+# Set environment variables to avoid interactive installation
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Update and install PostgreSQL and PostGIS dependencies
+RUN apt-get update && \
+    apt-get install -y \
+    postgresql \
+    postgis \
+    wget \
+    tar \
+    gzip && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Copy custom pg_hba.conf into the container
+COPY config/postgresql/pg_hba.conf /var/lib/postgresql/pg_hba.conf
+
+# Set up PostgreSQL and PostGIS
+USER postgres
+RUN /etc/init.d/postgresql start && \
+    createuser osmimport && \
+    createuser openrailwaymap && \
+    createdb -E UTF8 -O osmimport openrailwaymap && \
+    psql -d openrailwaymap -c "CREATE EXTENSION postgis;" && \
+    psql -d openrailwaymap -c "CREATE EXTENSION unaccent;" && \
+    psql -d openrailwaymap -c "CREATE EXTENSION hstore;"
+
+# Stage 2: Build Stage
+FROM ubuntu:rolling as builder
+
+# Set environment variables to avoid interactive installation
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Update and install build dependencies
+RUN apt-get update && \
+    apt-get install -y \
+    build-essential \
+    g++ \
+    make \
+    cmake \
+    wget \
+    git \
+    zlib1g-dev && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Clone the OpenRailwayMap repository
+WORKDIR /var/www/html
+RUN git clone https://github.com/openrailwaymap/OpenRailwayMap.git
+
+# Install Leaflet and the Leaflet extension that provides the edit link
+WORKDIR /var/www/html/OpenRailwayMap
+RUN make install-deps
+
+# Stage 3: Final Stage
+FROM ubuntu:rolling as runtime
+
+# Set environment variables to avoid interactive installation
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Update and install required packages
+RUN apt-get update && \
+    apt-get install -y \
+    osm2pgsql \
+    nodejs \
+    npm \
+    bc \
+    apache2 \
+    libapache2-mod-php \
+    php-php-gettext \
+    php-pgsql \
+    python3-pip \
+    python3-pil \
+    python3-cairo \
+    python3-ply \
+    apache2-dev \
+    zlib1g-dev \
+    build-essential \
+    g++ \
+    make && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Set up Apache modules
+RUN a2enmod rewrite && \
+    a2enmod proxy && \
+    a2enmod proxy_http && \
+    a2enmod headers
+
+# Copy Apache virtual host configuration files
+COPY config/apache/www.openrailwaymap.test.conf /etc/apache2/sites-available/www.openrailwaymap.test.conf
+COPY config/apache/api.openrailwaymap.test.conf /etc/apache2/sites-available/api.openrailwaymap.test.conf
+COPY config/apache/tiles.openrailwaymap.test.conf /etc/apache2/sites-available/tiles.openrailwaymap.test.conf
+
+# Enable virtual hosts
+RUN a2ensite www.openrailwaymap.test.conf && \
+    a2ensite api.openrailwaymap.test.conf && \
+    a2ensite tiles.openrailwaymap.test.conf
+
+# Set ServerName globally to suppress Apache warning
+RUN echo "ServerName localhost" >> /etc/apache2/apache2.conf
+
+# Set up Apache log files
+RUN ln -sf /proc/self/fd/1 /var/log/apache2/access.log && \
+    ln -sf /proc/self/fd/1 /var/log/apache2/error.log
+
+# Set working directory for OpenRailwayMap
+WORKDIR /var/www/html/OpenRailwayMap
+
+# Copy necessary files from builder stage
+COPY --from=builder /var/www/html/OpenRailwayMap /var/www/html/OpenRailwayMap
+
+# Copy PostgreSQL data from postgis-setup stage
+COPY --from=postgis-setup /var/lib/postgresql /var/lib/postgresql
+COPY --from=postgis-setup /var/run/postgresql /var/run/postgresql
+COPY --from=postgis-setup /etc/postgresql /etc/postgresql
+
+# Expose Apache and PostgreSQL ports
+EXPOSE 8080 5432
+
+# Start PostgreSQL and Apache
+CMD service postgresql start && apachectl -D FOREGROUND

--- a/config/apache/api.openrailwaymap.test.conf
+++ b/config/apache/api.openrailwaymap.test.conf
@@ -1,0 +1,21 @@
+<VirtualHost *:80>
+    ServerName api.openrailwaymap.test
+    DocumentRoot /var/www/html/OpenRailwayMap
+
+    ProxyPass /server-status !
+    ProxyPass /timestamp !
+    Alias "/timestamp" "/var/www/html/OpenRailwayMap/import/timestamp"
+    Header set Access-Control-Allow-Origin "*"
+    <Location /timestamp>
+        ForceType text/plain
+    </Location>
+
+    ProxyPreserveHost On
+    ProxyPass / http://localhost:9002/
+    ProxyPassReverse / http://localhost:9002/
+
+    ErrorLog ${APACHE_LOG_DIR}/api.openrailwaymap.test.error.log
+    LogLevel warn
+    CustomLog ${APACHE_LOG_DIR}/api.openrailwaymap.test.access.log combined
+</VirtualHost>
+

--- a/config/apache/tiles.openrailwaymap.test.conf
+++ b/config/apache/tiles.openrailwaymap.test.conf
@@ -1,0 +1,14 @@
+<VirtualHost *:80>
+    ServerName tiles.openrailwaymap.test
+    ServerAlias a.tiles.openrailwaymap.test b.tiles.openrailwaymap.test c.tiles.openrailwaymap.test
+
+    ProxyPreserveHost On
+    ProxyPass / http://localhost:9000/
+    ProxyPassReverse / http://localhost:9000/
+    ProxyPass /server-status !
+
+    ErrorLog ${APACHE_LOG_DIR}/tiles.openrailwaymap.test.error.log
+    LogLevel warn
+    CustomLog ${APACHE_LOG_DIR}/tiles.openrailwaymap.test.access.log combined
+</VirtualHost>
+

--- a/config/apache/www.openrailwaymap.test.conf
+++ b/config/apache/www.openrailwaymap.test.conf
@@ -1,0 +1,33 @@
+<VirtualHost *:80>
+    DocumentRoot /var/www/html/OpenRailwayMap/
+    ServerName www.openrailwaymap.test
+    ServerAlias openrailwaymap.test
+
+    <Directory /var/www/html/OpenRailwayMap >
+        AllowOverride None
+    </Directory>
+
+    DirectoryIndex index.php
+
+    AddType application/json .json
+
+    # alias for imprint
+    Alias /de/imprint /var/www/html/OpenRailwayMap/imprint-de.html
+    Alias /en/imprint /var/www/html/OpenRailwayMap/imprint-en.html
+
+    # language redirection for imprint page
+    RewriteEngine On
+    RewriteCond %{REQUEST_URI} ^/imprint$
+    RewriteCond %{HTTP:Accept-Language} ^de[-,;].*$ [NC]
+    RewriteRule ^/imprint$ /imprint-de.html [L,R=307]
+    RewriteCond %{HTTP:Accept-Language} ^en[-,;].*$ [NC]
+    RewriteRule ^/imprint$ /imprint-en.html [L,R=307]
+    RewriteCond %{HTTP:Accept-Language} [,;]de[-,;].*$ [NC]
+    RewriteRule ^/imprint$ /imprint-de.html [L,R=307]
+    RewriteCond %{HTTP:Accept-Language} [,;]en[-,;].*$ [NC]
+    RewriteRule ^/imprint$ /imprint-en.html [L,R=307]
+
+    ErrorLog ${APACHE_LOG_DIR}/www.openrailwaymap.test.error.log
+    LogLevel warn
+    CustomLog ${APACHE_LOG_DIR}/www.openrailwaymap.test.access.log combined
+</VirtualHost>

--- a/config/postgresql/pg_hba.conf
+++ b/config/postgresql/pg_hba.conf
@@ -1,0 +1,18 @@
+# TYPE  DATABASE        USER            ADDRESS                 METHOD
+
+# "local" is for Unix domain socket connections only
+local   replication     all                                     peer
+local   gis             osmimport                               peer
+local   gis             openrailwaymap                          peer
+local   gis             tirex                                   peer
+local   all             postgres                                peer
+local   all             all                                     peer
+
+# IPv4 local connections:
+host    replication     all             127.0.0.1/32            md5
+host    all             all             127.0.0.1/32            md5
+
+# IPv6 local connections:
+host    replication     all             ::1/128                 md5
+host    all             all             ::1/128                 md5
+


### PR DESCRIPTION
### Summary

This pull request adds a Dockerfile for building and running the OpenRailwayMap project. The Dockerfile includes three stages: setting up PostGIS, building dependencies, and configuring Apache to serve the application. This setup will facilitate a streamlined and consistent development environment.

### Changes

  - Added a multi-stage Dockerfile:
      - Stage 1: PostGIS Setup
          - Installs PostgreSQL and PostGIS dependencies.
          - Configures PostgreSQL with custom settings.
      - Stage 2: Build Stage
          - Installs necessary build dependencies.
          - Clones the OpenRailwayMap repository and installs Leaflet.
      - Stage 3: Final Stage
          - Installs required runtime packages.
          - Sets up and configures Apache with virtual hosts.
          - Copies the built files and PostgreSQL data from previous stages.
          - Exposes necessary ports and starts services.
  - Included Apache virtual host configuration files:
      - www.openrailwaymap.test.conf
      - api.openrailwaymap.test.conf
      - tiles.openrailwaymap.test.conf

### Instructions for Running

This can be done using either Podman or Docker. Tested with Podman 4.9.4 during development.

1. Ensure `/etc/hosts` contains new hostfile entries for `.test` domain like:
    ```term
    127.0.0.1   openrailwaymap.test www.openrailwaymap.test
    ::1         openrailwaymap.test www.openrailwaymap.test
    127.0.0.1   a.tiles.openrailwaymap.test b.tiles.openrailwaymap.test c.tiles.openrailwaymap.test
    ::1         a.tiles.openrailwaymap.test b.tiles.openrailwaymap.test c.tiles.openrailwaymap.test
    ```
2. Build the container image:
     ```sh
    podman build -t openrailwaymap:latest .
    ```
3. Run the container image:
    ```sh
    docker run -d -p 8080:80 -p 5432:5432 --name openrailwaymap openrailwaymap:latest
    ```
4. Access the container's shell (if needed for debugging):
    ```sh
    docker exec -it openrailwaymap /bin/bash
    ```
5. View Apache logs (within the container):
     ```sh
     tail -f /var/log/apache2/error.log /var/log/apache2/access.log
     ```
    
Without any further configuration or set-up, the user should be able to access the running application on their local machine (and `localhost:8080` will show a default apache site so we know it works).

![Screenshot from 2024-05-25 19-00-18](https://github.com/OpenRailwayMap/OpenRailwayMap/assets/97140109/22af4f64-cca8-4b80-8703-f7a9a1d09e60)

Tested on Asahi Linux 6.8.9-404.asahi.fc39.aarch64+16k using Podman 4.9.4 on 25 May 2024.