### PR TITLE
Fix false positive validation results of italian speed signals, check correct number of values

### DIFF
--- a/validator/openrailwaymap.validator.mapcss
+++ b/validator/openrailwaymap.validator.mapcss
@@ -498,6 +498,41 @@ node["railway:signal:combined"]["railway:signal:distant"]
 	assertNoMatch: "node railway=signal railway:signal:combined=DE-ESO:ks railway:signal:minor=DE-ESO:sh1";
 }
 
+/* Italian speed boards can have one to three different speeds. Check if signal type matches the
+   number of speeds. */
+node["railway:signal:speed_limit"="IT:1R"]["railway:signal:speed_limit:speed"=~/;/],
+node["railway:signal:speed_limit_distant"="IT:1R"]["railway:signal:speed_limit_distant:speed"=~/;/],
+node["railway:signal:speed_limit"="IT:2R"]["railway:signal:speed_limit:speed"=~/;[^;]*;/],
+node["railway:signal:speed_limit"="IT:2R"]["railway:signal:speed_limit:speed"=~/^[^;]+$/],
+node["railway:signal:speed_limit_distant"="IT:2R"]["railway:signal:speed_limit_distant:speed"=~/;[^;]*;/],
+node["railway:signal:speed_limit_distant"="IT:2R"]["railway:signal:speed_limit_distant:speed"=~/^[^;]+$/],
+node["railway:signal:speed_limit"="IT:3R"]["railway:signal:speed_limit:speed"=~/^[^;]*(;[^;]*)?$/],
+node["railway:signal:speed_limit_distant"="IT:3R"]["railway:signal:speed_limit_distant:speed"=~/^[^;]*(;[^;]*)?$/] {
+	throwError: "Italian (distant) speed signal 1R/2R/3R has wrong number of speeds.";
+	assertMatch: "node railway:signal:speed_limit=IT:1R railway:signal:speed_limit:speed=50;70";
+	assertMatch: "node railway:signal:speed_limit=IT:1R railway:signal:speed_limit:speed=50;";
+	assertMatch: "node railway:signal:speed_limit=IT:1R railway:signal:speed_limit:speed=;50";
+	assertMatch: "node railway:signal:speed_limit_distant=IT:1R railway:signal:speed_limit_distant:speed=50;70";
+	assertMatch: "node railway:signal:speed_limit=IT:2R railway:signal:speed_limit:speed=50";
+	assertMatch: "node railway:signal:speed_limit_distant=IT:2R railway:signal:speed_limit_distant:speed=50";
+	assertMatch: "node railway:signal:speed_limit=IT:2R railway:signal:speed_limit:speed=50;60;70";
+	assertMatch: "node railway:signal:speed_limit_distant=IT:2R railway:signal:speed_limit_distant:speed=50;60;70";
+	assertMatch: "node railway:signal:speed_limit=IT:2R railway:signal:speed_limit:speed=;60;70";
+	assertMatch: "node railway:signal:speed_limit=IT:2R railway:signal:speed_limit:speed=50;60;";
+	assertMatch: "node railway:signal:speed_limit=IT:3R railway:signal:speed_limit:speed=50;60";
+	assertMatch: "node railway:signal:speed_limit_distant=IT:3R railway:signal:speed_limit_distant:speed=50;60";
+	assertNoMatch: "node railway:signal:speed_limit=IT:1R railway:signal:speed_limit:speed=50";
+	assertNoMatch: "node railway:signal:speed_limit_distant=IT:1R railway:signal:speed_limit_distant:speed=50";
+	assertNoMatch: "node railway:signal:speed_limit=IT:2R railway:signal:speed_limit:speed=50;60";
+	assertNoMatch: "node railway:signal:speed_limit_distant=IT:2R railway:signal:speed_limit_distant:speed=50;60";
+	assertNoMatch: "node railway:signal:speed_limit=IT:3R railway:signal:speed_limit:speed=50;60;70";
+	assertNoMatch: "node railway:signal:speed_limit_distant=IT:3R railway:signal:speed_limit_distant:speed=50;60;70";
+	/* Do not report cases where one of the speed limits is unknown (empty value in list). */
+	assertNoMatch: "node railway:signal:speed_limit=IT:2R railway:signal:speed_limit:speed=50;";
+	assertNoMatch: "node railway:signal:speed_limit=IT:3R railway:signal:speed_limit:speed=50;60;";
+	assertNoMatch: "node railway:signal:speed_limit=IT:3R railway:signal:speed_limit:speed=;60;70";
+}
+
 /* signals should have ref, and not railway:ref */
 node[railway=signal]["railway:ref"][!ref]
 {

--- a/validator/openrailwaymap.validator.mapcss
+++ b/validator/openrailwaymap.validator.mapcss
@@ -166,8 +166,8 @@ node[railway=signal]["railway:signal:minor_distant:form"=sign]["railway:signal:m
 node[railway=signal]["railway:signal:crossing:form"=sign]["railway:signal:crossing:states"],
 node[railway=signal]["railway:signal:crossing_distant:form"=sign]["railway:signal:crossing_distant:states"],
 node[railway=signal]["railway:signal:humping:form"=sign]["railway:signal:humping:states"],
-node[railway=signal]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=~/;/],
-node[railway=signal]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=~/;/],
+node[railway=signal]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=~/;/]["railway:signal:speed"!~/IT:[23]R/],
+node[railway=signal]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=~/;/]["railway:signal:speed:distant"!~/IT:[23]R/],
 node[railway=signal]["railway:signal:route:form"=sign]["railway:signal:route:states"],
 node[railway=signal]["railway:signal:route_distant:form"=sign]["railway:signal:route_distant:states"],
 node[railway=signal]["railway:signal:wrong_road:form"=sign]["railway:signal:wrong_road:states"],
@@ -183,6 +183,8 @@ node[railway=signal]["railway:signal:brake_test:form"=sign]["railway:signal:brak
 	assertNoMatch: "node railway=signal railway:signal:main:states=hp0;hp1 railway:signal:main:form=semaphore";
 	assertNoMatch: "node railway=signal railway:signal:main:states=hp0;hp1 railway:signal:main:form=light";
 	assertNoMatch: "node railway=signal railway:signal:speed_limit:form=sign railway:signal:speed_limit:speed=80";
+	assertNoMatch: "node railway=signal railway:signal:speed_limit:form=sign railway:signal:speed_limit:speed=80;100 railway:signal:speed_limit=IT:2R";
+	assertNoMatch: "node railway=signal railway:signal:speed_limit_distant:form=sign railway:signal:speed_limit_distant:speed=80;100 railway:signal:speed_limit_distant=IT:2R";
 }
 
 /* track numbers inside a station should be railway:track_ref, not name */


### PR DESCRIPTION
Fixes #917. In addition, the number of speeds is compared to the signal type.